### PR TITLE
Fix remaining types

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -9,7 +9,8 @@ from typing import (
     TypeVar,
     Union,
     Dict,
-    NamedTuple, Any,
+    NamedTuple,
+    Any,
 )
 from typing import TypedDict
 

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -98,7 +98,7 @@ class SentTransaction:
 @add_sync_methods
 @dataclass(frozen=True)
 class InvokeResult(SentTransaction):
-    # We ensure these not None in __post_init__
+    # We ensure these are not None in __post_init__
     contract: ContractData = None  # pyright: ignore
     invoke_transaction: InvokeFunction = None  # pyright: ignore
 

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -1,5 +1,3 @@
-# pyright: reportGeneralTypeIssues=false, reportOptionalMemberAccess=false
-
 from __future__ import annotations
 
 import dataclasses
@@ -11,7 +9,7 @@ from typing import (
     TypeVar,
     Union,
     Dict,
-    NamedTuple,
+    NamedTuple, Any,
 )
 from typing import TypedDict
 
@@ -99,8 +97,9 @@ class SentTransaction:
 @add_sync_methods
 @dataclass(frozen=True)
 class InvokeResult(SentTransaction):
-    contract: ContractData = None
-    invoke_transaction: InvokeFunction = None
+    # We ensure these not None in __post_init__
+    contract: ContractData = None  # pyright: ignore
+    invoke_transaction: InvokeFunction = None  # pyright: ignore
 
     def __post_init__(self):
         assert self.contract is not None
@@ -113,7 +112,8 @@ InvocationResult = InvokeResult
 @add_sync_methods
 @dataclass(frozen=True)
 class DeployResult(SentTransaction):
-    deployed_contract: "Contract" = None
+    # We ensure this is not None in __post_init__
+    deployed_contract: "Contract" = None  # pyright: ignore
 
     def __post_init__(self):
         assert self.deployed_contract is not None
@@ -130,7 +130,7 @@ class PreparedFunctionCall(Call):
         client: Client,
         payload_transformer: FunctionCallSerializer,
         contract_data: ContractData,
-        max_fee: int,
+        max_fee: Optional[int],
         version: int,
     ):
         # pylint: disable=too-many-arguments
@@ -181,22 +181,20 @@ class PreparedFunctionCall(Call):
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs
         :return: InvokeResult
         """
-        self._assert_can_invoke()
-
         if max_fee is not None:
             self.max_fee = max_fee
 
-        transaction = await self._client.sign_invoke_transaction(
+        transaction = await self._account_client.sign_invoke_transaction(
             calls=self,
             max_fee=self.max_fee,
             auto_estimate=auto_estimate,
             version=self.version,
         )
-        response = await self._client.send_transaction(transaction)
+        response = await self._account_client.send_transaction(transaction)
 
         invoke_result = InvokeResult(
             hash=response.transaction_hash,  # noinspection PyTypeChecker
-            _client=self._client,
+            _client=self._account_client,
             contract=self._contract_data,
             invoke_transaction=transaction,
         )
@@ -216,26 +214,28 @@ class PreparedFunctionCall(Call):
         :return: Estimated amount of Wei executing specified transaction will cost
         :raises ValueError: when max_fee of PreparedFunctionCall is not None or 0.
         """
-        self._assert_can_invoke()
-
         if self.max_fee is not None and self.max_fee != 0:
             raise ValueError(
                 "Cannot estimate fee of PreparedFunctionCall with max_fee not None or 0."
             )
 
