### PR TITLE
Remove some deprecated features

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ It requires information about used network:
 
 .. literalinclude:: ../starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
     :language: python
-    :lines: 8-29
+    :lines: 8-25
     :dedent: 4
 
 The default interface is asynchronous. Although it is the recommended way of using Starknet.py, you can also use a

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -82,14 +82,14 @@ class AccountClient(Client):
                 "Either a signer or a key_pair must be provided in AccountClient constructor"
             )
 
-        if chain is None and signer is None and client.chain is None:
+        if chain is None and signer is None:
             raise ValueError("One of chain or signer must be provided")
 
         self.address = parse_address(address)
         self.client = client
 
         if signer is None:
-            chain = chain_from_network(net=client.net, chain=chain or self.client.chain)
+            chain = chain_from_network(net=client.net, chain=chain)
             signer = StarkCurveSigner(
                 account_address=self.address, key_pair=key_pair, chain_id=chain
             )
@@ -106,14 +106,6 @@ class AccountClient(Client):
     @property
     def net(self) -> Network:
         return self.client.net
-
-    @property
-    def chain(self) -> StarknetChainId:
-        warnings.warn(
-            "Chain is deprecated and will be deleted in the future",
-            category=DeprecationWarning,
-        )
-        return self.signer.chain_id
 
     async def get_block(
         self,
@@ -536,20 +528,19 @@ class AccountClient(Client):
             Consider transitioning to deploying account contract of choice and creating AccountClient
             through a constructor.
         """
-        if chain is None and signer is None and client.chain is None:
-            warnings.warn(
-                "Account deployment through AccountClient is deprecated and will be deleted once transaction version "
-                "0 is removed. Consider transitioning to creating AccountClient through a constructor.",
-                category=DeprecationWarning,
-            )
+        warnings.warn(
+            "Account deployment through AccountClient is deprecated and will be deleted once transaction version "
+            "0 is removed. Consider transitioning to creating AccountClient through a constructor.",
+            category=DeprecationWarning,
+        )
 
-        if chain is None and client.chain is None and signer is None:
+        if chain is None and signer is None:
             raise ValueError("One of chain or signer must be provided")
 
         if signer is None:
             private_key = private_key or get_random_private_key()
 
-            chain = chain_from_network(net=client.net, chain=chain or client.chain)
+            chain = chain_from_network(net=client.net, chain=chain)
             key_pair = KeyPair.from_private_key(private_key)
             address = await deploy_account_contract(client, key_pair.public_key)
             signer = StarkCurveSigner(

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -23,7 +23,6 @@ from starknet_py.net.client_models import (
     DeclareTransactionResponse,
     Call,
 )
-from starknet_py.net.models import StarknetChainId
 from starknet_py.net.networks import Network
 from starknet_py.transaction_exceptions import (
     TransactionRejectedError,
@@ -40,13 +39,6 @@ class Client(ABC):
     def net(self) -> Network:
         """
         Network of the client
-        """
-
-    @property
-    @abstractmethod
-    def chain(self) -> StarknetChainId:
-        """
-        ChainId of the chain used by the client. Chain is deprecated!
         """
 
     @abstractmethod

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -28,10 +28,6 @@ from starknet_py.net.client_models import (
     Call,
 )
 from starknet_py.net.http_client import RpcHttpClient
-from starknet_py.net.models import (
-    StarknetChainId,
-    chain_from_network,
-)
 from starknet_py.net.networks import Network
 from starknet_py.net.schemas.rpc import (
     StarknetBlockSchema,
@@ -56,7 +52,6 @@ class FullNodeClient(Client):
         self,
         node_url: str,
         net: Network,
-        chain: Optional[StarknetChainId] = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
@@ -64,31 +59,16 @@ class FullNodeClient(Client):
 
         :param node_url: Url of the node providing rpc interface
         :param net: StarkNet network identifier
-        :param chain: Chain id of the network used by the rpc client. Chain is deprecated
-                        and will be removed in the future
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
                         every request. When using a custom session, user is responsible for closing it manually.
         """
         self.url = node_url
         self._client = RpcHttpClient(url=node_url, session=session)
-
-        if net in ["testnet", "mainnet"]:
-            chain = chain_from_network(net, chain)
-        self._chain = chain
-
         self._net = net
 
     @property
     def net(self) -> Network:
         return self._net
-
-    @property
-    def chain(self) -> StarknetChainId:
-        warnings.warn(
-            "Chain is deprecated and will be deleted in the future",
-            category=DeprecationWarning,
-        )
-        return self._chain
 
     async def get_block(
         self,

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -43,7 +43,6 @@ from starknet_py.net.schemas.gateway import (
     TransactionReceiptSchema,
 )
 from starknet_py.net.http_client import GatewayHttpClient
-from starknet_py.net.models import StarknetChainId, chain_from_network
 from starknet_py.net.networks import Network, net_address_from_net
 from starknet_py.net.client_errors import ContractNotFoundError
 from starknet_py.net.client_utils import convert_to_felt, is_block_identifier
@@ -56,7 +55,6 @@ class GatewayClient(Client):
     def __init__(
         self,
         net: Network,
-        chain: Optional[StarknetChainId] = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
@@ -64,8 +62,6 @@ class GatewayClient(Client):
 
         :param net: Target network for the client. Can be a string with URL, one of ``"mainnet"``, ``"testnet"``
                     or dict with ``"feeder_gateway_url"`` and ``"gateway_url"`` fields
-        :param chain: Chain used by the network. Required if you use a custom URL for ``net`` param. Chain is deprecated
-                        and will be removed in the future
         :param session: Aiohttp session to be used for request. If not provided, client will create a session for
                         every request. When using a custom session, user is resposible for closing it manually.
         """
@@ -79,10 +75,6 @@ class GatewayClient(Client):
 
         self._net = net
 
-        if net in ["testnet", "mainnet"]:
-            chain = chain_from_network(net, chain)
-        self._chain = chain
-
         self._feeder_gateway_client = GatewayHttpClient(
             url=feeder_gateway_url, session=session
         )
@@ -91,14 +83,6 @@ class GatewayClient(Client):
     @property
     def net(self) -> Network:
         return self._net
-
-    @property
-    def chain(self) -> StarknetChainId:
-        warnings.warn(
-            "Chain is deprecated and will be deleted in the future",
-            category=DeprecationWarning,
-        )
-        return self._chain
 
     async def get_block(
         self,

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -112,7 +112,7 @@ async def test_estimated_fee_greater_than_zero(erc20_contract, account_client):
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
 async def test_create_account_client(network):
-    client = GatewayClient(net=network, chain=StarknetChainId.TESTNET)
+    client = GatewayClient(net=network)
     acc_client = await AccountClient.create_account(
         client=client, chain=StarknetChainId.TESTNET
     )
@@ -124,7 +124,7 @@ async def test_create_account_client(network):
 @pytest.mark.asyncio
 async def test_create_account_client_with_private_key(network):
     private_key = 1234
-    gt_client = GatewayClient(net=network, chain=StarknetChainId.TESTNET)
+    gt_client = GatewayClient(net=network)
     acc_client = await AccountClient.create_account(
         client=gt_client, private_key=private_key, chain=StarknetChainId.TESTNET
     )

--- a/starknet_py/tests/e2e/client/conftest.py
+++ b/starknet_py/tests/e2e/client/conftest.py
@@ -16,7 +16,6 @@ from starknet_py.net import AccountClient
 from starknet_py.net.client import Client
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.gateway_client import GatewayClient
-from starknet_py.net.models import StarknetChainId
 from starknet_py.tests.e2e.client.prepare_net_for_gateway_test import (
     prepare_net_for_tests,
     PreparedNetworkData,
@@ -187,10 +186,9 @@ def fixture_clients(network: str) -> Tuple[Client, Client]:
     """
     Returns Gateway and FullNode Clients
     """
-    gateway_client = GatewayClient(net=network, chain=StarknetChainId.TESTNET)
+    gateway_client = GatewayClient(net=network)
     full_node_client = FullNodeClient(
         node_url=network + "/rpc",
-        chain=StarknetChainId.TESTNET,
         net=network,
     )
 

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_gateway_client.py
@@ -18,11 +18,7 @@ async def test_using_gateway_client():
     mainnet_client = GatewayClient("mainnet")
 
     # Local network
-    from starknet_py.net.models import StarknetChainId
-
-    local_network_client = GatewayClient(
-        "http://localhost:5000", chain=StarknetChainId.TESTNET
-    )
+    local_network_client = GatewayClient("http://localhost:5000")
 
     call_result = await testnet_client.get_block(
         "0x495c670c53e4e76d08292524299de3ba078348d861dd7b2c7cc4933dbc27943"

--- a/starknet_py/utils/crypto/crypto_test.py
+++ b/starknet_py/utils/crypto/crypto_test.py
@@ -1,48 +1,13 @@
-import time
-
 from crypto_cpp_py.cpp_bindings import (
     unload_cpp_lib,
     get_cpp_lib_file,
-    load_cpp_lib,
 )
 from starkware.crypto.signature.signature import verify, private_to_stark_key
 
 from starknet_py.utils.crypto.facade import (
-    MultiCall,
-    Call,
     use_cpp_variant,
-    hash_multicall,
     message_signature,
 )
-
-
-def test_hashing(monkeypatch):
-    call = Call(to_addr=1, selector=2, calldata=[4, 5])
-    multi_call = MultiCall(account=3, calls=[call], nonce=6)
-    times = []
-
-    load_cpp_lib()  # Pre-load cpp extension to make the hashing time appropriate
-    for _ in range(2):
-        monkeypatch.setenv("DISABLE_CRYPTO_C_EXTENSION", "")
-
-        assert use_cpp_variant()
-        start = time.time()
-        hash_1 = hash_multicall(multi_call)
-        end = time.time()
-        time_with_crypto = end - start
-
-        monkeypatch.setenv("DISABLE_CRYPTO_C_EXTENSION", "true")
-        assert not use_cpp_variant()
-        start = time.time()
-        hash_2 = hash_multicall(multi_call)
-        end = time.time()
-        time_without_crypto = end - start
-        times.append((time_with_crypto, time_without_crypto))
-
-        assert hash_1 == hash_2
-
-    assert times[1][0] < times[1][1]
-    assert times[0][0] < times[0][1]
 
 
 def test_signing(monkeypatch):

--- a/starknet_py/utils/crypto/facade.py
+++ b/starknet_py/utils/crypto/facade.py
@@ -1,6 +1,5 @@
 import os
-from dataclasses import dataclass
-from typing import Callable, Iterable, Optional
+from typing import Optional
 
 from crypto_cpp_py.cpp_bindings import (
     cpp_hash,
@@ -15,43 +14,6 @@ from starknet_py.net.client_models import Call
 
 # PREFIX_TRANSACTION = encoded 'StarkNet Transaction'
 PREFIX_TRANSACTION = 476441609247967894954472788179128007176248455022
-
-
-@dataclass(frozen=True)
-class MultiCall:
-    account: int
-    calls: Iterable[Call]
-    nonce: int
-    max_fee: int = 0
-    version: int = 0
-
-
-# pylint: disable=too-many-arguments
-def hash_multicall_with(
-    multi_call: MultiCall,
-    hash_fun: Callable[[int, int], int],
-) -> int:
-    """
-    Mimics the behavior of
-    https://github.com/argentlabs/cairo-contracts/blob/c2ff198e5de5b19514d99ecff604a7cbf3377d2f/contracts/Account.cairo#L248
-    """
-
-    calls_hash = compute_hash_on_elements(
-        [hash_call_with(c, hash_fun=hash_fun) for c in multi_call.calls],
-        hash_func=hash_fun,
-    )
-
-    return compute_hash_on_elements(
-        [
-            PREFIX_TRANSACTION,
-            multi_call.account,
-            calls_hash,
-            multi_call.nonce,
-            multi_call.max_fee,
-            multi_call.version,
-        ],
-        hash_func=hash_fun,
-    )
 
 
 def hash_call_with(call: Call, hash_fun):
@@ -84,10 +46,3 @@ def pedersen_hash(left: int, right: int) -> int:
     if use_cpp_variant():
         return cpp_hash(left, right)
     return default_hash(left, right)
-
-
-def hash_multicall(multi_call: MultiCall) -> int:
-    return hash_multicall_with(
-        multi_call=multi_call,
-        hash_fun=pedersen_hash,
-    )


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chain is gone! It was removed from the Client interface and all clients implementing it.
Also Multicall was removed from facade.py (it wasn't used anywhere)

## **What is the current behavior?** (You can also link to an open issue here)

Chain is deprecated

## **What is the new behavior (if this is a feature change)?**

Chain is gone

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes! It removes the method from the client interface

## **Other information**
