### PR TITLE
Deprecate chain in the Client interface

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -18,7 +18,7 @@ This is how we can interact with it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
     :language: python
-    :lines: 34-39,43-46,54-89
+    :lines: 34-40,44-49,57-92
     :dedent: 4
 
 
@@ -201,7 +201,7 @@ Here is a usage example:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
     :language: python
-    :lines: 9-42,47-51,56-98
+    :lines: 9-42,47-52,57-99
     :dedent: 4
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -50,7 +50,7 @@ There are some examples how to do it:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
     :language: python
-    :lines: 10-15,19-37
+    :lines: 10-15,19-40
     :dedent: 4
 
 Using AccountClient
@@ -60,7 +60,7 @@ Example usage:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
     :language: python
-    :lines: 14-17,21-24,28-58
+    :lines: 14-17,21-26,30-60
     :dedent: 4
 
 Using Contract
@@ -69,7 +69,7 @@ Using Contract
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
     :language: python
-    :lines: 12-17,22-28,33-35,41-58
+    :lines: 12-18,23-31,36-38,44-61
     :dedent: 4
 
 .. note::

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -55,14 +55,16 @@ class AccountClient(Client):
         client: Client,
         signer: Optional[BaseSigner] = None,
         key_pair: Optional[KeyPair] = None,
+        chain: Optional[StarknetChainId] = None,
     ):
         """
         :param address: Address of the account contract
         :param client: Instance of GatewayClient which will be used to add transactions
         :param signer: Custom signer to be used by AccountClient.
-                       If none is provieded, default
+                       If none is provided, default
                        :py:class:`starknet_py.net.signer.stark_curve_signer.StarkCurveSigner` is used.
         :param key_pair: Key pair that will be used to create a default `Signer`
+        :param chain: ChainId of the chain used by the client
         """
         # pylint: disable=too-many-arguments
         if signer is None and key_pair is None:
@@ -70,23 +72,26 @@ class AccountClient(Client):
                 "Either a signer or a key_pair must be provied in AccountClient constructor"
             )
 
-        chain = chain_from_network(net=client.net, chain=client.chain)
+        if chain is None and client.chain is None and signer is None:
+            raise ValueError("One of chain or signer must be provided")
 
-        if chain is None and client is None:
-            raise ValueError("One of chain or client must be provided")
         self.address = parse_address(address)
         self.client = client
-        self.signer = signer or StarkCurveSigner(
-            account_address=self.address, key_pair=key_pair, chain_id=self.client.chain
-        )
 
-    @property
-    def chain(self) -> StarknetChainId:
-        return self.client.chain
+        if signer is None:
+            chain = chain_from_network(net=client.net, chain=chain or self.client.chain)
+            signer = StarkCurveSigner(
+                account_address=self.address, key_pair=key_pair, chain_id=chain
+            )
+        self.signer = signer
 
     @property
     def net(self) -> Network:
         return self.client.net
+
+    @property
+    def chain(self) -> StarknetChainId:
+        return self.signer.chain_id
 
     async def get_block(
         self,
@@ -359,6 +364,7 @@ class AccountClient(Client):
         client: Client,
         private_key: Optional[int] = None,
         signer: Optional[BaseSigner] = None,
+        chain: Optional[StarknetChainId] = None,
     ) -> "AccountClient":
         """
         Creates the account using
@@ -369,15 +375,20 @@ class AccountClient(Client):
                        which will be used to add the transactions
         :param private_key: Private Key used for the account
         :param signer: Signer used to create account and sign transaction
+        :param chain: ChainId of the chain used by the client
         :return: Instance of AccountClient which interacts with created account on given network
         """
+        if chain is None and client.chain is None and signer is None:
+            raise ValueError("One of chain or signer must be provided")
+
         if signer is None:
             private_key = private_key or get_random_private_key()
 
