### PR TITLE
Add custom exceptions for transaction failures

### DIFF
--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -211,9 +211,7 @@ class Client:
                 if not wait_for_accept and "block_number" in result:
                     return result.block_number, status
             elif status == TxStatus.REJECTED:
-                raise TransactionRejectedError(
-                    str(result.transaction_failure_reason)
-                )
+                raise TransactionRejectedError(str(result.transaction_failure_reason))
             elif status == TxStatus.NOT_RECEIVED:
                 if not first_run:
                     raise TransactionNotReceivedError()

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -28,9 +28,9 @@ from starknet_py.net.models import (
 )
 from starknet_py.net.networks import Network, net_address_from_net
 from starknet_py.transaction_exceptions import (
-    TransactionFailedException,
-    TransactionRejectedException,
-    TransactionNotReceivedException,
+    TransactionFailedError,
+    TransactionRejectedError,
+    TransactionNotReceivedError,
 )
 
 BadRequest = BadRequestError
@@ -211,14 +211,14 @@ class Client:
                 if not wait_for_accept and "block_number" in result:
                     return result.block_number, status
             elif status == TxStatus.REJECTED:
-                raise TransactionRejectedException(
+                raise TransactionRejectedError(
                     str(result.transaction_failure_reason)
                 )
             elif status == TxStatus.NOT_RECEIVED:
                 if not first_run:
-                    raise TransactionNotReceivedException()
+                    raise TransactionNotReceivedError()
             elif status != TxStatus.RECEIVED:
-                raise TransactionFailedException()
+                raise TransactionFailedError()
 
             first_run = False
             await asyncio.sleep(check_interval)

--- a/starknet_py/net/client_test.py
+++ b/starknet_py/net/client_test.py
@@ -10,9 +10,9 @@ from starkware.starknet.services.api.feeder_gateway.response_objects import (
 
 from starknet_py.net.client import Client
 from starknet_py.transaction_exceptions import (
-    TransactionRejectedException,
-    TransactionNotReceivedException,
-    TransactionFailedException,
+    TransactionRejectedError,
+    TransactionNotReceivedError,
+    TransactionFailedError,
 )
 
 
@@ -25,7 +25,7 @@ async def test_wait_for_tx_throws_transaction_rejected():
     client.get_transaction = MagicMock()
     client.get_transaction.return_value = result
 
-    with pytest.raises(TransactionRejectedException):
+    with pytest.raises(TransactionRejectedError):
         await client.wait_for_tx(tx_hash="0x0")
 
 
@@ -38,7 +38,7 @@ async def test_wait_for_tx_throws_transaction_not_received():
     client.get_transaction = MagicMock()
     client.get_transaction.return_value = result
 
-    with pytest.raises(TransactionNotReceivedException):
+    with pytest.raises(TransactionNotReceivedError):
         await client.wait_for_tx(tx_hash="0x0")
 
 
@@ -52,5 +52,5 @@ async def test_wait_for_tx_throws_transaction_failed():
     client.get_transaction = MagicMock()
     client.get_transaction.return_value = result
 
-    with pytest.raises(TransactionFailedException):
+    with pytest.raises(TransactionFailedError):
         await client.wait_for_tx(tx_hash="0x0")

--- a/starknet_py/net/client_test.py
+++ b/starknet_py/net/client_test.py
@@ -1,0 +1,56 @@
+from asyncio import Future
+from unittest.mock import MagicMock
+
+import pytest
+
+
+from starkware.starknet.services.api.feeder_gateway.response_objects import (
+    TransactionStatus,
+)
+
+from starknet_py.net.client import Client
+from starknet_py.transaction_exceptions import (
+    TransactionRejectedException,
+    TransactionNotReceivedException,
+    TransactionFailedException,
+)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_tx_throws_transaction_rejected():
+    client = Client("testnet")
+
+    result = Future()
+    result.set_result(MagicMock(status=TransactionStatus.REJECTED))
+    client.get_transaction = MagicMock()
+    client.get_transaction.return_value = result
+
+    with pytest.raises(TransactionRejectedException):
+        await client.wait_for_tx(tx_hash="0x0")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_tx_throws_transaction_not_received():
+    client = Client("testnet")
+
+    result = Future()
+    result.set_result(MagicMock(status=TransactionStatus.NOT_RECEIVED))
+    client.get_transaction = MagicMock()
+    client.get_transaction.return_value = result
+
+    with pytest.raises(TransactionNotReceivedException):
+        await client.wait_for_tx(tx_hash="0x0")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_tx_throws_transaction_failed():
+    client = Client("testnet")
+
+    result = Future()
+    # TransactionStatus is and Enum, using nonsensical value to test for base exception
+    result.set_result(MagicMock(status=-100))
+    client.get_transaction = MagicMock()
+    client.get_transaction.return_value = result
+
+    with pytest.raises(TransactionFailedException):
+        await client.wait_for_tx(tx_hash="0x0")

--- a/starknet_py/transaction_exceptions.py
+++ b/starknet_py/transaction_exceptions.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 
-class TransactionFailedException(Exception):
+class TransactionFailedError(Exception):
     """
     Base exception for transaction failure
     """
@@ -14,7 +14,7 @@ class TransactionFailedException(Exception):
         return f"Transaction failed with following starknet error: {self.transaction_failure_reason}."
 
 
-class TransactionRejectedException(TransactionFailedException):
+class TransactionRejectedError(TransactionFailedError):
     """
     Exception for transactions rejected by starknet
     """
@@ -26,7 +26,7 @@ class TransactionRejectedException(TransactionFailedException):
         return f"Transaction was rejected with following starknet error: {self.transaction_failure_reason}."
 
 
-class TransactionNotReceivedException(TransactionFailedException):
+class TransactionNotReceivedError(TransactionFailedError):
     """
     Exception for transactions not received on starknet
     """

--- a/starknet_py/transaction_exceptions.py
+++ b/starknet_py/transaction_exceptions.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+
+class TransactionFailedException(Exception):
+    """
+    Base exception for transaction failure
+    """
+
+    def __init__(self, tx_failure_reason: Optional[str] = None):
+        self.transaction_failure_reason = tx_failure_reason or "Unknown starknet error."
+        super().__init__(self.transaction_failure_reason)
+
+    def __str__(self):
+        return f"Transaction failed with following starknet error: {self.transaction_failure_reason}."
+
+
+class TransactionRejectedException(TransactionFailedException):
+    """
+    Exception for transactions rejected by starknet
+    """
+
+    def __init__(self, transaction_rejection_reason: str):
+        super().__init__(transaction_rejection_reason)
+
+    def __str__(self):
+        return f"Transaction was rejected with following starknet error: {self.transaction_failure_reason}."
+
+
+class TransactionNotReceivedException(TransactionFailedException):
+    """
+    Exception for transactions not received on starknet
+    """
+
+    def __init__(self):
+        super().__init__("Transaction not received")
+
+    def __str__(self):
+        return "Transaction was not received on starknet."


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add custom exceptions for transaction failures to be used in `Client.wait_for_tx()`. 

See #113 

* **What is the current behavior?** (You can also link to an open issue here)

Generic `Exception` with custom message is being raised.

## **What is the new behavior (if this is a feature change)?**

Custom exceptions are used.

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Custom exceptions still extend base `Exception` types so no changes in error handling on user side should be necessary.

## **Other information**
