### PR TITLE
feat: expose public key in AccountClient

### DIFF
--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -56,6 +56,10 @@ class AccountClient(Client):
     def private_key(self) -> int:
         return self._key_pair.private_key
 
+    @property
+    def public_key(self) -> int:
+        return self._key_pair.public_key
+
     async def _get_nonce(self) -> int:
         [nonce] = await super().call_contract(
             InvokeFunction(


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: Expose the public key in the `AccountClient`.


* **What is the current behavior?** (You can also link to an open issue here)
You have to access a protected property to find the public key of an `AccountClient`.


## **What is the new behavior (if this is a feature change)?**
You can do `account_client.public_key` (similar to `account_client.private_key`)


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


## **Other information**
I don't think this all that useful for most use-cases, but from an "I need to implement this abstract base class perspective", this helps me out.

Am I missing something though? I may not be fully understanding the reason why it is not currently exposed.
