### PR TITLE
Add parameter for changing between testnet and devnet in e2e tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,8 @@ target-version = ["py37"]
 extend-exclude = """
 crypto-cpp
 """
+
+[tool.pytest.ini_options]
+markers = [
+    "run_on_testnet: marks test that will only run on testnet (when --net=test)"
+]

--- a/starknet_py/tests/e2e/conftest.py
+++ b/starknet_py/tests/e2e/conftest.py
@@ -56,3 +56,16 @@ def run_devnet(request):
 @pytest.fixture
 def run_net(request):
     return request.config.getoption("--net")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--net") == "testnet":
+        skip_devnet = pytest.mark.skip()
+        for item in items:
+            if "run_on_testnet" not in item.keywords:
+                item.add_marker(skip_devnet)
+    else:
+        skip_testnet = pytest.mark.skip()
+        for item in items:
+            if "run_on_testnet" in item.keywords:
+                item.add_marker(skip_testnet)

--- a/starknet_py/tests/e2e/conftest.py
+++ b/starknet_py/tests/e2e/conftest.py
@@ -47,11 +47,6 @@ def run_devnet():
     proc.kill()
 
 
-@pytest.fixture
-def run_net(request):
-    return request.config.getoption("--net")
-
-
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--net") == "all":
         return

--- a/starknet_py/tests/e2e/conftest.py
+++ b/starknet_py/tests/e2e/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
         "--net",
         action="store",
         default="devnet",
-        help="Network to run tests on: possible 'testnet', 'devnet'",
+        help="Network to run tests on: possible 'testnet', 'devnet', 'all'",
     )
 
 
@@ -41,16 +41,10 @@ def start_devnet():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def run_devnet(request):
-    net = request.config.getoption("--net")
-    if net == "devnet":
-        devnet_port, proc = start_devnet()
-        yield f"http://localhost:{devnet_port}"
-        proc.kill()
-    elif net == "testnet":
-        yield "testnet"
-    else:
-        raise ValueError("Not supported value provided for --net")
+def run_devnet():
+    devnet_port, proc = start_devnet()
+    yield f"http://localhost:{devnet_port}"
+    proc.kill()
 
 
 @pytest.fixture
@@ -59,13 +53,12 @@ def run_net(request):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--net") == "testnet":
-        skip_devnet = pytest.mark.skip()
-        for item in items:
-            if "run_on_testnet" not in item.keywords:
-                item.add_marker(skip_devnet)
-    else:
-        skip_testnet = pytest.mark.skip()
-        for item in items:
-            if "run_on_testnet" in item.keywords:
-                item.add_marker(skip_testnet)
+    if config.getoption("--net") == "all":
+        return
+
+    run_testnet = config.getoption("--net") == "testnet"
+    for item in items:
+        runs_on_testnet = "run_on_testnet" in item.keywords
+        should_run = run_testnet == runs_on_testnet
+        if not should_run:
+            item.add_marker(pytest.mark.skip())

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -316,6 +316,7 @@ async def test_wait_for_tx_devnet(run_devnet):
     await client.wait_for_tx(deployment.hash)
 
 
+@pytest.mark.run_on_testnet
 @pytest.mark.asyncio
 async def test_wait_for_tx_testnet():
     client = Client(net="testnet")


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Added a `--net` parameter to e2e tests that allows changing between running tests on "devnet" and "testnet".

Will require further verification as running tests on testnet is super slow.

Should close #139 

* **What is the current behavior?** (You can also link to an open issue here)

Test can only be run on devnet

## **What is the new behavior (if this is a feature change)?**

Test can be run on devnet and testnet

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
