### PR TITLE
Improve transaction error messages

### DIFF
--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -211,7 +211,10 @@ class Client:
                 if not wait_for_accept and "block_number" in result:
                     return result.block_number, status
             elif status == TxStatus.REJECTED:
-                raise TransactionRejectedError(str(result.transaction_failure_reason))
+                raise TransactionRejectedError(
+                    code=result.transaction_failure_reason.code,
+                    message=result.transaction_failure_reason.error_message,
+                )
             elif status == TxStatus.NOT_RECEIVED:
                 if not first_run:
                     raise TransactionNotReceivedError()

--- a/starknet_py/transaction_exceptions.py
+++ b/starknet_py/transaction_exceptions.py
@@ -6,12 +6,16 @@ class TransactionFailedError(Exception):
     Base exception for transaction failure
     """
 
-    def __init__(self, tx_failure_reason: Optional[str] = None):
-        self.transaction_failure_reason = tx_failure_reason or "Unknown starknet error."
-        super().__init__(self.transaction_failure_reason)
+    def __init__(self, code: Optional[str] = None, message: Optional[str] = None):
+        self.code = code
+        self.message = message or "Unknown starknet error."
+        super().__init__(self.message)
 
     def __str__(self):
-        return f"Transaction failed with following starknet error: {self.transaction_failure_reason}."
+        return (
+            f"Transaction failed with following starknet error: "
+            f"{self.code + ':' if self.code is not None else ''}{self.message}."
+        )
 
 
 class TransactionRejectedError(TransactionFailedError):
@@ -19,11 +23,14 @@ class TransactionRejectedError(TransactionFailedError):
     Exception for transactions rejected by starknet
     """
 
-    def __init__(self, transaction_rejection_reason: str):
-        super().__init__(transaction_rejection_reason)
+    def __init__(self, message: str, code: Optional[str] = None):
+        super().__init__(code=code, message=message)
 
     def __str__(self):
-        return f"Transaction was rejected with following starknet error: {self.transaction_failure_reason}."
+        return (
+            f"Transaction was rejected with following starknet error: "
+            f"{self.code + ':' if self.code is not None else ''}{self.message}."
+        )
 
 
 class TransactionNotReceivedError(TransactionFailedError):
@@ -32,7 +39,7 @@ class TransactionNotReceivedError(TransactionFailedError):
     """
 
     def __init__(self):
-        super().__init__("Transaction not received")
+        super().__init__(message="Transaction not received")
 
     def __str__(self):
         return "Transaction was not received on starknet."


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Closes #129

* **What is the current behavior?** (You can also link to an open issue here)

Starknet error is parsed into a string

## **What is the new behavior (if this is a feature change)?**

Adds `code` and `message` fields to transactions errors so underlying starknet error can be accessed without parsing a whole error message.

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Error messages are changed
