### PR TITLE
fix: block number check in wait_for_tx method

### DIFF
--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -66,7 +66,7 @@ class AccountClient(Client):
                 entry_point_selector=get_selector_from_name("get_nonce"),
                 calldata=[],
                 signature=[],
-                # verifiy this is correct
+                # verify this is correct
                 max_fee=0,
                 version=0,
             )

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -208,7 +208,7 @@ class Client:
             if status in ACCEPTED_STATUSES:
                 return result.block_number, status
             if status == TxStatus.PENDING:
-                if not wait_for_accept and "block_number" in result:
+                if not wait_for_accept and hasattr(result, "block_number"):
                     return result.block_number, status
             elif status == TxStatus.REJECTED:
                 raise TransactionRejectedError(str(result.transaction_failure_reason))


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix - was hitting error about `TransactionInfo` not being sub-scriptable

* **What is the current behavior?** (You can also link to an open issue here)

An error about  `TransactionInfo` not being sub-scriptable when trying to wait for a transaction.
**NOTE**: I only observed this when using actual networks and not during starknet-devnet.

## **What is the new behavior (if this is a feature change)?**

I can successfully wait for transactions.


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

## **Other information**
