### PR TITLE
Fix `Client.get_state_update`

### DIFF
--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -273,7 +273,7 @@ class StorageEntry:
 
 
 @dataclass
-class StorageDiff:
+class StorageDiffItem:
     address: int
     storage_entries: List[StorageEntry]
 
@@ -301,7 +301,7 @@ class ContractsNonce:
 class StateDiff:
     deployed_contracts: List[DeployedContract]
     declared_contract_hashes: List[int]
-    storage_diffs: List[StorageDiff]
+    storage_diffs: List[StorageDiffItem]
     nonces: List[ContractsNonce]
 
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -266,6 +266,7 @@ class BlockTransactionTraces:
     traces: List[BlockSingleTransactionTrace]
 
 
+@dataclass
 class StorageEntry:
     key: int
     value: int

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -266,11 +266,15 @@ class BlockTransactionTraces:
     traces: List[BlockSingleTransactionTrace]
 
 
+class StorageEntry:
+    key: int
+    value: int
+
+
 @dataclass
 class StorageDiff:
     address: int
-    key: int
-    value: int
+    storage_entries: List[StorageEntry]
 
 
 @dataclass
@@ -287,6 +291,20 @@ class DeployedContract:
 
 
 @dataclass
+class UpdatedNonce:
+    contract_address: int
+    nonce: int
+
+
+@dataclass
+class StateDiff:
+    deployed_contracts: List[DeployedContract]
+    declared_contract_hashes: List[int]
+    storage_diffs: List[StorageDiff]
+    nonces: List[UpdatedNonce]
+
+
+@dataclass
 class BlockStateUpdate:
     """
     Dataclass representing a change in state of a block
@@ -295,16 +313,7 @@ class BlockStateUpdate:
     block_hash: int
     new_root: int
     old_root: int
-    storage_diffs: List[StorageDiff]
-    deployed_contracts: List[DeployedContract]
-    declared_contracts: List[int]
-
-
-@dataclass
-class StateDiff:
-    deployed_contracts: List[DeployedContract]
-    storage_diffs: List[StorageDiff]
-    declared_contract_hashes: List[int]
+    state_diff: StateDiff
 
 
 @dataclass

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -292,7 +292,7 @@ class DeployedContract:
 
 
 @dataclass
-class UpdatedNonce:
+class ContractsNonce:
     contract_address: int
     nonce: int
 
@@ -302,7 +302,7 @@ class StateDiff:
     deployed_contracts: List[DeployedContract]
     declared_contract_hashes: List[int]
     storage_diffs: List[StorageDiff]
-    nonces: List[UpdatedNonce]
+    nonces: List[ContractsNonce]
 
 
 @dataclass

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Union, cast
 
 import aiohttp
@@ -103,6 +104,7 @@ class FullNodeClient(Client):
             method_name="getStateUpdate",
             params=block_identifier,
         )
+        print(json.dumps(res))
         return cast(
             BlockStateUpdate, BlockStateUpdateSchema().load(res, unknown=EXCLUDE)
         )

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Optional, Union, cast
 
 import aiohttp
@@ -104,10 +103,7 @@ class FullNodeClient(Client):
             method_name="getStateUpdate",
             params=block_identifier,
         )
-        print(json.dumps(res))
-        return cast(
-            BlockStateUpdate, BlockStateUpdateSchema().load(res, unknown=EXCLUDE)
-        )
+        return BlockStateUpdateSchema().load(res, unknown=EXCLUDE)
 
     async def get_storage_at(
         self,

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -103,7 +103,9 @@ class FullNodeClient(Client):
             method_name="getStateUpdate",
             params=block_identifier,
         )
-        return BlockStateUpdateSchema().load(res, unknown=EXCLUDE)
+        return cast(
+            BlockStateUpdate, BlockStateUpdateSchema().load(res, unknown=EXCLUDE)
+        )
 
     async def get_storage_at(
         self,

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -1,9 +1,10 @@
 from typing import Any, Mapping, Optional, Union
 
-from marshmallow import ValidationError, fields
+from marshmallow import Schema, ValidationError, fields, post_load
 
 from starknet_py.net.client_models import (
     BlockStatus,
+    StorageEntry,
     TransactionStatus,
     TransactionType,
 )
@@ -114,3 +115,13 @@ class TransactionTypeField(fields.Field):
             )
 
         return TransactionType(value)
+
+
+class StorageEntrySchema(Schema):
+    key = Felt(data_key="key", required=True)
+    value = Felt(data_key="value", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs):
+        # pylint: disable=no-self-use
+        return StorageEntry(**data)

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -27,7 +27,7 @@ from starknet_py.net.client_models import (
     L2toL1Message,
     SentTransactionResponse,
     StateDiff,
-    StorageDiff,
+    StorageDiffItem,
     TransactionReceipt,
     TransactionStatusResponse,
 )
@@ -320,12 +320,12 @@ class BlockStateUpdateSchema(Schema):
     @post_load
     def make_dataclass(self, data, **kwargs):
         storage_diffs: Dict = data["state_diff"].storage_diffs
-        fixed_storage_diffs: List[StorageDiff] = []
+        fixed_storage_diffs: List[StorageDiffItem] = []
         for address in storage_diffs.keys():
             entries = []
             for entry in storage_diffs[address]:
                 entries.append(StorageEntrySchema().load(entry))
-            fixed_storage_diffs.append(StorageDiff(address, entries))
+            fixed_storage_diffs.append(StorageDiffItem(address, entries))
 
         nonces: Dict = data["state_diff"].nonces
         fixed_nonces: List[ContractsNonce] = []

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 from marshmallow import EXCLUDE, Schema, fields, post_load
 from marshmallow_oneofschema import OneOfSchema

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -36,11 +36,10 @@ from starknet_py.net.schemas.common import (
     Felt,
     NonPrefixedHex,
     StatusField,
+    StorageEntrySchema,
 )
 
-# pylint: disable=unused-argument
-# pylint: disable=no-self-use
-from starknet_py.net.schemas.rpc import StorageEntrySchema
+# pylint: disable=unused-argument, no-self-use
 
 
 class EventSchema(Schema):

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -317,7 +317,10 @@ class StateDiffSchema(Schema):
         required=True,
     )
     storage_diffs = fields.Dict(
-        keys=fields.String(), values=fields.Raw(), data_key="storage_diffs", required=True
+        keys=fields.String(),
+        values=fields.Raw(),
+        data_key="storage_diffs",
+        required=True,
     )
     nonces = fields.Dict(
         keys=Felt(), values=fields.Raw(), data_key="nonces", required=True

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -8,6 +8,7 @@ from starknet_py.net.client_models import (
     BlockStateUpdate,
     BlockTransactionTraces,
     ContractCode,
+    ContractsNonce,
     DeclaredContract,
     DeclareTransaction,
     DeclareTransactionResponse,
@@ -28,7 +29,7 @@ from starknet_py.net.client_models import (
     StateDiff,
     StorageDiff,
     TransactionReceipt,
-    TransactionStatusResponse, UpdatedNonce,
+    TransactionStatusResponse,
 )
 from starknet_py.net.schemas.common import (
     BlockStatusField,
@@ -303,9 +304,7 @@ class StateDiffSchema(Schema):
         data_key="storage_diffs",
         required=True,
     )
-    nonces = fields.Dict(
-        keys=Felt(), values=Felt(), data_key="nonces", required=True
-    )
+    nonces = fields.Dict(keys=Felt(), values=Felt(), data_key="nonces", required=True)
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> StateDiff:
@@ -329,9 +328,9 @@ class BlockStateUpdateSchema(Schema):
             fixed_storage_diffs.append(StorageDiff(address, entries))
 
         nonces: Dict = data["state_diff"].nonces
-        fixed_nonces: List[UpdatedNonce] = []
+        fixed_nonces: List[ContractsNonce] = []
         for address, nonce in nonces.items():
-            fixed_nonces.append(UpdatedNonce(address, nonce))
+            fixed_nonces.append(ContractsNonce(address, nonce))
 
         data["state_diff"].storage_diffs = fixed_storage_diffs
         data["state_diff"].nonces = fixed_nonces

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -27,7 +27,6 @@ from starknet_py.net.client_models import (
     SentTransactionResponse,
     StateDiff,
     StorageDiff,
-    StorageEntry,
     TransactionReceipt,
     TransactionStatusResponse,
 )
@@ -40,6 +39,7 @@ from starknet_py.net.schemas.common import (
 
 # pylint: disable=unused-argument
 # pylint: disable=no-self-use
+from starknet_py.net.schemas.rpc import StorageEntrySchema
 
 
 class EventSchema(Schema):
@@ -277,16 +277,6 @@ class DeployAccountTransactionResponseSchema(SentTransactionSchema):
         return DeployAccountTransactionResponse(**data)
 
 
-class StorageDiffSchema(Schema):
-    address = Felt(data_key="address", required=True)
-    key = Felt(data_key="key", required=True)
-    value = Felt(data_key="value", required=True)
-
-    @post_load
-    def make_dataclass(self, data, **kwargs):
-        return StorageDiff(**data)
-
-
 class DeployedContractSchema(Schema):
     address = Felt(data_key="address", required=True)
     class_hash = NonPrefixedHex(data_key="class_hash", required=True)
@@ -294,15 +284,6 @@ class DeployedContractSchema(Schema):
     @post_load
     def make_dataclass(self, data, **kwargs):
         return DeployedContract(**data)
-
-
-class StorageEntrySchema(Schema):
-    key = Felt(data_key="key", required=True)
-    value = Felt(data_key="value", required=True)
-
-    @post_load
-    def make_dataclass(self, data, **kwargs):
-        return StorageEntry(**data)
 
 
 class StateDiffSchema(Schema):
@@ -345,12 +326,9 @@ class BlockStateUpdateSchema(Schema):
             entries = []
             for entry in storage_diffs[address]:
                 entries.append(StorageEntrySchema().load(entry))
-            proper_storage_diffs.append(
-                StorageDiff(Felt().deserialize(address), entries)
-            )
+            proper_storage_diffs.append(StorageDiff(address, entries))
 
         data["state_diff"].storage_diffs = proper_storage_diffs
-
         return BlockStateUpdate(
             **data,
         )

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -24,7 +24,6 @@ from starknet_py.net.client_models import (
     StarknetBlock,
     StateDiff,
     StorageDiffItem,
-    StorageEntry,
     TransactionReceipt,
 )
 from starknet_py.net.schemas.common import (
@@ -32,10 +31,10 @@ from starknet_py.net.schemas.common import (
     Felt,
     NonPrefixedHex,
     StatusField,
+    StorageEntrySchema,
 )
 
-# pylint: disable=unused-argument
-# pylint: disable=no-self-use
+# pylint: disable=unused-argument, no-self-use
 
 
 class FunctionCallSchema(Schema):
@@ -205,15 +204,6 @@ class StarknetBlockSchema(Schema):
     @post_load
     def make_dataclass(self, data, **kwargs) -> StarknetBlock:
         return StarknetBlock(**data)
-
-
-class StorageEntrySchema(Schema):
-    key = Felt(data_key="key", required=True)
-    value = Felt(data_key="value", required=True)
-
-    @post_load
-    def make_dataclass(self, data, **kwargs):
-        return StorageEntry(**data)
 
 
 class StorageDiffSchema(Schema):

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -23,6 +23,7 @@ from starknet_py.net.client_models import (
     StarknetBlock,
     StateDiff,
     StorageDiff,
+    StorageEntry,
     TransactionReceipt,
 )
 from starknet_py.net.schemas.common import (
@@ -209,6 +210,10 @@ class StorageEntrySchema(Schema):
     key = Felt(data_key="key", required=True)
     value = Felt(data_key="value", required=True)
 
+    @post_load
+    def make_dataclass(self, data, **kwargs):
+        return StorageEntry(**data)
+
 
 class StorageDiffSchema(Schema):
     address = Felt(data_key="address", required=True)
@@ -279,7 +284,6 @@ class BlockStateUpdateSchema(Schema):
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> BlockStateUpdate:
-
         return BlockStateUpdate(
             **data,
         )

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -23,7 +23,7 @@ from starknet_py.net.client_models import (
     SentTransactionResponse,
     StarknetBlock,
     StateDiff,
-    StorageDiff,
+    StorageDiffItem,
     StorageEntry,
     TransactionReceipt,
 )
@@ -225,8 +225,8 @@ class StorageDiffSchema(Schema):
     )
 
     @post_load
-    def make_dataclass(self, data, **kwargs) -> StorageDiff:
-        return StorageDiff(**data)
+    def make_dataclass(self, data, **kwargs) -> StorageDiffItem:
+        return StorageDiffItem(**data)
 
 
 class ContractDiffSchema(Schema):

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -24,7 +24,7 @@ from starknet_py.net.client_models import (
     StateDiff,
     StorageDiff,
     StorageEntry,
-    TransactionReceipt,
+    TransactionReceipt, ContractsNonce,
 )
 from starknet_py.net.schemas.common import (
     BlockStatusField,
@@ -246,9 +246,13 @@ class DeployedContractSchema(Schema):
         return DeployedContract(**data)
 
 
-class UpdatedNonceSchema(Schema):
+class ContractsNonceSchema(Schema):
     contract_address = Felt(data_key="contract_address", required=True)
     nonce = Felt(data_key="nonce", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs):
+        return ContractsNonce(**data)
 
 
 class StateDiffSchema(Schema):
@@ -268,7 +272,7 @@ class StateDiffSchema(Schema):
         required=True,
     )
     nonces = fields.List(
-        fields.Nested(UpdatedNonceSchema()), data_key="nonces", required=True
+        fields.Nested(ContractsNonceSchema()), data_key="nonces", required=True
     )
 
     @post_load

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -4,6 +4,7 @@ from marshmallow_oneofschema import OneOfSchema
 from starknet_py.abi.schemas import ContractAbiEntrySchema
 from starknet_py.net.client_models import (
     BlockStateUpdate,
+    ContractsNonce,
     DeclaredContract,
     DeclareTransaction,
     DeclareTransactionResponse,
@@ -24,7 +25,7 @@ from starknet_py.net.client_models import (
     StateDiff,
     StorageDiff,
     StorageEntry,
-    TransactionReceipt, ContractsNonce,
+    TransactionReceipt,
 )
 from starknet_py.net.schemas.common import (
     BlockStatusField,

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -396,9 +396,7 @@ async def test_state_update_declared_contract_hashes(
     block_with_declare_number,
     class_hash,
 ):
-    state_update = await client.get_state_update(
-        block_number=block_with_declare_number
-    )
+    state_update = await client.get_state_update(block_number=block_with_declare_number)
 
     assert class_hash in state_update.state_diff.declared_contract_hashes
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -23,6 +23,7 @@ from starknet_py.net.client_models import (
 )
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models.transaction import Declare
+from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 from starknet_py.transaction_exceptions import (
@@ -386,3 +387,52 @@ async def test_get_l1_handler_transaction(client):
         assert isinstance(transaction, L1HandlerTransaction)
         assert transaction.nonce is not None
         assert transaction.nonce == 0x34C20
+
+
+@pytest.mark.run_on_devnet
+@pytest.mark.asyncio
+async def test_state_update_declared_contract_hashes(
+    client,
+    block_with_declare_number,
+    class_hash,
+):
+    state_update = await client.get_state_update(
+        block_number=block_with_declare_number
+    )
+
+    assert class_hash in state_update.state_diff.declared_contract_hashes
+
+
+@pytest.mark.run_on_devnet
+@pytest.mark.asyncio
+async def test_state_update_storage_diffs(
+    client,
+    map_contract,
+):
+    resp = await map_contract.functions["put"].invoke(key=10, value=20, max_fee=MAX_FEE)
+    await resp.wait_for_acceptance()
+
+    state_update = await client.get_state_update()
+
+    assert len(state_update.state_diff.storage_diffs) != 0
+
+
+@pytest.mark.run_on_devnet
+@pytest.mark.asyncio
+async def test_state_update_deployed_contracts(
+    class_hash,
+    account,
+):
+    # setup
+    deployer = Deployer()
+    contract_deployment = deployer.create_deployment_call(class_hash=class_hash)
+    deploy_invoke_tx = await account.sign_invoke_transaction(
+        contract_deployment.call, max_fee=MAX_FEE
+    )
+    resp = await account.client.send_transaction(deploy_invoke_tx)
+    await account.client.wait_for_tx(resp.transaction_hash)
+
+    # test
+    state_update = await account.client.get_state_update()
+
+    assert len(state_update.state_diff.deployed_contracts) != 0

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -104,7 +104,7 @@ async def test_state_update_full_node_client(
         block_number=block_with_declare_number
     )
 
-    assert class_hash in state_update.declared_contracts
+    assert class_hash in state_update.state_diff.declared_contract_hashes
 
 
 @pytest.mark.run_on_devnet

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -95,20 +95,6 @@ async def test_pending_transactions(full_node_client):
 
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
-async def test_state_update_full_node_client(
-    full_node_client,
-    block_with_declare_number,
-    class_hash,
-):
-    state_update = await full_node_client.get_state_update(
-        block_number=block_with_declare_number
-    )
-
-    assert class_hash in state_update.state_diff.declared_contract_hashes
-
-
-@pytest.mark.run_on_devnet
-@pytest.mark.asyncio
 async def test_get_storage_at_incorrect_address_full_node_client(full_node_client):
     with pytest.raises(ClientError, match="Contract not found"):
         await full_node_client.get_storage_at(

--- a/starknet_py/tests/e2e/client/gateway_test.py
+++ b/starknet_py/tests/e2e/client/gateway_test.py
@@ -185,7 +185,7 @@ async def test_state_update_gateway_client(
         block_number=block_with_declare_number
     )
 
-    assert class_hash in state_update.declared_contracts
+    assert class_hash in state_update.state_diff.declared_contract_hashes
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/client/gateway_test.py
+++ b/starknet_py/tests/e2e/client/gateway_test.py
@@ -176,19 +176,6 @@ def test_creating_client_with_custom_net_dict():
 
 
 @pytest.mark.asyncio
-async def test_state_update_gateway_client(
-    gateway_client,
-    block_with_declare_number,
-    class_hash,
-):
-    state_update = await gateway_client.get_state_update(
-        block_number=block_with_declare_number
-    )
-
-    assert class_hash in state_update.state_diff.declared_contract_hashes
-
-
-@pytest.mark.asyncio
 async def test_get_storage_at_incorrect_address_gateway_client(gateway_client):
     storage = await gateway_client.get_storage_at(
         contract_address=0x1111,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #731 


## Introduced changes
<!-- A brief description of the changes -->

- Client.get_state_update works how it should
- Dataclasses are compatible with RPC API
- Tests are added to avoid such a situation next time

- Tests for the `nonces` field can't be added because `devnet` doesn't include them in the block


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->

- Dataclasses for BlockStateUpdate are different (compatible with RPC API)


