### PR TITLE
Warn if max fee is zero

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import (
@@ -229,6 +230,9 @@ class PreparedFunctionCall:
 
         if self.max_fee is None:
             raise ValueError("Max_fee must be specified when invoking a transaction")
+
+        if self.max_fee == 0:
+            warnings.warn("Max fee should be higher than 0")
 
         tx = self._make_invoke_function(signature=signature)
         response = await self._client.add_transaction(tx=tx)

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -232,7 +232,9 @@ class PreparedFunctionCall:
             raise ValueError("Max_fee must be specified when invoking a transaction")
 
         if self.max_fee == 0:
-            warnings.warn("Max fee should be higher than 0")
+            warnings.warn(
+                "Transaction will fail with max_fee set to 0. Change it to a higher value."
+            )
 
         tx = self._make_invoke_function(signature=signature)
         response = await self._client.add_transaction(tx=tx)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Warns when max_fee in Contract.invoke is 0
