### PR TITLE
fix: correct the type of Multicall.calls

### DIFF
--- a/starknet_py/utils/crypto/facade.py
+++ b/starknet_py/utils/crypto/facade.py
@@ -44,7 +44,7 @@ class Call:
 @dataclass(frozen=True)
 class MultiCall:
     account: int
-    calls: List[Call]
+    calls: Iterable[Call]
     nonce: int
     max_fee: int = 0
     version: int = 0

--- a/starknet_py/utils/crypto/facade.py
+++ b/starknet_py/utils/crypto/facade.py
@@ -44,7 +44,7 @@ class Call:
 @dataclass(frozen=True)
 class MultiCall:
     account: int
-    calls: Call
+    calls: List[Call]
     nonce: int
     max_fee: int = 0
     version: int = 0


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix / Docs

The type of `Multicall.calls` was documented as a a `Call` but used everywhere as a list of `Call` objects.


* **What is the current behavior?** (You can also link to an open issue here)

The type of `Multicall.calls` was documented as a a `Call`.


## **What is the new behavior (if this is a feature change)?**

It changed the type to a `List[Call]`.


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking changes.


## **Other information**

