### PR TITLE
Wrong value for MIN and MAX Felt fixed

### DIFF
--- a/starknet_py/cairo/felt.py
+++ b/starknet_py/cairo/felt.py
@@ -35,8 +35,8 @@ def uint256_range_check(value: int):
         raise ValueError(f"UInt256 is expected to be in range [0;2^256), got {value}")
 
 
-MIN_FELT = -FIELD_PRIME / 2
-MAX_FELT = FIELD_PRIME / 2
+MIN_FELT = -FIELD_PRIME // 2
+MAX_FELT = FIELD_PRIME // 2
 
 
 def cairo_vm_range_check(value: int):


### PR DESCRIPTION
### **Please check if the PR fulfils these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes a bug in the felt.py

* **What is the current behaviour?** (You can also link to an open issue here)

MIN_FELT and MAX_FELT are not integers (but should be)

## **What is the new behaviour (if this is a feature change)?**

MIN_FELT and MAX_FELT are integers

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Probably not, but if someone is using them this PR can cause changes in the business logic

## **Other information**