+            chain = chain_from_network(net=client.net, chain=chain or client.chain)
             key_pair = KeyPair.from_private_key(private_key)
             address = await deploy_account_contract(client, key_pair.public_key)
             signer = StarkCurveSigner(
-                account_address=address, key_pair=key_pair, chain_id=client.chain
+                account_address=address, key_pair=key_pair, chain_id=chain
             )
         else:
             address = await deploy_account_contract(client, signer.public_key)

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -45,7 +45,7 @@ class Client(ABC):
     @abstractmethod
     def chain(self) -> StarknetChainId:
         """
-        ChainId of the chain used by the client
+        ChainId of the chain used by the client. Chain is deprecated!
         """
 
     @abstractmethod

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from typing import List, Optional, Union
 
 import aiohttp
@@ -57,10 +58,16 @@ class FullNodeClient(Client):
 
         :param node_url: Url of the node providing rpc interface
         :param net: StarkNet network identifier
-        :param chain: Chain id of the network used by the rpc client
+        :param chain: Chain id of the network used by the rpc client. Chain is deprecated
+                        and will be removed in the next releases
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
-                        every request. When using a custom session, user is resposible for closing it manually.
+                        every request. When using a custom session, user is responsible for closing it manually.
         """
+        if chain is not None:
+            warnings.warn(
+                "Chain is deprecated and will be deleted in the next releases"
+            )
+
         self.url = node_url
         self._client = RpcHttpClient(url=node_url, session=session)
         self._chain = chain_from_network(net, chain)
@@ -72,6 +79,7 @@ class FullNodeClient(Client):
 
     @property
     def chain(self) -> StarknetChainId:
+        warnings.warn("Chain is deprecated and will be deleted in the next releases")
         return self._chain
 
     async def get_block(

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from typing import Union, Optional, List
 
 import aiohttp
@@ -53,17 +54,23 @@ class GatewayClient(Client):
     def __init__(
         self,
         net: Network,
-        chain: StarknetChainId = None,
+        chain: Optional[StarknetChainId] = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
         Client for interacting with starknet gateway.
 
         :param net: Target network for the client. Can be a string with URL or one of ``"mainnet"``, ``"testnet"``
-        :param chain: Chain used by the network. Required if you use a custom URL for ``net`` param.
+        :param chain: Chain used by the network. Required if you use a custom URL for ``net`` param. Chain is deprecated
+                        and will be removed in the next releases
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
                         every request. When using a custom session, user is resposible for closing it manually.
         """
+        if chain is not None:
+            warnings.warn(
+                "Chain is deprecated and will be deleted in the next releases"
+            )
+
         host = net_address_from_net(net)
         feeder_gateway_url = f"{host}/feeder_gateway"
         gateway_url = f"{host}/gateway"
@@ -77,10 +84,11 @@ class GatewayClient(Client):
 
     @property
     def chain(self) -> StarknetChainId:
+        warnings.warn("Chain is deprecated and will be deleted in the next releases")
         return self._chain
 
     @property
