### PR TITLE
Add munch-style shorthand for contract functions

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -238,6 +238,22 @@ class ContractFunction:
 FunctionsRepository = Dict[str, ContractFunction]
 
 
+class FunctionsRepositoryShorthand(dict):
+    """
+    A simplified Munch implementation, supporting attribute-style access,
+    a la JavaScript.
+
+    https://github.com/Infinidat/munch
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+    def __getattribute__(self, __name: str) -> ContractFunction:
+        return cast(ContractFunction, super().__getattribute__(__name))
+
+
 @add_sync_methods
 class Contract:
     """
@@ -261,6 +277,13 @@ class Contract:
         :return: All functions exposed from a contract.
         """
         return self._functions
+
+    @property
+    def fn(self) -> FunctionsRepositoryShorthand:
+        """
+        :return: All functions exposed from a contract, allowing attribue-style access.
+        """
+        return FunctionsRepositoryShorthand(**self._functions)
 
     @property
     def address(self) -> int:

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -23,22 +23,8 @@ async def test_invoke_and_call(key, value):
     # Deploy simple k-v store
     contract = await Contract.deploy(client=client, compilation_source=map_source)
     contract = await Contract.from_address(contract.address, client)
-    await contract.functions["put"].invoke(key, value)
+    await contract.functions.put.invoke(key, value)
     (response,) = await contract.functions["get"].call(key)
-
-    assert response == value
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("key, value", ((2, 13), (412312, 32134), (12345, 3567)))
-async def test_invoke_and_call_shorthand(key, value):
-    client = DevnetClient()
-
-    # Deploy simple k-v store
-    contract = await Contract.deploy(client=client, compilation_source=map_source)
-    contract = await Contract.from_address(contract.address, client)
-    await contract.fn.put.invoke(key, value)
-    (response,) = await contract.fn.get.call(key)
 
     assert response == value
 
@@ -62,7 +48,7 @@ async def test_signature():
     contract = await Contract.deploy(client=client, compilation_source=user_auth_source)
     contract = await Contract.from_address(contract.address, client)
 
-    fun_call = contract.functions["set_details"].prepare(public_key, details)
+    fun_call = contract.functions.set_details.prepare(public_key, details)
 
     # Verify that it doesn't work with proper signature
     with pytest.raises(Exception):
@@ -73,7 +59,7 @@ async def test_signature():
     invocation = await fun_call.invoke(signature=signature)
     await invocation.wait_for_acceptance()
 
-    (balance,) = await contract.functions["get_details"].call(public_key)
+    (balance,) = await contract.functions.get_details.call(public_key)
 
     assert balance == details
 

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -29,6 +29,20 @@ async def test_invoke_and_call(key, value):
     assert response == value
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key, value", ((2, 13), (412312, 32134), (12345, 3567)))
+async def test_invoke_and_call_shorthand(key, value):
+    client = DevnetClient()
+
+    # Deploy simple k-v store
+    contract = await Contract.deploy(client=client, compilation_source=map_source)
+    contract = await Contract.from_address(contract.address, client)
+    await contract.fn.put.invoke(key, value)
+    (response,) = await contract.fn.get.call(key)
+
+    assert response == value
+
+
 user_auth_source = Path(directory, "user_auth.cairo").read_text("utf-8")
 
 


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The formatter, linter, and tests all run without an error
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

Will update docs, write more tests, and generally upon this if there's any interest in this PR :)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature (minor quality of life / ux improvement)


## **What is the current behavior?** (You can also link to an open issue here)
Functions are accessed through dictionary-style key lookups:
```python
contract = await Contract.from_address(address, client)
await contract.functions["put"].invoke(key, value)
(response,) = await contract.functions["get"].call(key)
```

## **What is the new behavior (if this is a feature change)?**
Functions can also be accessed through a shorthand (based on the [munch](https://github.com/Infinidat/munch) pattern):
```python
contract = await Contract.from_address(address, client)
await contract.fn.put.invoke(key, value)
(response,) = await contract.fn.get.call(key)
```

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.


## **Other information**

Just getting into starknet development and this felt like low hanging fruit.

Opted to introduce a new property `.fn` instead of re-using /  upgrading the `.functions` property to avoid breaking changes. By trying to support `contract.functions.function_name.call()`, bugs would be introduced anywhere that a contract function shares the same name as a builtin `dict` method (e.g. "get", "keys", "items", etc...).

Open to suggestions / improvements! Or if you don't think such a feature would be right for the lib, all good :)