### PR TITLE
Rename `ContractDeployment.udc`-> `ContractDeployment.call`

### DIFF
--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -17,7 +17,9 @@ from starknet_py.utils.data_transformer.universal_deployer_serializer import (
 )
 from starknet_py.utils.sync import add_sync_methods
 
-ContractDeployment = NamedTuple("ContractDeployment", [("udc", Call), ("address", int)])
+ContractDeployment = NamedTuple(
+    "ContractDeployment", [("call", Call), ("address", int)]
+)
 
 
 @add_sync_methods
@@ -106,7 +108,7 @@ class Deployer:
 
         address = self._compute_address(salt, class_hash, raw_calldata or [])
 
-        return ContractDeployment(udc=call, address=address)
+        return ContractDeployment(call=call, address=address)
 
     def _compute_address(
         self, salt: int, class_hash: int, constructor_calldata: List[int]

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -10,16 +10,16 @@ from starknet_py.utils.contructor_args_translator import translate_constructor_a
 async def test_default_deploy_with_class_hash(account, map_class_hash):
     deployer = Deployer()
 
-    deploy_call, address = deployer.create_deployment_call(class_hash=map_class_hash)
+    contract_deployment = deployer.create_deployment_call(class_hash=map_class_hash)
 
     deploy_invoke_tx = await account.sign_invoke_transaction(
-        deploy_call, max_fee=MAX_FEE
+        contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)
     await account.client.wait_for_tx(resp.transaction_hash)
 
-    assert isinstance(address, int)
-    assert address != 0
+    assert isinstance(contract_deployment.address, int)
+    assert contract_deployment.address != 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes
<!-- A brief description of the changes -->

NamedTuple returned by `Deployer.create_deployment_call` had the wrong name for the first parameter.
It is now renamed to `call`


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->

`ContractDeployment.udc`-> `ContractDeployment.call`

