### PR TITLE
Fix API docs (order and undocumented members)

### DIFF
--- a/docs/api/abi.rst
+++ b/docs/api/abi.rst
@@ -22,5 +22,11 @@ Model
     :members: defined_structures, functions, constructor, l1_handler, events
 
 .. autoclass:: starknet_py.abi.Abi.Function
+    :members:
+    :undoc-members:
+    :member-order: groupwise
 
 .. autoclass:: starknet_py.abi.Abi.Event
+    :members:
+    :undoc-members:
+    :member-order: groupwise

--- a/docs/api/account.rst
+++ b/docs/api/account.rst
@@ -1,9 +1,9 @@
 Account
 =======
 
----------
-Interface
----------
+---------------------
+BaseAccount interface
+---------------------
 
 .. py:module:: starknet_py.net.account.base_account
 
@@ -12,9 +12,9 @@ Interface
     :undoc-members:
     :member-order: groupwise
 
-----------------------
-Default implementation
-----------------------
+----------------------------------
+BaseAccount default implementation
+----------------------------------
 
 .. py:module:: starknet_py.net.account.account
 

--- a/docs/api/account.rst
+++ b/docs/api/account.rst
@@ -9,7 +9,8 @@ Interface
 
 .. autoclass:: BaseAccount
     :members:
-    :member-order: bysource
+    :undoc-members:
+    :member-order: groupwise
 
 ----------------------
 Default implementation
@@ -19,7 +20,8 @@ Default implementation
 
 .. autoclass-with-examples:: Account
     :members:
-    :member-order: bysource
+    :undoc-members:
+    :member-order: groupwise
 
 ------------------
 Account deployment

--- a/docs/api/contract.rst
+++ b/docs/api/contract.rst
@@ -4,27 +4,36 @@ Contract
 .. py:module:: starknet_py.contract
 
 .. autoclass:: Contract
-    :members: from_address, __init__, functions, from_address_sync, compute_address, compute_contract_hash
+    :members:
+    :undoc-members:
+    :member-order: groupwise
 
 .. autoclass:: ContractFunction
     :exclude-members: __init__, __new__
-    :members: prepare, call, invoke, call_sync, invoke_sync, get_selector
+    :members:
+    :undoc-members:
+    :member-order: groupwise
 
 .. autoclass:: PreparedFunctionCall
     :exclude-members: __init__, __new__
-    :members: call, call_raw, invoke, call_sync, call_raw_sync, invoke_sync, estimate_fee, estimate_fee_sync
+    :members:
+    :undoc-members:
+    :member-order: groupwise
 
 .. autoclass:: InvokeResult
     :exclude-members: __init__, __new__
-    :members: wait_for_acceptance, wait_for_acceptance_sync, contract, invoke_transaction, hash, status, block_number
+    :members:
+    :undoc-members:
     :member-order: groupwise
 
 .. autoclass:: DeployResult
     :exclude-members: __init__, __new__
-    :members: wait_for_acceptance, wait_for_acceptance_sync, deployed_contract, hash, status, block_number
+    :members:
+    :undoc-members:
     :member-order: groupwise
 
 .. autoclass:: DeclareResult
     :exclude-members: __init__, __new__
-    :members: deploy, deploy_sync, wait_for_acceptance, wait_for_acceptance_sync, class_hash, compiled_contract, hash, status, block_number
+    :members:
+    :undoc-members:
     :member-order: groupwise

--- a/docs/api/full_node_client.rst
+++ b/docs/api/full_node_client.rst
@@ -5,4 +5,5 @@ FullNodeClient
 
 .. autoclass-with-examples:: FullNodeClient
     :members:
-    :member-order: bysource
+    :undoc-members:
+    :member-order: groupwise

--- a/docs/api/gateway_client.rst
+++ b/docs/api/gateway_client.rst
@@ -5,4 +5,5 @@ GatewayClient
 
 .. autoclass-with-examples:: GatewayClient
     :members:
-    :member-order: bysource
+    :undoc-members:
+    :member-order: groupwise

--- a/docs/api/signer.rst
+++ b/docs/api/signer.rst
@@ -1,16 +1,36 @@
 Signer
 ======
 
