### PR TITLE
Block number is "pending" for default

### DIFF
--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -4,9 +4,6 @@ from dataclasses import replace
 
 from starkware.crypto.signature.signature import get_random_private_key
 from starkware.starknet.public.abi import get_selector_from_name
-from starkware.starknet.services.api.feeder_gateway.feeder_gateway_client import (
-    CastableToHash,
-)
 
 from starknet_py.net.client import Client
 from starknet_py.net.client_models import (
@@ -32,7 +29,6 @@ from starknet_py.net.models import (
     InvokeFunction,
     StarknetChainId,
     Transaction,
-    BlockIdentifier,
     chain_from_network,
 )
 from starknet_py.net.networks import Network, MAINNET, TESTNET
@@ -337,13 +333,13 @@ class AccountClient(Client):
     async def estimate_fee(
         self,
         tx: InvokeFunction,
-        block_hash: Optional[CastableToHash] = None,
-        block_number: BlockIdentifier = "pending",
+        block_hash: Optional[Union[Hash, Tag]] = None,
+        block_number: Optional[Union[int, Tag]] = None,
     ) -> EstimatedFee:
         """
         :param tx: Transaction which fee we want to calculate
         :param block_hash: Estimate fee at specific block hash
-        :param block_number: Estimate fee at given block number (or "pending" for pending block)
+        :param block_number: Estimate fee at given block number (or "pending" for pending block), default is "pending"
         :return: Estimated fee
         """
         signature = self.signer.sign_transaction(tx)

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -185,7 +185,7 @@ class Client(ABC):
     async def estimate_fee(
         self,
         tx: InvokeFunction,
-        block_hash: Union[Hash, Tag] = None,
+        block_hash: Optional[Union[Hash, Tag]] = None,
         block_number: Optional[Union[int, Tag]] = None,
     ) -> EstimatedFee:
         """

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -191,7 +191,7 @@ class FullNodeClient(Client):
     async def estimate_fee(
         self,
         tx: InvokeFunction,
-        block_hash: Union[Hash, Tag] = None,
+        block_hash: Optional[Union[Hash, Tag]] = None,
         block_number: Optional[Union[int, Tag]] = None,
     ) -> EstimatedFee:
         raise NotImplementedError()

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -163,8 +163,8 @@ class GatewayClient(Client):
         Get the information about the result of executing the requested block
 
         :param block_hash: Block's hash
-        :param block_number: Block's number
-        :return: BlockStateUpdate oject representing changes in the requested block
+        :param block_number: Block's number (default "pending")
+        :return: BlockStateUpdate object representing changes in the requested block
         """
         block_identifier = get_block_identifier(
             block_hash=block_hash, block_number=block_number
@@ -186,7 +186,7 @@ class GatewayClient(Client):
         :param contract_address: Contract's address on Starknet
         :param key: An address of the storage variable inside the contract.
         :param block_hash: Fetches the value of the variable at given block hash
-        :param block_number: See above, uses block number instead of hash
+        :param block_number: See above, uses block number instead of hash (default "pending")
         :return: Storage value of given contract
         """
         block_identifier = get_block_identifier(
@@ -217,7 +217,7 @@ class GatewayClient(Client):
         self,
         contract_address: Hash,
         block_hash: Optional[Union[Hash, Tag]] = None,
-        block_number: Optional[Union[int, Tag]] = "pending",
+        block_number: Optional[Union[int, Tag]] = None,
     ) -> ContractCode:
         block_identifier = get_block_identifier(
             block_hash=block_hash, block_number=block_number
@@ -233,7 +233,7 @@ class GatewayClient(Client):
 
         if len(res["bytecode"]) == 0:
             raise ContractNotFoundError(
-                block_hash=block_hash, block_number=block_number
+                block_hash=block_hash, block_number=block_identifier["blockNumber"]
             )
 
         return ContractCodeSchema().load(res, unknown=EXCLUDE)
@@ -266,7 +266,8 @@ class GatewayClient(Client):
 
         :param invoke_tx: Invoke transaction
         :param block_hash: Block hash to execute the contract at specific point of time
-        :param block_number: Block number (or "pending" for pending block) to execute the contract at
+        :param block_number: Block number (or "pending" for pending block)
+            to execute the contract at (default "pending")
         :return: List of integers representing contract's function output (structured like calldata)
         """
         block_identifier = get_block_identifier(
@@ -341,6 +342,9 @@ def get_block_identifier(
         raise ValueError(
             "block_hash and block_number parameters are mutually exclusive."
         )
+
+    if block_hash is None and block_number is None:
+        return {"blockNumber": "pending"}
 
     if block_hash is not None:
         if is_block_identifier(block_hash):

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -233,7 +233,8 @@ class GatewayClient(Client):
 
         if len(res["bytecode"]) == 0:
             raise ContractNotFoundError(
-                block_hash=block_hash, block_number=block_identifier["blockNumber"]
+                block_hash=block_hash,
+                block_number=block_identifier.get("blockNumber", None),
             )
 
         return ContractCodeSchema().load(res, unknown=EXCLUDE)

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -343,9 +343,6 @@ def get_block_identifier(
             "block_hash and block_number parameters are mutually exclusive."
         )
 
-    if block_hash is None and block_number is None:
-        return {"blockNumber": "pending"}
-
     if block_hash is not None:
         if is_block_identifier(block_hash):
             return {"blockNumber": block_hash}
@@ -354,4 +351,4 @@ def get_block_identifier(
     if block_number is not None:
         return {"blockNumber": block_number}
 
-    return {}
+    return {"blockNumber": "pending"}


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It sets block_number parameter as "pending" everywhere

**What is the current behaviour?** (You can also link to an open issue here)

block_number is set to "pending" as default only in two methods (get_code and estimate_fee).
If block_hash is provided to these methods there is an error, because block_hash and block_number are passed (first as an argument and second as default)

## **What is the new behaviour (if this is a feature change)?**

block_number is default everywhere

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

## **Other information**
