### PR TITLE
Simplify `Contract` constructor

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -179,7 +179,7 @@ class DeclareResult(SentTransaction):
         )
 
         deployed_contract = Contract(
-            account=self._account,
+            provider=self._account,
             address=address,
             abi=abi,
         )
@@ -447,8 +447,9 @@ class Contract:
         self,
         address: AddressRepresentation,
         abi: list,
+        provider: Union[BaseAccount, Client] = None,  # pyright: ignore
+        *,
         client: Optional[Client] = None,
-        account: Optional[BaseAccount] = None,
     ):
         """
         Should be used instead of ``from_address`` when ABI is known statically.
@@ -457,10 +458,10 @@ class Contract:
 
         :param address: contract's address.
         :param abi: contract's abi.
+        :param provider: BaseAccount or Client used to perform transactions.
         :param client: client used to perform transactions.
-        :param account: account used to perform transactions.
         """
-        client, account = _unpack_client_and_account(client, account)
+        client, account = _unpack_provider(provider, client)
 
         self.account: Optional[BaseAccount] = account
         self.client: Client = client
@@ -481,9 +482,10 @@ class Contract:
     @staticmethod
     async def from_address(
         address: AddressRepresentation,
-        client: Optional[Client] = None,
+        provider: Union[BaseAccount, Client] = None,  # pyright: ignore
         proxy_config: Union[bool, ProxyConfig] = False,
-        account: Optional[BaseAccount] = None,
+        *,
+        client: Optional[Client] = None,
     ) -> "Contract":
         """
         Fetches ABI for given contract and creates a new Contract instance with it. If you know ABI statically you
@@ -493,8 +495,7 @@ class Contract:
         :raises TypeError: when given client's `get_class_by_hash` method does not return abi.
         :raises ProxyResolutionError: when given ProxyChecks were not sufficient to resolve proxy's implementation.
         :param address: Contract's address.
-        :param client: Client.
-        :param account: BaseAccount.
+        :param provider: BaseAccount or Client.
         :param proxy_config: Proxy resolving config
             If set to ``True``, will use default proxy checks
             :class:`starknet_py.proxy.proxy_check.OpenZeppelinProxyCheck`
@@ -503,10 +504,11 @@ class Contract:
             If set to ``False``, :meth:`Contract.from_address` will not resolve proxies.
 
             If a valid :class:`starknet_py.contract_abi_resolver.ProxyConfig` is provided, will use its values instead.
+        :param client: Client.
 
         :return: an initialized Contract instance.
         """
-        client, account = _unpack_client_and_account(client, account)
+        client, account = _unpack_provider(provider, client)
 
         address = parse_address(address)
         proxy_config = Contract._create_proxy_config(proxy_config)
@@ -516,7 +518,7 @@ class Contract:
         ).resolve()
 
         if account is not None:
-            return Contract(address=address, abi=abi, account=account)
+            return Contract(address=address, abi=abi, provider=account)
 
         return Contract(address=address, abi=abi, client=client)
 
@@ -593,7 +595,7 @@ class Contract:
         )
 
         deployed_contract = Contract(
-            account=account,
+            provider=account,
             address=address,
             abi=abi,
         )
@@ -691,8 +693,8 @@ class Contract:
         return prepare_proxy_config(proxy_arg)
 
 
-def _unpack_client_and_account(
-    client: Optional[Client] = None, account: Optional[BaseAccount] = None
+def _unpack_provider(
+    provider: Union[BaseAccount, Client], client: Optional[Client] = None
 ) -> Tuple[Client, Optional[BaseAccount]]:
     """
     Get the client and optional account to be used by Contract.
@@ -701,19 +703,30 @@ def _unpack_client_and_account(
     If provided with Client, returns this Client and None.
     If provided with Account, returns underlying Client and the account.
     """
-    if client is not None and account is not None:
-        raise ValueError("Arguments account and client are mutually exclusive.")
-
     if client is not None:
-        if isinstance(client, AccountClient):
-            return client.client, AccountProxy(client)
+        warnings.warn(
+            "Argument client has been deprecated. Use provider instead.",
+            category=DeprecationWarning,
+        )
 
-        return client, None
+    if provider is not None and client is not None:
+        raise ValueError("Arguments provider and client are mutually exclusive.")
 
-    if account is not None:
-        return account.client, account
+    if provider is None and client is None:
+        raise ValueError("One of provider or client must be provided.")
 
-    raise ValueError("One of client or account must be provided.")
+    provider = provider or client
+
+    if isinstance(provider, Client):
+        if isinstance(provider, AccountClient):
+            return provider.client, AccountProxy(provider)
+
+        return provider, None
+
+    if isinstance(provider, BaseAccount):
+        return provider.client, provider
+
+    raise ValueError("Argument provider is not of accepted type.")
 
 
 def _account_or_proxy(account: Union[BaseAccount, AccountClient]) -> BaseAccount:

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -517,10 +517,7 @@ class Contract:
             address=address, client=client, proxy_config=proxy_config
         ).resolve()
 
