### PR TITLE
Update examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ contract = await Contract.from_address(
     address="0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
     client=GatewayClient("testnet"),
 )
-(saved,) = await contract.functions["get_value"].call(key)  # 7
+(value,) = await contract.functions["get_value"].call(key)
 ```
 
 ### Synchronous API

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ from starknet_py.net.gateway_client import GatewayClient
 
 key = 1234
 contract = Contract.from_address_sync(
-    "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
-    GatewayClient("testnet"),
+    address="0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
+    client=GatewayClient("testnet"),
 )
 (saved,) = contract.functions["get_value"].call_sync(key)  # 7
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ contract = Contract.from_address_sync(
     address="0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
     client=GatewayClient("testnet"),
 )
-(saved,) = contract.functions["get_value"].call_sync(key)  # 7
+(value,) = contract.functions["get_value"].call_sync(key)
 ```
 
 For more examples click [here](https://starknetpy.rtfd.io/en/latest/quickstart.html).

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ This is the recommended way of using the SDK.
 
 ```python
 from starknet_py.contract import Contract
-from starknet_py.net.client import Client
+from starknet_py.net.gateway_client import GatewayClient
 
 key = 1234
-contract = await Contract.from_address("0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b", Client("testnet"))
-invocation = await contract.functions["set_value"].invoke(key, 7)
-await invocation.wait_for_acceptance()
-
-(saved,) = await contract.functions["get_value"].call(key) # 7
+contract = await Contract.from_address(
+    "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
+    GatewayClient("testnet"),
+)
+(saved,) = await contract.functions["get_value"].call(key)  # 7
 ```
 
 ### Synchronous API
@@ -55,14 +55,14 @@ You can access synchronous world with `_sync` postfix.
 
 ```python
 from starknet_py.contract import Contract
-from starknet_py.net.client import Client
+from starknet_py.net.gateway_client import GatewayClient
 
 key = 1234
-contract = Contract.from_address_sync("0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b", Client("testnet"))
-invocation = contract.functions["set_value"].invoke_sync(key, 7)
-invocation.wait_for_acceptance_sync()
-
-(saved,) = contract.functions["get_value"].call_sync(key) # 7
+contract = Contract.from_address_sync(
+    "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
+    GatewayClient("testnet"),
+)
+(saved,) = contract.functions["get_value"].call_sync(key)  # 7
 ```
 
 For more examples click [here](https://starknetpy.rtfd.io/en/latest/quickstart.html).

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ from starknet_py.net.gateway_client import GatewayClient
 
 key = 1234
 contract = await Contract.from_address(
-    "0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
-    GatewayClient("testnet"),
+    address="0x01336fa7c870a7403aced14dda865b75f29113230ed84e3a661f7af70fe83e7b",
+    client=GatewayClient("testnet"),
 )
 (saved,) = await contract.functions["get_value"].call(key)  # 7
 ```


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #568 


## Introduced changes
<!-- A brief description of the changes -->


- This PR changes examples in the README to only use `Contract.call` as account is now required for invokes.
- It changes `Client` to `GatewayClient` in examples.


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


