### PR TITLE
Remove chain id from Client interface

### DIFF
--- a/docs/contract.rst
+++ b/docs/contract.rst
@@ -12,7 +12,7 @@ Contract
 
 .. autoclass:: PreparedFunctionCall
     :exclude-members: __init__, __new__
-    :members: call, call_raw, invoke, call_sync, call_raw_sync, invoke_sync, hash, estimate_fee, estimate_fee_sync
+    :members: call, call_raw, invoke, call_sync, call_raw_sync, invoke_sync, estimate_fee, estimate_fee_sync
 
 .. autoclass:: InvokeResult
     :exclude-members: __init__, __new__

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -32,7 +32,7 @@ Here is an example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_account_client_details.py
     :language: python
-    :lines: 10-15,19-23,28-55
+    :lines: 10-14,18-20,25-52
     :dedent: 4
 
 
@@ -201,7 +201,7 @@ Here is a usage example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
     :language: python
-    :lines: 9-42,47-51,56-98
+    :lines: 9-41,46-48,53-95
     :dedent: 4
 
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -18,7 +18,7 @@ This is how we can interact with it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
     :language: python
-    :lines: 34-40,44-47,55-90
+    :lines: 34-40,44-49,57-92
     :dedent: 4
 
 
@@ -201,7 +201,7 @@ Here is a usage example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
     :language: python
-    :lines: 9-42,47-49,54-96
+    :lines: 9-42,47-51,56-98
     :dedent: 4
 
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -32,7 +32,7 @@ Here is an example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_account_client_details.py
     :language: python
-    :lines: 10-14,18-20,25-52
+    :lines: 10-15,19-23,28-55
     :dedent: 4
 
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -18,7 +18,7 @@ This is how we can interact with it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
     :language: python
-    :lines: 34-39,43-46,54-89
+    :lines: 34-40,44-47,55-90
     :dedent: 4
 
 
@@ -201,7 +201,7 @@ Here is a usage example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
     :language: python
-    :lines: 9-41,46-48,53-95
+    :lines: 9-42,47-49,54-96
     :dedent: 4
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ It requires information about used network:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
     :language: python
-    :lines: 8-29
+    :lines: 8-25
     :dedent: 4
 
 The default interface is asynchronous. Although it is the recommended way of using Starknet.py, you can also use a
@@ -50,7 +50,7 @@ There are some examples how to do it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
     :language: python
-    :lines: 10-15,19-37
+    :lines: 10-15,19-38
     :dedent: 4
 
 Using AccountClient
@@ -60,7 +60,7 @@ Example usage:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
     :language: python
-    :lines: 14-17,21-24,28-58
+    :lines: 13-16,20-23,27-57
     :dedent: 4
 
 Using Contract

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -50,7 +50,7 @@ There are some examples how to do it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
     :language: python
-    :lines: 10-15,19-38
+    :lines: 10-15,19-40
     :dedent: 4
 
 Using AccountClient
@@ -60,7 +60,7 @@ Example usage:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
     :language: python
-    :lines: 13-17,21-24,28-58
+    :lines: 13-17,21-26,30-60
     :dedent: 4
 
 Using Contract
@@ -69,7 +69,7 @@ Using Contract
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
     :language: python
-    :lines: 12-18,23-29,34-36,42-59
+    :lines: 12-18,23-31,36-38,44-61
     :dedent: 4
 
 .. note::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -60,7 +60,7 @@ Example usage:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
     :language: python
-    :lines: 13-16,20-23,27-57
+    :lines: 13-17,21-24,28-58
     :dedent: 4
 
 Using Contract
@@ -69,7 +69,7 @@ Using Contract
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
     :language: python
