### PR TITLE
Bump actions versions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,9 +8,9 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
     - name: Install poetry

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -17,7 +17,7 @@ jobs:
       - name: Build SDist
         run: poetry build -f sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #573 


## Introduced changes
<!-- A brief description of the changes -->


- This PR bumps the versions of actions used in different workflows, to avoid errors about using deprecated node 12 actions.


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


