### PR TITLE
Hot fix for using "get_code" in add_transaction

### DIFF
--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -3,13 +3,11 @@ from dataclasses import replace
 
 from starkware.crypto.signature.signature import get_random_private_key
 from starkware.starknet.public.abi import get_selector_from_name
-from starkware.starknet.public.abi_structs import identifier_manager_from_abi
 from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
     CastableToHash,
 )
 
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
-from starknet_py.utils.data_transformer.data_transformer import DataTransformer
 from starknet_py.net.client import Client
 from starknet_py.net.account.compiled_account_contract import COMPILED_ACCOUNT_CONTRACT
 from starknet_py.net.models import (
@@ -22,6 +20,7 @@ from starknet_py.net.models import (
 from starknet_py.net.networks import Network, MAINNET, TESTNET
 from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner, KeyPair
 from starknet_py.net.signer import BaseSigner
+from starknet_py.utils.data_transformer.execute_transformer import execute_transformer
 from starknet_py.utils.sync import add_sync_methods
 from starknet_py.net.models.address import AddressRepresentation, parse_address
 
@@ -116,16 +115,7 @@ class AccountClient(Client):
             nonce,
         ]
 
-        code = await self.get_code(contract_address=parse_address(self.address))
-        abi = code["abi"]
-        identifier_manager = identifier_manager_from_abi(abi)
-        [execute_abi] = [a for a in abi if a["name"] == "__execute__"]
-
-        payload_transformer = DataTransformer(
-            abi=execute_abi, identifier_manager=identifier_manager
-        )
-
-        wrapped_calldata, _ = payload_transformer.from_python(*calldata_py)
+        wrapped_calldata, _ = execute_transformer.from_python(*calldata_py)
 
         return InvokeFunction(
             entry_point_selector=get_selector_from_name("__execute__"),

--- a/starknet_py/utils/data_transformer/execute_transformer.py
+++ b/starknet_py/utils/data_transformer/execute_transformer.py
@@ -1,0 +1,36 @@
+from starkware.starknet.public.abi_structs import identifier_manager_from_abi
+
+from starknet_py.utils.data_transformer import DataTransformer
+
+abi = [
+    {
+        "inputs": [
+            {"name": "call_array_len", "type": "felt"},
+            {"name": "call_array", "type": "CallArray*"},
+            {"name": "calldata_len", "type": "felt"},
+            {"name": "calldata", "type": "felt*"},
+            {"name": "nonce", "type": "felt"},
+        ],
+        "name": "__execute__",
+        "outputs": [
+            {"name": "retdata_size", "type": "felt"},
+            {"name": "retdata", "type": "felt*"},
+        ],
+        "type": "function",
+    },
+    {
+        "members": [
+            {"name": "to", "offset": 0, "type": "felt"},
+            {"name": "selector", "offset": 1, "type": "felt"},
+            {"name": "data_offset", "offset": 2, "type": "felt"},
+            {"name": "data_len", "offset": 3, "type": "felt"},
+        ],
+        "name": "CallArray",
+        "size": 4,
+        "type": "struct",
+    },
+]
+
+execute_transformer = DataTransformer(
+    abi=abi[0], identifier_manager=identifier_manager_from_abi(abi)
+)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)

get_code is used every time add_transaction is invoked

## **What is the new behavior (if this is a feature change)?**

There is no need to use get_code that's why static execute_transformer was created

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No