-        if account is not None:
-            return Contract(address=address, abi=abi, provider=account)
-
-        return Contract(address=address, abi=abi, client=client)
+        return Contract(address=address, abi=abi, provider=account or client)
 
     @staticmethod
     async def declare(

--- a/starknet_py/contract_test.py
+++ b/starknet_py/contract_test.py
@@ -160,11 +160,8 @@ def test_contract_raises_on_both_provider_and_client(
 
 
 def test_contract_raises_on_incorrect_provider_type():
-    class MyClass:
-        pass
-
     with pytest.raises(ValueError, match="Argument provider is not of accepted type."):
-        Contract(address=0x1, abi=[], provider=MyClass())  # pyright: ignore
+        Contract(address=0x1, abi=[], provider=1)  # pyright: ignore
 
 
 def test_contract_create_with_base_account(gateway_account):

--- a/starknet_py/contract_test.py
+++ b/starknet_py/contract_test.py
@@ -159,6 +159,14 @@ def test_contract_raises_on_both_provider_and_client(
         )
 
 
+def test_contract_raises_on_incorrect_provider_type():
+    class MyClass:
+        pass
+
+    with pytest.raises(ValueError, match="Argument provider is not of accepted type."):
+        Contract(address=0x1, abi=[], provider=MyClass())  # pyright: ignore
+
+
 def test_contract_create_with_base_account(gateway_account):
     contract = Contract(address=0x1, abi=[], provider=gateway_account)
     assert isinstance(contract.account, BaseAccount)

--- a/starknet_py/net/account/account_test.py
+++ b/starknet_py/net/account/account_test.py
@@ -3,18 +3,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
-from starknet_py.contract import Contract
 from starknet_py.net import KeyPair
 from starknet_py.net.account.account import Account
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId, parse_address
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2
 from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
-
-
-def test_contract_raises_on_no_client_and_account():
-    with pytest.raises(ValueError, match="One of client or account must be provided"):
-        Contract(address=1234, abi=[])
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -38,7 +38,7 @@ async def test_balance_when_token_specified(account, erc20_contract):
 @pytest.mark.asyncio
 async def test_estimated_fee_greater_than_zero(erc20_contract, account):
     erc20_contract = Contract(
-        address=erc20_contract.address, abi=erc20_contract.data.abi, account=account
+        address=erc20_contract.address, abi=erc20_contract.data.abi, provider=account
     )
 
     estimated_fee = (

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -232,5 +232,7 @@ async def test_deploy_contract_flow(account, map_compiled_contract, map_class_ha
 
 
 def test_contract_raises_on_both_client_and_account(gateway_client, gateway_account):
-    with pytest.raises(ValueError, match="account and client are mutually exclusive"):
-        Contract(address=1234, abi=[], client=gateway_client, account=gateway_account)
+    with pytest.raises(
+        ValueError, match="Arguments provider and client are mutually exclusive"
+    ):
+        Contract(address=1234, abi=[], client=gateway_client, provider=gateway_account)

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -79,7 +79,7 @@ async def test_constructor_arguments_contract_deploy(
     contract = Contract(
         address=contract_address,
         abi=constructor_with_arguments_abi,
-        account=account,
+        provider=account,
     )
 
     result = await contract.functions["get"].call(block_hash="latest")

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
@@ -21,7 +21,7 @@ async def test_deploying_in_multicall(account, map_class_hash, map_compiled_cont
     # docs: start
 
     # Address of the `map` contract is known here, so we can create its instance!
-    map_contract = Contract(address=address, abi=map_abi, account=account)
+    map_contract = Contract(address=address, abi=map_abi, provider=account)
 
     # And now we can prepare a call
     put_call = map_contract.functions["put"].prepare(key=10, value=20)

--- a/starknet_py/tests/e2e/docs/guide/test_handling_client_errors.py
+++ b/starknet_py/tests/e2e/docs/guide/test_handling_client_errors.py
@@ -13,7 +13,7 @@ async def test_handling_client_errors(gateway_account):
         # docs: end
         account = gateway_account
         # docs: start
-        await Contract.from_address(address=contract_address, account=account)
+        await Contract.from_address(address=contract_address, provider=account)
     except ClientError as error:
         print(error.code, error.message)
     # docs: end

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -32,14 +32,14 @@ async def test_using_existing_contracts(account, erc20_contract):
     address = "0x00178130dd6286a9a0e031e4c73b2bd04ffa92804264a25c1c08c1612559f458"
 
     # When ABI is known statically just use the Contract constructor
-    contract = Contract(address=address, abi=abi, account=account)
+    contract = Contract(address=address, abi=abi, provider=account)
     # or if it is not known
     # Contract.from_address makes additional request to fetch the ABI
     # docs: end
 
     address = erc20_contract.address
     # docs: start
-    contract = await Contract.from_address(account=account, address=address)
+    contract = await Contract.from_address(provider=account, address=address)
 
     sender = "321"
     recipient = "123"

--- a/starknet_py/tests/e2e/docs/quickstart/test_synchronous_api.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_synchronous_api.py
@@ -15,7 +15,7 @@ def test_synchronous_api(account, map_contract):
     # docs: start
 
     key = 1234
-    contract = Contract.from_address_sync(address=contract_address, account=account)
+    contract = Contract.from_address_sync(address=contract_address, provider=account)
 
     invocation = contract.functions["put"].invoke_sync(key, 7, max_fee=int(1e16))
     invocation.wait_for_acceptance_sync()

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -22,7 +22,7 @@ async def test_using_contract(account, map_contract):
     # docs: start
 
     # Create contract from contract's address - Contract will download contract's ABI to know its interface.
-    contract = await Contract.from_address(address=contract_address, account=account)
+    contract = await Contract.from_address(address=contract_address, provider=account)
     # docs: end
 
     abi = contract.data.abi
@@ -33,7 +33,7 @@ async def test_using_contract(account, map_contract):
     contract = Contract(
         address=contract_address,
         abi=abi,
-        account=account,
+        provider=account,
     )
 
     # All exposed functions are available at contract.functions.

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -175,7 +175,7 @@ def fee_contract(gateway_account: BaseAccount) -> Contract:
     return Contract(
         address=FEE_CONTRACT_ADDRESS,
         abi=abi,
-        account=gateway_account,
+        provider=gateway_account,
     )
 
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->


- This PR combines Contract constructor arguments `account` and `client` into single `provider` and deprecates `client` argument.


##

- [x] This PR contains breaking changes

- Contract constructor parameters changed


