### PR TITLE
Remove unused `TransactionStatus` import from cairo-lang

### DIFF
--- a/starknet_py/constants.py
+++ b/starknet_py/constants.py
@@ -1,11 +1,3 @@
-from starkware.starknet.services.api.feeder_gateway.response_objects import (
-    TransactionStatus,
-)
-
-TxStatus = TransactionStatus
-
-ACCEPTED_STATUSES = (TxStatus.ACCEPTED_ON_L1, TxStatus.ACCEPTED_ON_L2)
-
 # Address came from starkware-libs/starknet-addresses repository: https://github.com/starkware-libs/starknet-addresses
 FEE_CONTRACT_ADDRESS = (
     "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes
<!-- A brief description of the changes -->

We are going to remove Cairo-lang dependency one day, so this is the first step to achieving that.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->

 - Someone could probably be using `TxStatus` or `ACCEPTED_STATUSES` constants
