### PR TITLE
0.10.1 initial support

### DIFF
--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -77,6 +77,7 @@ class TransactionType(Enum):
     INVOKE = "INVOKE"
     DEPLOY = "DEPLOY"
     DECLARE = "DECLARE"
+    DEPLOY_ACCOUNT = "DEPLOY_ACCOUNT"
 
 
 @dataclass
@@ -103,7 +104,7 @@ class InvokeTransaction(Transaction):
 
     contract_address: int
     calldata: List[int]
-    entry_point_selector: int
+    entry_point_selector: Optional[int] = None
     nonce: Optional[int] = None
 
 
@@ -127,6 +128,18 @@ class DeployTransaction(Transaction):
     contract_address: int
     constructor_calldata: List[int]
     class_hash: int
+
+
+@dataclass
+class DeployAccountTransaction(Transaction):
+    """
+    Dataclass representing deploy account transaction
+    """
+
+    contract_address_salt: int
+    class_hash: int
+    constructor_calldata: List[int]
+    nonce: int
 
 
 class TransactionStatus(Enum):

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -104,6 +104,7 @@ class InvokeTransaction(Transaction):
 
     contract_address: int
     calldata: List[int]
+    # This field is always None for transactions with version = 1
     entry_point_selector: Optional[int] = None
     nonce: Optional[int] = None
 

--- a/starknet_py/net/models/transaction.py
+++ b/starknet_py/net/models/transaction.py
@@ -8,6 +8,7 @@ from starkware.starknet.services.api.gateway.transaction import (
     Deploy as D,
     Transaction as T,
     Declare as DCL,
+    DeployAccount as DAC,
 )
 from starkware.starknet.core.os.transaction_hash.transaction_hash import (
     calculate_transaction_hash_common,
@@ -28,6 +29,7 @@ Deploy = as_our_module(D)
 Transaction = as_our_module(T)
 TransactionType = as_our_module(TT)
 Declare = as_our_module(DCL)
+DeployAccount = as_our_module(DAC)
 
 
 def compute_invoke_hash(

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -26,6 +26,7 @@ from starknet_py.net.client_models import (
     Event,
     DeclareTransactionResponse,
     DeployTransactionResponse,
+    DeployAccountTransaction,
 )
 from starknet_py.net.schemas.common import (
     Felt,
@@ -78,7 +79,7 @@ class TransactionSchema(Schema):
 class InvokeTransactionSchema(TransactionSchema):
     contract_address = Felt(data_key="contract_address", required=True)
     calldata = fields.List(Felt(), data_key="calldata", required=True)
-    entry_point_selector = Felt(data_key="entry_point_selector", required=True)
+    entry_point_selector = Felt(data_key="entry_point_selector", load_default=None)
     nonce = Felt(data_key="nonce", load_default=None)
 
     @post_load
@@ -108,12 +109,26 @@ class DeclareTransactionSchema(TransactionSchema):
         return DeclareTransaction(**data)
 
 
+class DeployAccountTransactionSchema(TransactionSchema):
+    contract_address_salt = Felt(data_key="contract_address_salt", required=True)
+    class_hash = Felt(data_key="class_hash", required=True)
+    constructor_calldata = fields.List(
+        Felt(), data_key="constructor_calldata", required=True
+    )
+    nonce = Felt(data_key="nonce", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> DeployAccountTransaction:
+        return DeployAccountTransaction(**data)
+
+
 class TypesOfTransactionsSchema(OneOfSchema):
     type_field = "type"
     type_schemas = {
         "INVOKE_FUNCTION": InvokeTransactionSchema,
         "DECLARE": DeclareTransactionSchema,
         "DEPLOY": DeployTransactionSchema,
+        "DEPLOY_ACCOUNT": DeployAccountTransactionSchema,
     }
 
 

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -153,6 +153,8 @@ class TypesOfTransactionsSchema(OneOfSchema):
         "INVOKE": InvokeTransactionSchema,
         "DECLARE": DeclareTransactionSchema,
         "DEPLOY": DeployTransactionSchema,
+        # FIXME add proper handling/serialization
+        "DEPLOY_ACCOUNT": None,
     }
 
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -96,7 +96,6 @@ async def test_get_block_by_hash(
     block_with_deploy_number,
     contract_address,
     class_hash,
-    default_gateway_gas_price,
 ):
     for client in clients:
         block = await client.get_block(block_hash=block_with_deploy_hash)
@@ -129,7 +128,6 @@ async def test_get_block_by_number(
     block_with_deploy_hash,
     contract_address,
     class_hash,
-    default_gateway_gas_price,
 ):
     for client in clients:
         block = await client.get_block(block_number=block_with_deploy_number)

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-many-arguments
 import asyncio
-import typing
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -116,7 +115,6 @@ async def test_get_block_by_hash(
         )
 
         if isinstance(client, GatewayClient):
-            block = typing.cast(GatewayBlock, block)
             assert block.gas_price > 0
 
 
@@ -148,7 +146,6 @@ async def test_get_block_by_number(
         )
 
         if isinstance(client, GatewayClient):
-            block = typing.cast(GatewayBlock, block)
             assert block.gas_price > 0
 
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-arguments
 import asyncio
+import typing
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -17,6 +18,7 @@ from starknet_py.net.client_models import (
     DeployedContract,
     DeployTransaction,
     Call,
+    GatewayBlock,
 )
 from starknet_py.net.client_errors import ClientError
 from starknet_py.net.gateway_client import GatewayClient
@@ -115,7 +117,8 @@ async def test_get_block_by_hash(
         )
 
         if isinstance(client, GatewayClient):
-            assert block.gas_price == default_gateway_gas_price
+            block = typing.cast(GatewayBlock, block)
+            assert block.gas_price > 0
 
 
 @pytest.mark.asyncio
@@ -147,7 +150,8 @@ async def test_get_block_by_number(
         )
 
         if isinstance(client, GatewayClient):
-            assert block.gas_price == default_gateway_gas_price
+            block = typing.cast(GatewayBlock, block)
+            assert block.gas_price > 0
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/conftest.py
+++ b/starknet_py/tests/e2e/conftest.py
@@ -14,7 +14,6 @@ from typing import Tuple, List, Generator
 import pytest
 import pytest_asyncio
 from starkware.crypto.signature.signature import get_random_private_key
-from starkware.starknet.definitions.general_config import StarknetGeneralConfig
 
 from starknet_py.net import KeyPair, AccountClient
 from starknet_py.net.client import Client
@@ -466,13 +465,3 @@ async def cairo_serializer(gateway_account_client: AccountClient) -> CairoSerial
     contract = deployment_result.deployed_contract
 
     return CairoSerializer(identifier_manager=contract.data.identifier_manager)
-
-
-@pytest_asyncio.fixture(name="default_gateway_gas_price", scope="module")
-def default_gateway_gas_price() -> int:
-    """
-    Returns the default min gas price from the StarknetGeneralConfig.
-    Useful for asserting that the gas price appears in the block response from
-    the GatewayClient.
-    """
-    return StarknetGeneralConfig().min_gas_price


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The formatter, linter, and tests all run without an error
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR aims to ensure that all existing modules still work with changes to the feeder gateway and cairo lang in 0.10.1.

* **What is the current behavior?** (You can also link to an open issue here)

StarkNet.py does not work with 0.10.1

## **What is the new behavior (if this is a feature change)?**

Minimal functionality is preserved

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes

* entry_point_selector was removed from gateway responses (at least for tx version 1) so InvokeTransaction dataclass `entry_point_selector` has been changed to `Optional[int]`

## **Other information**

n/a