-    def net(self) -> StarknetChainId:
+    def net(self) -> Network:
         return self._net
 
     async def get_transaction(

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -50,7 +50,10 @@ async def test_balance_when_token_specified(gateway_account_client, erc20_contra
 async def test_get_balance_default_token_address(net):
     client = GatewayClient(net=net)
     acc_client = AccountClient(
-        client=client, address="0x123", key_pair=KeyPair(123, 456)
+        client=client,
+        address="0x123",
+        key_pair=KeyPair(123, 456),
+        chain=StarknetChainId.TESTNET,
     )
 
     with patch(
@@ -103,7 +106,9 @@ async def test_estimated_fee_greater_than_zero(erc20_contract):
 @pytest.mark.asyncio
 async def test_create_account_client(run_devnet):
     client = GatewayClient(net=run_devnet, chain=StarknetChainId.TESTNET)
-    acc_client = await AccountClient.create_account(client)
+    acc_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId.TESTNET
+    )
     assert acc_client.signer is not None
     assert acc_client.address is not None
 
@@ -114,7 +119,7 @@ async def test_create_account_client_with_private_key(run_devnet):
     private_key = 1234
     gt_client = GatewayClient(net=run_devnet, chain=StarknetChainId.TESTNET)
     acc_client = await AccountClient.create_account(
-        client=gt_client, private_key=private_key
+        client=gt_client, private_key=private_key, chain=StarknetChainId.TESTNET
     )
     assert acc_client.signer.private_key == private_key
     assert acc_client.signer is not None

--- a/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
@@ -47,7 +47,8 @@ async def test_using_cairo_serializer(run_devnet, gateway_account_client):
 
     # Creates an account
     client = await AccountClient.create_account(
-        client=GatewayClient(net=net, chain=StarknetChainId.TESTNET)
+        client=GatewayClient(net=net, chain=StarknetChainId.TESTNET),
+        chain=StarknetChainId.TESTNET,
     )
     # add to docs: end
 

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -34,6 +34,7 @@ async def test_using_existing_contracts(
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.contract import Contract
     from starknet_py.net.networks import TESTNET
+    from starknet_py.net.models import StarknetChainId
 
     address = "0x00178130dd6286a9a0e031e4c73b2bd04ffa92804264a25c1c08c1612559f458"
     client = GatewayClient(TESTNET)
@@ -43,7 +44,9 @@ async def test_using_existing_contracts(
 
     contract = Contract(address=address, abi=abi, client=gateway_client)
     # or
-    acc_client = await AccountClient.create_account(client=gateway_client)
+    acc_client = await AccountClient.create_account(
+        client=gateway_client, chain=StarknetChainId.TESTNET
+    )
     # add to docs: end
 
     acc_client = gateway_account_client

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account_client.py
@@ -23,6 +23,7 @@ async def test_creating_account_client(run_devnet):
         client=client,
         address="0x1234",
         key_pair=KeyPair(private_key=123, public_key=456),
+        chain=StarknetChainId.TESTNET,
     )
 
     # There is another way of creating key_pair
@@ -34,5 +35,7 @@ async def test_creating_account_client(run_devnet):
     account_client = AccountClient(client=client, address="0x1234", signer=signer)
 
     # Deploys an account on testnet and returns an instance
-    account_client = await AccountClient.create_account(client=client)
+    account_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId.TESTNET
+    )
     # add to docs: end

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account_client.py
@@ -21,7 +21,9 @@ async def test_using_account_client(
 
     # Creates an account on testnet and returns an instance
     client = GatewayClient(net=testnet, chain=StarknetChainId.TESTNET)
-    acc_client = await AccountClient.create_account(client=client)
+    acc_client = await AccountClient.create_account(
+        client=client, chain=StarknetChainId
+    )
     # add to docs: end
     acc_client = gateway_account_client
     # add to docs: start

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -13,6 +13,7 @@ async def test_using_contract(gateway_client, gateway_account_client, map_contra
     from starknet_py.net import AccountClient
     from starknet_py.net.networks import TESTNET
     from starknet_py.net.gateway_client import GatewayClient
+    from starknet_py.net.models import StarknetChainId
 
     client = GatewayClient(TESTNET)
     # add to docs: end
@@ -20,7 +21,9 @@ async def test_using_contract(gateway_client, gateway_account_client, map_contra
 
     # add to docs: start
 
-    acc_client = await AccountClient.create_account(gateway_client)
+    acc_client = await AccountClient.create_account(
+        gateway_client, chain=StarknetChainId.TESTNET
+    )
 
     contract_address = (
         "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b"


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It deprecates chain

## **What is the current behavior?** (You can also link to an open issue here)

Chain id is used only in the AccountClient to sign transactions, but it is in the Client interface

## **What is the new behavior (if this is a feature change)?**

Chain id is deprecated and chain parameter is  added to AccountClient

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

## **Other information**