+--------------------
+BaseSigner interface
+--------------------
+
 .. py:module:: starknet_py.net.signer
 
 .. autoclass:: BaseSigner
     :members:
+    :undoc-members:
+    :member-order: groupwise
+
+---------------------------------
+BaseSigner default implementation
+---------------------------------
 
 By default, StarkNet.py uses ``StarkCurveSigner`` which works with OpenZeppelin's account contract.
 
 .. py:module:: starknet_py.net.signer.stark_curve_signer
 
 .. autoclass:: StarkCurveSigner
+    :members:
+    :undoc-members:
+    :member-order: groupwise
+
+-------
+KeyPair
+-------
 
 .. autoclass:: KeyPair
+    :members:
+    :undoc-members:
+    :member-order: groupwise
 

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -47,9 +47,11 @@ from starknet_py.serialization.data_serializers.struct_serializer import (
     StructSerializer,
 )
 from starknet_py.utils.iterable import ensure_iterable
+from starknet_py.utils.sync import add_sync_methods
 from starknet_py.utils.typed_data import TypedData as TypedDataDataclass
 
 
+@add_sync_methods
 class Account(BaseAccount):
     """
     Default Account implementation.

--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -13,14 +13,12 @@ from starknet_py.net.models import AddressRepresentation, compute_address, parse
 from starknet_py.serialization import serializer_for_function
 from starknet_py.utils.contructor_args_translator import translate_constructor_args
 from starknet_py.utils.crypto.facade import pedersen_hash
-from starknet_py.utils.sync import add_sync_methods
 
 ContractDeployment = NamedTuple(
     "ContractDeployment", [("call", Call), ("address", int)]
 )
 
 
-@add_sync_methods
 class Deployer:
     """
     Deployer used to deploy contracts through Universal Deployer Contract (UDC)

--- a/starknet_py/utils/sync/sync.py
+++ b/starknet_py/utils/sync/sync.py
@@ -27,17 +27,21 @@ def add_sync_methods(original_class: T) -> T:
     for name, value in properties.items():
         sync_name = name + "_sync"
 
-        # Hand written implementation exists
+        # Handwritten implementation exists
         if sync_name in properties:
             continue
 
         # Make all callables synchronous
         if inspect.iscoroutinefunction(value):
             setattr(original_class, sync_name, make_sync(value))
+            sync_method = getattr(original_class, sync_name)
+            sync_method.__doc__ = "Synchronous version of the method."
         elif isinstance(value, staticmethod) and inspect.iscoroutinefunction(
             value.__func__
         ):
             setattr(original_class, sync_name, staticmethod(make_sync(value.__func__)))
+            sync_method = getattr(original_class, sync_name)
+            sync_method.__doc__ = "Synchronous version of the method."
         elif isinstance(value, classmethod) and inspect.iscoroutinefunction(
             value.__func__
         ):

--- a/starknet_py/utils/sync/sync.py
+++ b/starknet_py/utils/sync/sync.py
@@ -34,17 +34,20 @@ def add_sync_methods(original_class: T) -> T:
         # Make all callables synchronous
         if inspect.iscoroutinefunction(value):
             setattr(original_class, sync_name, make_sync(value))
-            sync_method = getattr(original_class, sync_name)
-            sync_method.__doc__ = "Synchronous version of the method."
+            _set_sync_method_docstring(original_class, sync_name)
         elif isinstance(value, staticmethod) and inspect.iscoroutinefunction(
             value.__func__
         ):
             setattr(original_class, sync_name, staticmethod(make_sync(value.__func__)))
-            sync_method = getattr(original_class, sync_name)
-            sync_method.__doc__ = "Synchronous version of the method."
+            _set_sync_method_docstring(original_class, sync_name)
         elif isinstance(value, classmethod) and inspect.iscoroutinefunction(
             value.__func__
         ):
             setattr(original_class, sync_name, classmethod(make_sync(value.__func__)))
 
     return original_class
+
+
+def _set_sync_method_docstring(original_class, sync_name: str):
+    sync_method = getattr(original_class, sync_name)
+    sync_method.__doc__ = "Synchronous version of the method."


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->

- Adds `groupwise` order (sync methods are just below `async` ones.
- Methods/parameters without docstrings are now present in the API docs.


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