-        tx = await self._client.sign_invoke_transaction(
+        tx = await self._account_client.sign_invoke_transaction(
             calls=self, max_fee=0, version=self.version
         )
 
-        return await self._client.estimate_fee(
+        return await self._account_client.estimate_fee(
             tx=tx, block_hash=block_hash, block_number=block_number
         )
 
-    def _assert_can_invoke(self):
-        if not isinstance(self._client, AccountClient):
-            raise ValueError(
-                "Contract uses an account that can't invoke transactions. You need to use AccountClient for that."
-            )
+    @property
+    def _account_client(self) -> AccountClient:
+        client = self._client
+        if isinstance(client, AccountClient):
+            return client
+
+        raise ValueError(
+            "Contract uses an account that can't invoke transactions. You need to use AccountClient for that."
+        )
 
 
 @add_sync_methods
@@ -441,7 +441,7 @@ class Contract:
         client: Client,
         compilation_source: Optional[StarknetCompilationSource] = None,
         compiled_contract: Optional[str] = None,
-        constructor_args: Optional[Union[List[any], dict]] = None,
+        constructor_args: Optional[Union[List, Dict]] = None,
         salt: Optional[int] = None,
         search_paths: Optional[List[str]] = None,
     ) -> "DeployResult":
@@ -459,14 +459,14 @@ class Contract:
         :raises: `ValueError` if neither compilation_source nor compiled_contract is provided.
         :return: DeployResult instance
         """
-        compiled_contract = create_compiled_contract(
+        compiled = create_compiled_contract(
             compilation_source, compiled_contract, search_paths
         )
         translated_args = Contract._translate_constructor_args(
-            compiled_contract, constructor_args
+            compiled, constructor_args
         )
         deploy_tx = make_deploy_tx(
-            compiled_contract=compiled_contract,
+            compiled_contract=compiled,
             constructor_calldata=translated_args,
             salt=salt,
         )
@@ -476,7 +476,7 @@ class Contract:
         deployed_contract = Contract(
             client=client,
             address=contract_address,
-            abi=compiled_contract.abi,
+            abi=compiled.abi,
         )
         deploy_result = DeployResult(
             hash=res.transaction_hash,
@@ -491,7 +491,7 @@ class Contract:
         salt: int,
         compilation_source: Optional[StarknetCompilationSource] = None,
         compiled_contract: Optional[str] = None,
-        constructor_args: Optional[Union[List[any], dict]] = None,
+        constructor_args: Optional[Union[List, Dict]] = None,
         search_paths: Optional[List[str]] = None,
     ) -> int:
         """
@@ -543,7 +543,7 @@ class Contract:
 
     @staticmethod
     def _translate_constructor_args(
-        contract: ContractClass, constructor_args: any
+        contract: ContractClass, constructor_args: Any
     ) -> List[int]:
         constructor_abi = next(
             (member for member in contract.abi if member["type"] == "constructor"),

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -1,10 +1,8 @@
-# pyright: reportGeneralTypeIssues=false
-
 import dataclasses
 import re
 import warnings
 from dataclasses import replace
-from typing import Optional, List, Union, Dict, Tuple
+from typing import Optional, List, Union, Dict, Tuple, Iterable
 
 from starkware.crypto.signature.signature import get_random_private_key
 from starkware.starknet.public.abi import get_selector_from_name
@@ -47,6 +45,7 @@ from starknet_py.utils.crypto.facade import Call
 from starknet_py.utils.data_transformer.execute_transformer import (
     execute_transformer_by_version,
 )
+from starknet_py.utils.iterable import ensure_iterable
 from starknet_py.utils.sync import add_sync_methods
 from starknet_py.utils.typed_data import TypedData as TypedDataDataclass
 from starknet_py.net.models.typed_data import TypedData
@@ -80,11 +79,6 @@ class AccountClient(Client):
         :param supported_tx_version: Version of transactions supported by account
         """
         # pylint: disable=too-many-arguments
-        if signer is None and key_pair is None:
-            raise ValueError(
-                "Either a signer or a key_pair must be provided in AccountClient constructor"
-            )
-
         if chain is None and signer is None:
             raise ValueError("One of chain or signer must be provided")
 
@@ -92,6 +86,11 @@ class AccountClient(Client):
         self.client = client
 
         if signer is None:
+            if key_pair is None:
+                raise ValueError(
+                    "Either a signer or a key_pair must be provided in AccountClient constructor"
+                )
+
             chain = chain_from_network(net=client.net, chain=chain)
             signer = StarkCurveSigner(
                 account_address=self.address, key_pair=key_pair, chain_id=chain
@@ -282,11 +281,9 @@ class AccountClient(Client):
                 category=DeprecationWarning,
             )
 
-        calls = calls if isinstance(calls, List) else [calls]
-
         nonce = await self._get_nonce()
 
-        calldata_py = merge_calls(calls)
+        calldata_py = merge_calls(ensure_iterable(calls))
 
         if version == 0:
             calldata_py.append(nonce)
@@ -662,7 +659,7 @@ def add_signature_to_transaction(
     return replace(tx, signature=signature)
 
 
-def merge_calls(calls: Calls) -> List:
+def merge_calls(calls: Iterable[Call]) -> List:
     def parse_call(
         call: Call, current_data_len: int, entire_calldata: List
     ) -> Tuple[Dict, int, List]:

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -1,5 +1,3 @@
-# pyright: reportGeneralTypeIssues=false
-
 import typing
 import warnings
 from typing import Union, Optional, List
@@ -396,14 +394,14 @@ def get_block_identifier(
 
 
 def _get_call_payload(tx: Union[InvokeFunction, Call]) -> dict:
-    if isinstance(tx, InvokeFunction):
+    if isinstance(tx, Call):
         return {
-            "contract_address": hex(tx.contract_address),
-            "entry_point_selector": hex(tx.entry_point_selector),
+            "contract_address": hex(tx.to_addr),
+            "entry_point_selector": hex(tx.selector),
             "calldata": [str(i) for i in tx.calldata],
         }
     return {
-        "contract_address": hex(tx.to_addr),
-        "entry_point_selector": hex(tx.selector),
+        "contract_address": hex(tx.contract_address),
+        "entry_point_selector": hex(tx.entry_point_selector),
         "calldata": [str(i) for i in tx.calldata],
     }

--- a/starknet_py/net/networks.py
+++ b/starknet_py/net/networks.py
@@ -14,7 +14,7 @@ class CustomGatewayUrls(TypedDict):
 Network = Union[PredefinedNetwork, str, CustomGatewayUrls]
 
 
-def net_address_from_net(net: PredefinedNetwork) -> str:
+def net_address_from_net(net: str) -> str:
     return {
         MAINNET: "https://alpha-mainnet.starknet.io",
         TESTNET: "https://alpha4.starknet.io",

--- a/starknet_py/proxy_check.py
+++ b/starknet_py/proxy_check.py
@@ -1,4 +1,5 @@
-# pyright: reportGeneralTypeIssues=false, reportUndefinedVariable=false
+# Needed because of string typed Contract
+# pyright: reportUndefinedVariable=false
 
 from abc import ABC, abstractmethod
 

--- a/starknet_py/utils/data_transformer/data_transformer.py
+++ b/starknet_py/utils/data_transformer/data_transformer.py
@@ -86,9 +86,12 @@ def construct_result_object(result: dict) -> NamedTuple:
     dict_value = {name_mapping[key]: value for key, value in result.items()}
     tuple_value = named_tuple_class(**dict_value)
 
-    return cast(NamedTuple, Result(
-        tuple_value=tuple_value, name_mapping=name_mapping, dict_value=dict_value
-    ))  # We pretend Result is a named tuple
+    return cast(
+        NamedTuple,
+        Result(
+            tuple_value=tuple_value, name_mapping=name_mapping, dict_value=dict_value
+        ),
+    )  # We pretend Result is a named tuple
 
 
 def read_from_cairo_data(

--- a/starknet_py/utils/data_transformer/data_transformer.py
+++ b/starknet_py/utils/data_transformer/data_transformer.py
@@ -1,5 +1,3 @@
-# pyright: reportGeneralTypeIssues=false
-
 import warnings
 from dataclasses import dataclass
 from typing import (
@@ -40,12 +38,12 @@ from starknet_py.cairo.felt import (
     encode_shortstring,
 )
 
-ABIFunctionEntry = dict
+ABIFunctionEntry = Dict
 CairoData = List[int]
 
 
 class Result:
-    def __init__(self, tuple_value: namedtuple, name_mapping: dict, dict_value: dict):
+    def __init__(self, tuple_value: NamedTuple, name_mapping: Dict, dict_value: Dict):
         self.tuple_value = tuple_value
         self.name_mapping = name_mapping
         self.dict_value = dict_value
@@ -88,9 +86,9 @@ def construct_result_object(result: dict) -> NamedTuple:
     dict_value = {name_mapping[key]: value for key, value in result.items()}
     tuple_value = named_tuple_class(**dict_value)
 
-    return Result(
+    return cast(NamedTuple, Result(
         tuple_value=tuple_value, name_mapping=name_mapping, dict_value=dict_value
-    )
+    ))  # We pretend Result is a named tuple
 
 
 def read_from_cairo_data(
@@ -120,7 +118,7 @@ class TypeTransformer(Generic[UsedCairoType, PythonType]):
     resolve_type: Callable[[CairoType], "TypeTransformer"]
 
     def from_python(
-        self, cairo_type: UsedCairoType, name: str, value: any
+        self, cairo_type: UsedCairoType, name: str, value: Any
     ) -> CairoData:
         raise NotImplementedError()
 
@@ -236,8 +234,8 @@ class TupleTransformer(TypeTransformer[TypeTuple, Tuple]):
         results = []
 
         if TupleTransformer.isnamedtuple(values):
-            # noinspection PyUnresolvedReferences, PyProtectedMember, reportGeneralTypeIssues
-            values = values._asdict()
+            # noinspection PyUnresolvedReferences, PyProtectedMember
+            values = values._asdict()  # pyright: ignore
 
         for member in cairo_type.members:
             result = self.resolve_type(member).from_python(
@@ -248,7 +246,7 @@ class TupleTransformer(TypeTransformer[TypeTuple, Tuple]):
         return results
 
     @staticmethod
-    def isnamedtuple(value):
+    def isnamedtuple(value) -> bool:
         return isinstance(value, tuple) and hasattr(value, "_fields")
 
     def to_python(self, cairo_type, name, values) -> PythonResult[Tuple]:
@@ -280,7 +278,7 @@ class TupleTransformer(TypeTransformer[TypeTuple, Tuple]):
 
 class TupleItemTransformer(TypeTransformer[TypeTuple.Item, Any]):
     def from_python(
-        self, cairo_type: TypeTuple.Item, name: str, value: any
+        self, cairo_type: TypeTuple.Item, name: str, value: Any
     ) -> CairoData:
         value = self.resolve_type(cairo_type.typ).from_python(
             cairo_type.typ,

--- a/starknet_py/utils/iterable.py
+++ b/starknet_py/utils/iterable.py
@@ -1,0 +1,12 @@
+from typing import TypeVar, Iterable, Union
+
+T = TypeVar("T")
+
+# pyright: reportGeneralTypeIssues=false
+def ensure_iterable(value: Union[T, Iterable[T]]) -> Iterable[T]:
+    try:
+        iter(value)
+        # Now we now it is iterable
+        return value
+    except TypeError:
+        return [value]


### PR DESCRIPTION
Only `typed_data.py` has global `reportGeneralTypeIssues` enabled now. It will be addressed after logic fixes.