### PR TITLE
Feat/data transformer repr

### DIFF
--- a/starknet_py/utils/data_transformer/data_transformer_test.py
+++ b/starknet_py/utils/data_transformer/data_transformer_test.py
@@ -647,5 +647,6 @@ def test_result_warpper_as_str(result_dict, expected):
     ],
 )
 def test_result_wrapper_repr(result_dict, expected):
+    # pylint: disable=unused-argument
     result = construct_result_object(result_dict)
     assert str(result) == repr(result)

--- a/starknet_py/utils/data_transformer/data_transformer_test.py
+++ b/starknet_py/utils/data_transformer/data_transformer_test.py
@@ -2,7 +2,10 @@ from typing import NamedTuple
 import pytest
 from starkware.starknet.public.abi_structs import identifier_manager_from_abi
 
-from starknet_py.utils.data_transformer.data_transformer import FunctionCallSerializer
+from starknet_py.utils.data_transformer.data_transformer import (
+    FunctionCallSerializer,
+    construct_result_object,
+)
 from starknet_py.cairo.felt import decode_shortstring
 
 
@@ -607,3 +610,42 @@ def test_allow_underscores_in_abi():
     result = transformer_for_function(outputs=abi).to_python([1])
     # pylint: disable=protected-access
     assert result._first == 1
+
+
+@pytest.mark.parametrize(
+    "result_dict, expected",
+    [
+        ({"a": 1, "b": 2}, "Result(a=1, b=2)"),
+        ({"a": 1, "_b": 2}, "Result(a=1, _b=2)"),
+        ({"a": 1, "_b": 2, "def": 3}, "Result(a=1, _b=2, def=3)"),
+        ({"a": [1, 2, 3]}, "Result(a=[1, 2, 3])"),
+        ({"a": (1, 2, 3)}, "Result(a=(1, 2, 3))"),
+        (
+            {"a": {"val1": 1, "val2": [2, 3], "val3": (4, 5)}},
+            "Result(a={'val1': 1, 'val2': [2, 3], 'val3': (4, 5)})",
+        ),
+        ({}, "Result()"),
+    ],
+)
+def test_result_warpper_as_str(result_dict, expected):
+    assert str(construct_result_object(result_dict)) == expected
+
+
+@pytest.mark.parametrize(
+    "result_dict, expected",
+    [
+        ({"a": 1, "b": 2}, "Result(a=1, b=2)"),
+        ({"a": 1, "_b": 2}, "Result(a=1, _b=2)"),
+        ({"a": 1, "_b": 2, "def": 3}, "Result(a=1, _b=2, def=3)"),
+        ({"a": [1, 2, 3]}, "Result(a=[1, 2, 3])"),
+        ({"a": (1, 2, 3)}, "Result(a=(1, 2, 3))"),
+        (
+            {"a": {"val1": 1, "val2": [2, 3], "val3": (4, 5)}},
+            "Result(a={'val1': 1, 'val2': [2, 3], 'val3': (4, 5)})",
+        ),
+        ({}, "Result()"),
+    ],
+)
+def test_result_wrapper_repr(result_dict, expected):
+    result = construct_result_object(result_dict)
+    assert str(result) == repr(result)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The formatter, linter, and tests all run without an error
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds `__repr__` and `__str__` methods to the Result wrapper in data transformer.

Moves Result class outside of the `construct_result_argument` function.

* **What is the current behavior?** (You can also link to an open issue here)

`__repr__` and `__str__` are not implemented.

## **What is the new behavior (if this is a feature change)?**

as above

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Unless someone is relying on default `__repr__` and `__str__` representations, there shouldn't be any breaking changes 

## **Other information**

n/a