### PR TITLE
Fix error when creating GatewayClient with custom gateway url

### DIFF
--- a/starknet_py/net/models/chains.py
+++ b/starknet_py/net/models/chains.py
@@ -18,7 +18,7 @@ def chain_from_network(
         TESTNET: StarknetChainId.TESTNET,
     }
 
-    if net in mapping:
+    if isinstance(net, str) and net in mapping:
         return mapping[net]
 
     if not chain:

--- a/starknet_py/tests/e2e/client/gateway_test.py
+++ b/starknet_py/tests/e2e/client/gateway_test.py
@@ -1,6 +1,9 @@
 import pytest
 
 from starknet_py.net.client_models import TransactionStatusResponse, TransactionStatus
+from starknet_py.net.gateway_client import GatewayClient
+from starknet_py.net.models import StarknetChainId
+from starknet_py.net.networks import TESTNET, MAINNET, net_address_from_net
 
 
 @pytest.mark.asyncio
@@ -47,3 +50,53 @@ async def test_get_transaction_status(invoke_transaction_hash, gateway_client):
     assert isinstance(tx_status_resp, TransactionStatusResponse)
     assert tx_status_resp.transaction_status == TransactionStatus.ACCEPTED_ON_L2
     assert isinstance(tx_status_resp.block_hash, int)
+
+
+# pylint: disable=protected-access
+@pytest.mark.parametrize(
+    "net, chain",
+    ((TESTNET, StarknetChainId.TESTNET), (MAINNET, StarknetChainId.MAINNET)),
+)
+def test_creating_client_from_predefined_network(net, chain):
+    gateway_client = GatewayClient(net=net)
+    net_address = net_address_from_net(net)
+
+    assert gateway_client.net == net
+    assert gateway_client._feeder_gateway_client.url == f"{net_address}/feeder_gateway"
+    assert gateway_client._gateway_client.url == f"{net_address}/gateway"
+    assert gateway_client.chain == chain
+
+
+def test_creating_client_with_custom_net(run_devnet):
+    gateway_client = GatewayClient(net=run_devnet, chain=StarknetChainId.TESTNET)
+
+    assert gateway_client.net == run_devnet
+    assert gateway_client._feeder_gateway_client.url == f"{run_devnet}/feeder_gateway"
+    assert gateway_client._gateway_client.url == f"{run_devnet}/gateway"
+    assert gateway_client.chain == StarknetChainId.TESTNET
+
+
+def test_creating_client_with_custom_net_dict(run_devnet):
+    net = {
+        "feeder_gateway_url": f"{run_devnet}/feeder_gateway",
+        "gateway_url": f"{run_devnet}/gateway",
+    }
+
+    gateway_client = GatewayClient(net=net, chain=StarknetChainId.TESTNET)
+
+    assert gateway_client.net == net
+    assert gateway_client._feeder_gateway_client.url == net["feeder_gateway_url"]
+    assert gateway_client._gateway_client.url == net["gateway_url"]
+    assert gateway_client.chain == StarknetChainId.TESTNET
+
+
+def test_throwing_on_custom_net_dict_without_chain(run_devnet):
+    net = {
+        "feeder_gateway_url": f"{run_devnet}/feeder_gateway",
+        "gateway_url": f"{run_devnet}/gateway",
+    }
+
+    with pytest.raises(ValueError) as err:
+        GatewayClient(net=net)
+
+    assert "Chain is required when not using predefined networks." == str(err.value)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes a bug

* **What is the current behaviour?** (You can also link to an open issue here)

When providing net as dict with gateway_url and _feeder_gateway_url there was an error while computing the chain property.

## **What is the new behaviour (if this is a feature change)?**

There are no wrong errors and tests were added to avoid such a situation

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

## **Other information**