-    :lines: 12-17,22-28,33-35,41-58
+    :lines: 12-18,23-29,34-36,42-59
     :dedent: 4
 
 .. note::

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import sys
-import warnings
 from dataclasses import dataclass
 from typing import (
     List,
@@ -32,7 +31,6 @@ from starknet_py.net.models import (
     AddressRepresentation,
     parse_address,
     compute_address,
-    compute_invoke_hash,
 )
 from starknet_py.compile.compiler import StarknetCompilationSource
 from starknet_py.transactions.deploy import make_deploy_tx
@@ -149,19 +147,6 @@ class PreparedFunctionCall(Call):
         self._contract_data = contract_data
         self.max_fee = max_fee
         self.version = version
-
-    @property
-    def hash(self) -> int:
-        warnings.warn("Hash is deprecated and will be deleted in next releases")
-
-        return compute_invoke_hash(
-            contract_address=self._contract_data.address,
-            entry_point_selector=self.selector,
-            calldata=self.calldata,
-            chain_id=self._client.chain,
-            max_fee=self.max_fee if self.max_fee is not None else 0,
-            version=self.version,
-        )
 
     async def call_raw(
         self,

--- a/starknet_py/contract_test.py
+++ b/starknet_py/contract_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from starknet_py.contract import Contract, PreparedFunctionCall, ContractData
-from starknet_py.net.gateway_client import GatewayClient
+from starknet_py.contract import Contract
 from starknet_py.tests.e2e.conftest import directory_with_contracts
 
 SOURCE = """
@@ -117,24 +116,6 @@ def test_compute_address_throws_on_no_source():
     assert "One of compiled_contract or compilation_source is required." in str(
         exinfo.value
     )
-
-
-def test_transaction_hash():
-    call = PreparedFunctionCall(
-        calldata=[1234],
-        arguments={},
-        selector=1530486729947006463063166157847785599120665941190480211966374137237989315360,
-        client=GatewayClient("testnet"),
-        payload_transformer=None,
-        contract_data=ContractData(
-            address=0x03606DB92E563E41F4A590BC01C243E8178E9BA8C980F8E464579F862DA3537C,
-            abi=None,
-            identifier_manager=None,
-        ),
-        version=0,
-        max_fee=0,
-    )
-    assert call.hash == 0xD0A52D6E77B836613B9F709AD7F4A88297697FEFBEF1ADA3C59692FF46702C
 
 
 def test_no_valid_source():

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -374,9 +374,18 @@ class AccountClient(Client):
         :return: Instance of AccountClient which interacts with created account on given network
         :param chain: ChainId of the chain used by the client
         """
+        if signer is None and private_key is None:
+            raise ValueError(
+                "Either a signer or a private_key must be provided in AccountClient constructor"
+            )
+
+        if chain is None and signer is None:
+            raise ValueError("One of chain or signer must be provided")
+
         if signer is None:
             private_key = private_key or get_random_private_key()
 
+            chain = chain_from_network(net=client.net, chain=chain)
             key_pair = KeyPair.from_private_key(private_key)
             address = await deploy_account_contract(client, key_pair.public_key)
             signer = StarkCurveSigner(

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -374,11 +374,6 @@ class AccountClient(Client):
         :return: Instance of AccountClient which interacts with created account on given network
         :param chain: ChainId of the chain used by the client
         """
-        if signer is None and private_key is None:
-            raise ValueError(
-                "Either a signer or a private_key must be provided in AccountClient constructor"
-            )
-
         if chain is None and signer is None:
             raise ValueError("One of chain or signer must be provided")
 

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -86,10 +86,6 @@ class AccountClient(Client):
         self.signer = signer
 
     @property
-    def chain(self) -> StarknetChainId:
-        return self.signer.chain_id
-
-    @property
     def net(self) -> Network:
         return self.client.net
 

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -72,15 +72,18 @@ class AccountClient(Client):
                 "Either a signer or a key_pair must be provied in AccountClient constructor"
             )
 
-        chain = chain_from_network(net=client.net, chain=chain)
+        if chain is None and signer is None:
+            raise ValueError("One of chain or signer must be provided")
 
-        if chain is None and client is None:
-            raise ValueError("One of chain or client must be provided")
         self.address = parse_address(address)
         self.client = client
-        self.signer = signer or StarkCurveSigner(
-            account_address=self.address, key_pair=key_pair, chain_id=chain
-        )
+
+        if signer is None:
+            chain = chain_from_network(net=client.net, chain=chain)
+            signer = StarkCurveSigner(
+                account_address=self.address, key_pair=key_pair, chain_id=chain
+            )
+        self.signer = signer
 
     @property
     def chain(self) -> StarknetChainId:

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -22,7 +22,6 @@ from starknet_py.net.client_models import (
     DeployTransactionResponse,
     DeclareTransactionResponse,
 )
-from starknet_py.net.models import StarknetChainId
 from starknet_py.net.networks import Network
 from starknet_py.transaction_exceptions import (
     TransactionRejectedError,
@@ -39,13 +38,6 @@ class Client(ABC):
     def net(self) -> Network:
         """
         Network of the client
-        """
-
-    @property
-    @abstractmethod
-    def chain(self) -> StarknetChainId:
-        """
-        ChainId of the chain used by the client
         """
 
     @abstractmethod

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -26,7 +26,6 @@ from starknet_py.net.client_models import (
     DeployTransactionResponse,
 )
 from starknet_py.net.http_client import RpcHttpClient
-from starknet_py.net.models import StarknetChainId, chain_from_network
 from starknet_py.net.networks import Network
 from starknet_py.net.rpc_schemas.rpc_schemas import (
     StarknetBlockSchema,
@@ -49,7 +48,6 @@ class FullNodeClient(Client):
         self,
         node_url: str,
         net: Network,
-        chain: Optional[StarknetChainId] = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
@@ -57,22 +55,16 @@ class FullNodeClient(Client):
 
         :param node_url: Url of the node providing rpc interface
         :param net: StarkNet network identifier
-        :param chain: Chain id of the network used by the rpc client
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
                         every request. When using a custom session, user is resposible for closing it manually.
         """
         self.url = node_url
         self._client = RpcHttpClient(url=node_url, session=session)
-        self._chain = chain_from_network(net, chain)
         self._net = net
 
     @property
     def net(self) -> Network:
         return self._net
-
-    @property
-    def chain(self) -> StarknetChainId:
-        return self._chain
 
     async def get_block(
         self,

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -40,7 +40,6 @@ from starknet_py.net.gateway_schemas.gateway_schemas import (
     TransactionReceiptSchema,
 )
 from starknet_py.net.http_client import GatewayHttpClient
-from starknet_py.net.models import StarknetChainId, chain_from_network
 from starknet_py.net.networks import Network, net_address_from_net
 from starknet_py.net.client_errors import ContractNotFoundError
 from starknet_py.net.client_utils import convert_to_felt, is_block_identifier
@@ -53,14 +52,12 @@ class GatewayClient(Client):
     def __init__(
         self,
         net: Network,
-        chain: StarknetChainId = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
         Client for interacting with starknet gateway.
 
         :param net: Target network for the client. Can be a string with URL or one of ``"mainnet"``, ``"testnet"``
-        :param chain: Chain used by the network. Required if you use a custom URL for ``net`` param.
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
                         every request. When using a custom session, user is resposible for closing it manually.
         """
@@ -69,18 +66,13 @@ class GatewayClient(Client):
         gateway_url = f"{host}/gateway"
 
         self._net = net
-        self._chain = chain_from_network(net, chain)
         self._feeder_gateway_client = GatewayHttpClient(
             url=feeder_gateway_url, session=session
         )
         self._gateway_client = GatewayHttpClient(url=gateway_url, session=session)
 
     @property
-    def chain(self) -> StarknetChainId:
-        return self._chain
-
-    @property
-    def net(self) -> StarknetChainId:
+    def net(self) -> Network:
         return self._net
 
     async def get_transaction(

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -50,7 +50,10 @@ async def test_balance_when_token_specified(gateway_account_client, erc20_contra
 async def test_get_balance_default_token_address(net):
     client = GatewayClient(net=net)
     acc_client = AccountClient(
-        client=client, address="0x123", key_pair=KeyPair(123, 456)
+        client=client,
+        address="0x123",
+        key_pair=KeyPair(123, 456),
+        chain=StarknetChainId.TESTNET,
     )
 
     with patch(
@@ -102,7 +105,7 @@ async def test_estimated_fee_greater_than_zero(erc20_contract):
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
 async def test_create_account_client(run_devnet):
-    client = GatewayClient(net=run_devnet, chain=StarknetChainId.TESTNET)
+    client = GatewayClient(net=run_devnet)
     acc_client = await AccountClient.create_account(client)
     assert acc_client.signer is not None
     assert acc_client.address is not None
@@ -112,9 +115,9 @@ async def test_create_account_client(run_devnet):
 @pytest.mark.asyncio
 async def test_create_account_client_with_private_key(run_devnet):
     private_key = 1234
-    gt_client = GatewayClient(net=run_devnet, chain=StarknetChainId.TESTNET)
+    gt_client = GatewayClient(net=run_devnet)
     acc_client = await AccountClient.create_account(
-        client=gt_client, private_key=private_key
+        client=gt_client, private_key=private_key, chain=StarknetChainId.TESTNET
     )
     assert acc_client.signer.private_key == private_key
     assert acc_client.signer is not None
@@ -127,7 +130,6 @@ async def test_create_account_client_with_signer(run_devnet):
     key_pair = KeyPair.from_private_key(1234)
     client = GatewayClient(
         net=run_devnet,
-        chain=StarknetChainId.TESTNET,
     )
     address = await deploy_account_contract(
         client=client,

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -106,7 +106,7 @@ async def test_estimated_fee_greater_than_zero(erc20_contract):
 @pytest.mark.asyncio
 async def test_create_account_client(run_devnet):
     client = GatewayClient(net=run_devnet)
-    acc_client = await AccountClient.create_account(client)
+    acc_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
     assert acc_client.signer is not None
     assert acc_client.address is not None
 

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -106,7 +106,9 @@ async def test_estimated_fee_greater_than_zero(erc20_contract):
 @pytest.mark.asyncio
 async def test_create_account_client(run_devnet):
     client = GatewayClient(net=run_devnet)
-    acc_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
+    acc_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId.TESTNET
+    )
     assert acc_client.signer is not None
     assert acc_client.address is not None
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -7,7 +7,6 @@ import pytest
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.services.api.gateway.transaction import DECLARE_SENDER_ADDRESS
 
-from starknet_py.net.models import StarknetChainId
 from starknet_py.net.client_models import (
     TransactionStatus,
     InvokeFunction,
@@ -338,11 +337,6 @@ async def test_get_class_by_hash(clients, class_hash):
         contract_class = await client.get_class_by_hash(class_hash=class_hash)
         assert contract_class.program != ""
         assert contract_class.entry_points_by_type is not None
-
-
-def test_chain_id(clients):
-    for client in clients:
-        assert client.chain == StarknetChainId.TESTNET
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/client/conftest.py
+++ b/starknet_py/tests/e2e/client/conftest.py
@@ -11,7 +11,6 @@ from starkware.starknet.public.abi import get_selector_from_name
 from starknet_py.net.client import Client
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.gateway_client import GatewayClient
-from starknet_py.net.models import StarknetChainId
 from starknet_py.tests.e2e.conftest import directory_with_contracts
 
 directory = os.path.dirname(__file__)
@@ -157,10 +156,9 @@ def fixture_class_hash(run_prepared_devnet, contract_address) -> int:
 @pytest.fixture(name="clients")
 def fixture_clients(run_prepared_devnet) -> Tuple[Client, Client]:
     devnet_address, _ = run_prepared_devnet
-    gateway_client = GatewayClient(net=devnet_address, chain=StarknetChainId.TESTNET)
+    gateway_client = GatewayClient(net=devnet_address)
     full_node_client = FullNodeClient(
         node_url=devnet_address + "/rpc",
-        chain=StarknetChainId.TESTNET,
         net=devnet_address,
     )
     return gateway_client, full_node_client

--- a/starknet_py/tests/e2e/conftest.py
+++ b/starknet_py/tests/e2e/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from starknet_py.net import KeyPair, AccountClient
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.gateway_client import GatewayClient
-from starknet_py.net.models import StarknetChainId, AddressRepresentation
+from starknet_py.net.models import AddressRepresentation, StarknetChainId
 from starknet_py.contract import Contract
 
 TESTNET_ACCOUNT_PRIVATE_KEY = (
@@ -102,24 +102,23 @@ def create_gateway_client(pytestconfig, run_devnet):
         "integration": "https://external.integration.starknet.io",
     }
 
-    return GatewayClient(net=net_address[net], chain=StarknetChainId.TESTNET)
+    return GatewayClient(net=net_address[net])
 
 
 @pytest.fixture(name="rpc_client", scope="module")
 def create_rpc_client(run_devnet):
-    return FullNodeClient(
-        node_url=run_devnet + "/rpc", chain=StarknetChainId.TESTNET, net=run_devnet
-    )
+    return FullNodeClient(node_url=run_devnet + "/rpc", net=run_devnet)
 
 
 def create_account_client(
-    address: AddressRepresentation, private_key: str, gateway_client: GatewayClient
+    address: AddressRepresentation,
+    private_key: str,
+    gateway_client: GatewayClient,
+    chain: StarknetChainId,
 ):
     key_pair = KeyPair.from_private_key(int(private_key, 0))
     return AccountClient(
-        address=address,
-        client=gateway_client,
-        key_pair=key_pair,
+        address=address, client=gateway_client, key_pair=key_pair, chain=chain
     )
 
 
@@ -141,14 +140,18 @@ def address_and_private_key(pytestconfig):
 def gateway_account_client(address_and_private_key, gateway_client):
     address, private_key = address_and_private_key
 
-    return create_account_client(address, private_key, gateway_client)
+    return create_account_client(
+        address, private_key, gateway_client, StarknetChainId.TESTNET
+    )
 
 
 @pytest.fixture(scope="module")
 def rpc_account_client(address_and_private_key, rpc_client):
     address, private_key = address_and_private_key
 
-    return create_account_client(address, private_key, rpc_client)
+    return create_account_client(
+        address, private_key, rpc_client, StarknetChainId.TESTNET
+    )
 
 
 @pytest.fixture(scope="module")

--- a/starknet_py/tests/e2e/docs/guide/test_account_client_details.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_client_details.py
@@ -9,6 +9,7 @@ async def test_account_client_details(
     # add to docs: start
     from starknet_py.contract import Contract
     from starknet_py.net import AccountClient
+    from starknet_py.net.models import StarknetChainId
     from starknet_py.net.gateway_client import GatewayClient
 
     net = "testnet"
@@ -17,7 +18,9 @@ async def test_account_client_details(
     # add to docs: start
 
     # Creates an account
-    client = await AccountClient.create_account(client=GatewayClient(net=net))
+    client = await AccountClient.create_account(
+        client=GatewayClient(net=net), chain=StarknetChainId.TESTNET
+    )
     # add to docs: end
 
     client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_account_client_details.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_client_details.py
@@ -10,7 +10,6 @@ async def test_account_client_details(
     from starknet_py.contract import Contract
     from starknet_py.net import AccountClient
     from starknet_py.net.gateway_client import GatewayClient
-    from starknet_py.net.models import StarknetChainId
 
     net = "testnet"
     # add to docs: end
@@ -18,9 +17,7 @@ async def test_account_client_details(
     # add to docs: start
 
     # Creates an account
-    client = await AccountClient.create_account(
-        client=GatewayClient(net=net, chain=StarknetChainId.TESTNET)
-    )
+    client = await AccountClient.create_account(client=GatewayClient(net=net))
     # add to docs: end
 
     client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
@@ -9,6 +9,7 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.contract import Contract
     from starknet_py.net import AccountClient
+    from starknet_py.net.models import StarknetChainId
     from starknet_py.utils.data_transformer.data_transformer import CairoSerializer
 
     # Code of the contract which emits an event
@@ -45,7 +46,7 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
     # add to docs: start
 
     # Creates an account
-    client = await AccountClient.create_account(client=GatewayClient(net=net))
+    client = await AccountClient.create_account(client=GatewayClient(net=net), chain=StarknetChainId.TESTNET)
     # add to docs: end
 
     client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
@@ -46,7 +46,9 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
     # add to docs: start
 
     # Creates an account
-    client = await AccountClient.create_account(client=GatewayClient(net=net), chain=StarknetChainId.TESTNET)
+    client = await AccountClient.create_account(
+        client=GatewayClient(net=net), chain=StarknetChainId.TESTNET
+    )
     # add to docs: end
 
     client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
@@ -7,7 +7,6 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
     # pylint: disable=unused-variable, too-many-locals, import-outside-toplevel
     # add to docs: start
     from starknet_py.net.gateway_client import GatewayClient
-    from starknet_py.net.models import StarknetChainId
     from starknet_py.contract import Contract
     from starknet_py.net import AccountClient
     from starknet_py.utils.data_transformer.data_transformer import CairoSerializer
@@ -46,9 +45,7 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
     # add to docs: start
 
     # Creates an account
-    client = await AccountClient.create_account(
-        client=GatewayClient(net=net, chain=StarknetChainId.TESTNET)
-    )
+    client = await AccountClient.create_account(client=GatewayClient(net=net))
     # add to docs: end
 
     client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -44,7 +44,9 @@ async def test_using_existing_contracts(
 
     contract = Contract(address=address, abi=abi, client=gateway_client)
     # or
-    acc_client = await AccountClient.create_account(client=gateway_client, chain=StarknetChainId.TESTNET)
+    acc_client = await AccountClient.create_account(
+        client=gateway_client, chain=StarknetChainId.TESTNET
+    )
     # add to docs: end
 
     acc_client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -34,6 +34,7 @@ async def test_using_existing_contracts(
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.contract import Contract
     from starknet_py.net.networks import TESTNET
+    from starknet_py.net.models import StarknetChainId
 
     address = "0x00178130dd6286a9a0e031e4c73b2bd04ffa92804264a25c1c08c1612559f458"
     client = GatewayClient(TESTNET)
@@ -43,7 +44,7 @@ async def test_using_existing_contracts(
 
     contract = Contract(address=address, abi=abi, client=gateway_client)
     # or
-    acc_client = await AccountClient.create_account(client=gateway_client)
+    acc_client = await AccountClient.create_account(client=gateway_client, chain=StarknetChainId.TESTNET)
     # add to docs: end
 
     acc_client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
@@ -23,6 +23,7 @@ async def test_creating_account_client(run_devnet):
         client=client,
         address="0x1234",
         key_pair=KeyPair(private_key=123, public_key=456),
+        chain=StarknetChainId.TESTNET,
     )
 
     # There is another way of creating key_pair

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
@@ -35,5 +35,5 @@ async def test_creating_account_client(run_devnet):
     account_client = AccountClient(client=client, address="0x1234", signer=signer)
 
     # Deploys an account on testnet and returns an instance
-    account_client = await AccountClient.create_account(client=client)
+    account_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
     # add to docs: end

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
@@ -35,5 +35,7 @@ async def test_creating_account_client(run_devnet):
     account_client = AccountClient(client=client, address="0x1234", signer=signer)
 
     # Deploys an account on testnet and returns an instance
-    account_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
+    account_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId.TESTNET
+    )
     # add to docs: end

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
@@ -18,7 +18,7 @@ async def test_creating_account_client(run_devnet):
     # add to docs: start
 
     # Creates an instance of account client which is already deployed (testnet):
-    client = GatewayClient(net=testnet, chain=chain_id)
+    client = GatewayClient(net=testnet)
     account_client_testnet = AccountClient(
         client=client,
         address="0x1234",

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
@@ -12,6 +12,7 @@ async def test_using_account_client(
     # add to docs: start
     from starknet_py.net import AccountClient
     from starknet_py.contract import Contract
+    from starknet_py.net.models import StarknetChainId
     from starknet_py.net.gateway_client import GatewayClient
 
     # add to docs: end
@@ -20,7 +21,7 @@ async def test_using_account_client(
 
     # Creates an account on testnet and returns an instance
     client = GatewayClient(net=testnet)
-    acc_client = await AccountClient.create_account(client=client)
+    acc_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
     # add to docs: end
     acc_client = gateway_account_client
     # add to docs: start

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-from starknet_py.net.models import StarknetChainId
 
 directory = os.path.dirname(__file__)
 
@@ -20,7 +19,7 @@ async def test_using_account_client(
     # add to docs: start
 
     # Creates an account on testnet and returns an instance
-    client = GatewayClient(net=testnet, chain=StarknetChainId.TESTNET)
+    client = GatewayClient(net=testnet)
     acc_client = await AccountClient.create_account(client=client)
     # add to docs: end
     acc_client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
@@ -21,7 +21,9 @@ async def test_using_account_client(
 
     # Creates an account on testnet and returns an instance
     client = GatewayClient(net=testnet)
-    acc_client = await AccountClient.create_account(client=client, chain=StarknetChainId.TESTNET)
+    acc_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId.TESTNET
+    )
     # add to docs: end
     acc_client = gateway_account_client
     # add to docs: start

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -11,6 +11,7 @@ async def test_using_contract(gateway_client, gateway_account_client, map_contra
     # add to docs: start
     from starknet_py.contract import Contract
     from starknet_py.net import AccountClient
+    from starknet_py.net.models import StarknetChainId
     from starknet_py.net.networks import TESTNET
     from starknet_py.net.gateway_client import GatewayClient
 
@@ -20,7 +21,7 @@ async def test_using_contract(gateway_client, gateway_account_client, map_contra
 
     # add to docs: start
 
-    acc_client = await AccountClient.create_account(gateway_client)
+    acc_client = await AccountClient.create_account(gateway_client, chain=StarknetChainId.TESTNET)
 
     contract_address = (
         "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b"

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -21,7 +21,9 @@ async def test_using_contract(gateway_client, gateway_account_client, map_contra
 
     # add to docs: start
 
-    acc_client = await AccountClient.create_account(gateway_client, chain=StarknetChainId.TESTNET)
+    acc_client = await AccountClient.create_account(
+        gateway_client, chain=StarknetChainId.TESTNET
+    )
 
     contract_address = (
         "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b"

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
@@ -18,11 +18,7 @@ async def test_using_gateway_client():
     mainnet_client = GatewayClient("mainnet")
 
     # Local network
-    from starknet_py.net.models import StarknetChainId
-
-    local_network_client = GatewayClient(
-        "http://localhost:5000", chain=StarknetChainId.TESTNET
-    )
+    local_network_client = GatewayClient("http://localhost:5000")
 
     call_result = await testnet_client.get_block(
         "0x495c670c53e4e76d08292524299de3ba078348d861dd7b2c7cc4933dbc27943"


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It removes unnecessary chain parameter from the Client interface

## **What is the current behaviour?** (You can also link to an open issue here)

Chain id is used only in the AccountClient to sign transactions, but it is in the Client interface

## **What is the new behaviour (if this is a feature change)?**

Chain id is present only in the AccontClient

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, the Client interface has changed

## **Other information**
