### PR TITLE
Add TupleDataclass

### DIFF
--- a/starknet_py/utils/tuple_dataclass_test.py
+++ b/starknet_py/utils/tuple_dataclass_test.py
@@ -1,0 +1,22 @@
+from starknet_py.utils.tuple_dataclass import TupleDataclass
+
+
+def test_wrapped_named_tuple():
+    input_dict = {
+        "first": 1,
+        "second": 2,
+        "third": {"key": "value"},
+    }
+    input_tuple = tuple(input_dict.values())
+
+    result = TupleDataclass.from_dict(input_dict)
+    assert result.as_tuple() == input_tuple
+    assert result.as_dict() == input_dict
+    assert (result[0], result[1], result[2]) == input_tuple
+    assert (result.first, result.second, result.third) == input_tuple
+    assert str(result) == "TupleDataclass(first=1, second=2, third={'key': 'value'})"
+    assert repr(result) == "TupleDataclass(first=1, second=2, third={'key': 'value'})"
+
+    result = TupleDataclass.from_dict(input_dict, name="CustomClass")
+    assert str(result) == "CustomClass(first=1, second=2, third={'key': 'value'})"
+    assert repr(result) == "CustomClass(first=1, second=2, third={'key': 'value'})"


### PR DESCRIPTION
# About
In data_transformer module we return `Result` class and pretend it is a NamedTuple. This can lead to some unexpected behaviour.

The most important feature of NamedTuple is that it can be used both as tuple and a regular object. By using dataclasses with `__getitem__` and `__iter__` we can replicate this behaviour. 

## Differences
The differences with previous implementation:
- No `_asdict` method
- Comparison with tuple will return False
I am wondering if we should support these two 🤔 Let me know what you think.

I also added 2 utility functions: `as_tuple` and `as_dict` to make sure the most popular flows are covered out of the box.

## Cool things
In the future when doing https://github.com/software-mansion/starknet.py/issues/492 we can easily subclass `TupleDataclass` to provide strict typing 🔥 



# Other solutions
To be honest ideally I would just switch to using dicts as returned values from functions, but we would be missing spreading values like this: `x, y = result`. It would be a big breaking change and would make quality of life worse. I think using simple dataclasses is nice compromise: we rely on solid, well known implementation and offer some simplifications.

# Related issues

Closes https://github.com/software-mansion/starknet.py/issues/589.