### PR TITLE
Make Compiler module pending deprecation

### DIFF
--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -1,6 +1,10 @@
 Compiler
 ========
 
+.. warning::
+    Compiler module will be deprecated in the future. Consider compiling contracts
+    yourself using cairo-lang CLI or other available tools.
+
 .. py:module:: starknet_py.compile.compiler
 
 .. autoclass:: Compiler

--- a/starknet_py/common.py
+++ b/starknet_py/common.py
@@ -1,12 +1,9 @@
+import warnings
 from typing import List, Literal, Optional, Union
 
 from starkware.starknet.services.api.contract_class import ContractClass
 
-from starknet_py.compile.compiler import (
-    Compiler,
-    StarknetCompilationSource,
-    create_contract_class,
-)
+from starknet_py.compile.compiler import Compiler, StarknetCompilationSource
 
 
 def create_compiled_contract(
@@ -14,6 +11,12 @@ def create_compiled_contract(
     compiled_contract: Optional[str] = None,
     search_paths: Optional[List[str]] = None,
 ) -> ContractClass:
+    warnings.warn(
+        "Function create_compiled_contract will be deprecated in the future. "
+        "Consider using create_contract_class instead.",
+        category=PendingDeprecationWarning,
+    )
+
     if not compiled_contract:
         if not compilation_source:
             raise ValueError(
@@ -25,6 +28,17 @@ def create_compiled_contract(
         ).compile_contract()
     definition = create_contract_class(compiled_contract)
     return definition
+
+
+def create_contract_class(
+    compiled_contract: str,
+) -> ContractClass:
+    """
+    Creates ContractDefinition either from already compiled contract
+
+    :return: a ContractDefinition
+    """
+    return ContractClass.loads(compiled_contract)
 
 
 def int_from_hex(number: Union[str, int]) -> int:

--- a/starknet_py/compile/compiler.py
+++ b/starknet_py/compile/compiler.py
@@ -1,6 +1,7 @@
 import json
 import os
 import typing
+import warnings
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -38,6 +39,10 @@ class Compiler:
         :param is_account_contract: Set this to ``True`` to compile account contracts
         :param cairo_path: a ``list`` of paths used by starknet_compile to resolve dependencies within contracts
         """
+        warnings.warn(
+            "Compiler module will be deprecated in the future. Consider compiling contracts using other tools.",
+            category=PendingDeprecationWarning,
+        )
         self.contract_source = contract_source
         self.is_account_contract = is_account_contract
         self.search_paths = cairo_path

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -629,6 +629,11 @@ class Contract:
         :return: contract's address
         """
         # pylint: disable=too-many-arguments
+        warnings.warn(
+            "Argument compilation_source will be deprecated in the future. Consider using already compiled contracts.",
+            category=PendingDeprecationWarning,
+        )
+
         compiled = create_compiled_contract(
             compilation_source, compiled_contract, search_paths
         )
@@ -656,6 +661,11 @@ class Contract:
         :raises: `ValueError` if neither compilation_source nor compiled_contract is provided.
         :return:
         """
+        warnings.warn(
+            "Argument compilation_source will be deprecated in the future. Consider using already compiled contracts.",
+            category=PendingDeprecationWarning,
+        )
+
         compiled_contract = create_compiled_contract(
             compilation_source, compiled_contract, search_paths
         )

--- a/starknet_py/net/account/account_client.py
+++ b/starknet_py/net/account/account_client.py
@@ -392,6 +392,11 @@ class AccountClient(Client):
                 "Signing declare transactions is only supported with transaction version 1."
             )
 
+        warnings.warn(
+            "Argument compilation_source will be deprecated in the future. Consider using already compiled contracts.",
+            category=PendingDeprecationWarning,
+        )
+
         compiled_contract = create_compiled_contract(
             compilation_source, compiled_contract, cairo_path
         )

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -8,8 +8,9 @@ from starknet_py.net.models import StarknetChainId
 from starknet_py.net.models.transaction import Declare, DeployAccount, Invoke
 from starknet_py.net.signer.stark_curve_signer import KeyPair, StarkCurveSigner
 
-contract_source = (
-    Path(os.path.dirname(__file__)) / "../../tests/e2e/mock/contracts/erc20.cairo"
+compiled_contract = (
+    Path(os.path.dirname(__file__))
+    / "../../tests/e2e/mock/contracts_compiled/erc20_compiled.json"
 ).read_text("utf-8")
 
 
@@ -34,7 +35,9 @@ contract_source = (
             version=1,
         ),
         Declare(
-            contract_class=create_compiled_contract(compilation_source=contract_source),
+            contract_class=create_compiled_contract(
+                compiled_contract=compiled_contract
+            ),
             sender_address=123,
             max_fee=10000,
             signature=[],

--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -1,32 +1,11 @@
 import pytest
 
-from starknet_py.compile.compiler import Compiler
 from starknet_py.contract import Contract
 from starknet_py.net import AccountClient
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 
 
-async def declare_contract(account_client: AccountClient):
-    contract = """
-            %lang starknet
-            %builtins pedersen range_check
-
-            from starkware.cairo.common.cairo_builtins import HashBuiltin
-
-            @storage_var
-            func public_key() -> (res: felt) {
-            }
-
-            @constructor
-            func constructor{syscall_ptr: felt*, range_check_ptr: felt, pedersen_ptr: HashBuiltin*}(
-                pkey: felt
-            ) {
-                public_key.write(pkey);
-                return ();
-            }
-        """
-    compiled_contract = Compiler(contract_source=contract).compile_contract()
-
+async def declare_contract(account_client: AccountClient, compiled_contract: str):
     declare_result = await Contract.declare(
         account=account_client,
         compiled_contract=compiled_contract,
@@ -36,17 +15,17 @@ async def declare_contract(account_client: AccountClient):
 
 
 @pytest.mark.asyncio
-async def test_pending_block(new_gateway_account_client):
+async def test_pending_block(new_gateway_account_client, map_compiled_contract):
     # TODO: change to new_account_client once devnet repaired
-    await declare_contract(new_gateway_account_client)
+    await declare_contract(new_gateway_account_client, map_compiled_contract)
 
     blk = await new_gateway_account_client.get_block(block_number="pending")
     assert blk.block_hash
 
 
 @pytest.mark.asyncio
-async def test_latest_block(new_account_client):
-    await declare_contract(new_account_client)
+async def test_latest_block(new_account_client, map_compiled_contract):
+    await declare_contract(new_account_client, map_compiled_contract)
 
     blk = await new_account_client.get_block(block_number="latest")
     assert blk.block_hash

--- a/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_cairo_serializer.py
@@ -1,11 +1,11 @@
 import pytest
 from starkware.starknet.public.abi import get_selector_from_name
 
-from starknet_py.compile.compiler import Compiler
-
 
 @pytest.mark.asyncio
-async def test_using_cairo_serializer(account):
+async def test_using_cairo_serializer(
+    account, simple_storage_with_event_compiled_contract
+):
     # pylint: disable=unused-variable, import-outside-toplevel, too-many-locals
     # docs: start
     from starknet_py.contract import Contract
@@ -35,7 +35,7 @@ async def test_using_cairo_serializer(account):
         }
     """
     # docs: end
-    compiled_contract = Compiler(contract_source=contract).compile_contract()
+    compiled_contract = simple_storage_with_event_compiled_contract
     # docs: start
 
     # Declares and deploys the contract

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -4,8 +4,7 @@ from typing import List, Union
 import pytest
 import pytest_asyncio
 
-from starknet_py.common import create_compiled_contract
-from starknet_py.compile.compiler import create_contract_class
+from starknet_py.common import create_compiled_contract, create_contract_class
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.contract import Contract
 from starknet_py.net import AccountClient
@@ -45,6 +44,14 @@ def map_compiled_contract() -> str:
     Returns compiled map contract.
     """
     return read_contract("map_compiled.json")
+
+
+@pytest.fixture(scope="module")
+def simple_storage_with_event_compiled_contract() -> str:
+    """
+    Returns compiled simple storage contract that emits an event
+    """
+    return read_contract("simple_storage_with_event_compiled.json")
 
 
 @pytest.fixture(scope="module")

--- a/starknet_py/transactions/declare.py
+++ b/starknet_py/transactions/declare.py
@@ -36,6 +36,12 @@ def make_declare_tx(
         "AccountClient.sign_declare_transaction instead,",
         category=DeprecationWarning,
     )
+
+    warnings.warn(
+        "Argument compilation_source will be deprecated in the future. Consider using already compiled contracts.",
+        category=PendingDeprecationWarning,
+    )
+
     compiled_contract = create_compiled_contract(
         compilation_source, compiled_contract, cairo_path
     )


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #635 


## Introduced changes
<!-- A brief description of the changes -->


- Adds pending deprecation warnings to Compiler module and methods with `compilation_source`.
- Removes the usage of Compiler in docs.


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


