### PR TITLE
Fix tests still using AccountClient

### DIFF
--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -2,11 +2,11 @@ import pytest
 
 from starknet_py.compile.compiler import Compiler
 from starknet_py.contract import Contract
-from starknet_py.net import AccountClient
+from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 
 
-async def declare_contract(account_client: AccountClient):
+async def declare_contract(account: BaseAccount):
     contract = """
             %lang starknet
             %builtins pedersen range_check
@@ -28,7 +28,7 @@ async def declare_contract(account_client: AccountClient):
     compiled_contract = Compiler(contract_source=contract).compile_contract()
 
     declare_result = await Contract.declare(
-        account=account_client,
+        account=account,
         compiled_contract=compiled_contract,
         max_fee=MAX_FEE,
     )
@@ -36,17 +36,16 @@ async def declare_contract(account_client: AccountClient):
 
 
 @pytest.mark.asyncio
-async def test_pending_block(new_gateway_account_client):
-    # TODO: change to new_account_client once devnet repaired
-    await declare_contract(new_gateway_account_client)
+async def test_pending_block(account):
+    await declare_contract(account)
 
-    blk = await new_gateway_account_client.get_block(block_number="pending")
+    blk = await account.client.get_block(block_number="pending")
     assert blk.block_hash
 
 
 @pytest.mark.asyncio
-async def test_latest_block(new_account_client):
-    await declare_contract(new_account_client)
+async def test_latest_block(account):
+    await declare_contract(account)
 
-    blk = await new_account_client.get_block(block_number="latest")
+    blk = await account.client.get_block(block_number="latest")
     assert blk.block_hash

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -174,7 +174,7 @@ async def test_transaction_not_received_error(map_contract):
 
 
 @pytest.mark.asyncio
-async def test_error_when_invoking_without_account_client(gateway_client, map_contract):
+async def test_error_when_invoking_without_account(gateway_client, map_contract):
     contract = await Contract.from_address(map_contract.address, gateway_client)
 
     with pytest.raises(
@@ -187,7 +187,7 @@ async def test_error_when_invoking_without_account_client(gateway_client, map_co
 
 
 @pytest.mark.asyncio
-async def test_error_when_estimating_fee_while_not_using_account_client(
+async def test_error_when_estimating_fee_while_not_using_account(
     gateway_client, map_contract
 ):
     contract = await Contract.from_address(map_contract.address, gateway_client)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->


- This PR replaces usages of AccountClient in tests
- This PR renames tests still having `account_client` in their names


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


