### PR TITLE
Bug/estimate fee for account client

### DIFF
--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -108,10 +108,7 @@ class AccountClient(Client):
 
         return (high << 128) + low
 
-    async def _prepare_invoke_function(
-            self,
-            tx: InvokeFunction
-    ) -> InvokeFunction:
+    async def _prepare_invoke_function(self, tx: InvokeFunction) -> InvokeFunction:
         nonce = await self._get_nonce()
 
         calldata_py = [
@@ -180,9 +177,7 @@ class AccountClient(Client):
                 "Adding signatures to a signer tx currently isn't supported"
             )
 
-        return await super().add_transaction(
-            await self._prepare_invoke_function(tx)
-        )
+        return await super().add_transaction(await self._prepare_invoke_function(tx))
 
     async def estimate_fee(
         self,
@@ -192,9 +187,7 @@ class AccountClient(Client):
         :param tx: Transaction which fee we want to calculate
         :return: Estimated fee
         """
-        return await super().estimate_fee(
-            await self._prepare_invoke_function(tx)
-        )
+        return await super().estimate_fee(await self._prepare_invoke_function(tx))
 
     @staticmethod
     async def create_account(


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Solution for [estimate_fee bug](https://github.com/software-mansion/starknet.py/issues/163)

* **What is the current behavior?** (You can also link to an open issue here)

Estimating fee for account client is based on Client.estimate_fee which does not create signature.
An empty signature is provided in InvokeFunction.

## **What is the new behavior (if this is a feature change)?**

There is a method estimate_fee inside AccountContract which prepares InvokeFunction for Client.estimate_fee

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
