### PR TITLE
Fix estimating fee on prepared calls

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -284,13 +284,7 @@ class PreparedFunctionCall(Call):
         :param block_number: Estimate fee at given block number
             (or "latest" / "pending" for the latest / pending block), default is "pending"
         :return: Estimated amount of Wei executing specified transaction will cost
-        :raises ValueError: when max_fee of PreparedFunctionCall is not None or 0.
         """
-        if self.max_fee is not None and self.max_fee != 0:
-            raise ValueError(
-                "Cannot estimate fee of PreparedFunctionCall with max_fee not None or 0."
-            )
-
         tx = await self._account_client.sign_invoke_transaction(
             calls=self, max_fee=0, version=self.version
         )

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -94,7 +94,7 @@ async def test_estimated_fee_greater_than_zero(erc20_contract, account_client):
 
     estimated_fee = (
         await erc20_contract.functions["balanceOf"]
-        .prepare("1234", max_fee=0)
+        .prepare("1234", max_fee=10)
         .estimate_fee(block_hash="latest")
     )
 

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -49,21 +49,6 @@ async def test_auto_fee_estimation(map_contract):
 
 
 @pytest.mark.asyncio
-async def test_throws_on_estimate_with_positive_max_fee(map_contract):
-    key = 2
-    value = 3
-
-    prepared_call = map_contract.functions["put"].prepare(key, value, max_fee=100)
-    with pytest.raises(ValueError) as exinfo:
-        await prepared_call.estimate_fee()
-
-    assert (
-        "Cannot estimate fee of PreparedFunctionCall with max_fee not None or 0."
-        in str(exinfo.value)
-    )
-
-
-@pytest.mark.asyncio
 async def test_throws_on_both_max_fee_and_auto_estimate(map_contract):
     key = 2
     value = 3


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #556 


## Introduced changes
<!-- A brief description of the changes -->

Instead of changing the documentation as suggested in the [issue](https://github.com/software-mansion/starknet.py/issues/556), removed the check for `max_fee`. 
- `ValueError` is not raised when `max_fee` is given
- Raising the error there doesn't make much sense since it's a fee estimation of an isolated prepared function call object (so the `max_fee` in the call is not tied to the method in any way)


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


