### PR TITLE
Fix result selector on Custom RPC call

### DIFF
--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -229,7 +229,7 @@ class FullNodeClient(Client):
                 **block_identifier,
             },
         )
-        return [int(i, 16) for i in res["result"]]
+        return [int(i, 16) for i in res]
 
     async def send_transaction(
         self, transaction: InvokeFunction


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The formatter, linter, and tests all run without an error
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix on Custom RPC call results -> `starknet_call`


* **What is the current behavior?** (You can also link to an open issue here)

Calling `starknet_call` will always result into a TypeError as we check twice "result" key

## **What is the new behavior (if this is a feature change)?**

`starknet_call` is now working.

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

## **Other information**

-
