### PR TITLE
Document deprecated contract methods parameters, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Quickstart](https://starknetpy.rtfd.io/en/latest/quickstart.html)
 - [Guide](https://starknetpy.rtfd.io/en/latest/guide.html)
 - [API](https://starknetpy.rtfd.io/en/latest/api.html)
+- [Migration guide](https://starknetpy.readthedocs.io/en/latest/migration_guide.html)
 
 ## ⚙️ Installation
 

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -467,7 +467,11 @@ class Contract:
         :param address: contract's address.
         :param abi: contract's abi.
         :param provider: BaseAccount or Client used to perform transactions.
-        :param client: client used to perform transactions.
+        :param client:
+            Client used to perform transactions.
+
+            .. deprecated:: 0.13.0
+                Argument client has been deprecated. Use provider instead.
         """
         client, account = _unpack_provider(provider, client)
 
@@ -513,7 +517,11 @@ class Contract:
             If set to ``False``, :meth:`Contract.from_address` will not resolve proxies.
 
             If a valid :class:`starknet_py.contract_abi_resolver.ProxyConfig` is provided, will use its values instead.
-        :param client: Client.
+        :param client:
+            Client
+
+            .. deprecated:: 0.13.0
+                Argument client has been deprecated. Use provider instead.
 
         :return: an initialized Contract instance.
         """
@@ -627,15 +635,20 @@ class Contract:
         Either `compilation_source` or `compiled_contract` is required.
 
         :param salt: int
-        :param compilation_source: string containing source code or a list of source files paths
-        :param compiled_contract: string containing compiled contract. Useful for reading compiled contract from a file.
-        :param constructor_args: a ``list`` or ``dict`` of arguments for the constructor.
-        :param search_paths: a ``list`` of paths used by starknet_compile to resolve dependencies within contracts.
-        :param deployer_address: address of the deployer (if not provided default 0 is used)
+        :param compilation_source:
+            String containing source code or a list of source files paths.
+
+            .. deprecated:: 0.14.0
+                Argument compilation_source is deprecated and will be removed in the future.
+                Consider using already compiled contracts.
+        :param compiled_contract: String containing compiled contract. Useful for reading compiled contract from a file.
+        :param constructor_args: A ``list`` or ``dict`` of arguments for the constructor.
+        :param search_paths: A ``list`` of paths used by starknet_compile to resolve dependencies within contracts.
+        :param deployer_address: Address of the deployer (if not provided default 0 is used).
 
         :raises: `ValueError` if neither compilation_source nor compiled_contract is provided.
 
-        :return: contract's address
+        :return: Contract's address.
         """
         # pylint: disable=too-many-arguments
         warnings.warn(
@@ -665,11 +678,16 @@ class Contract:
         Computes hash for given contract.
         Either `compilation_source` or `compiled_contract` is required.
 
-        :param compilation_source: string containing source code or a list of source files paths
-        :param compiled_contract: string containing compiled contract. Useful for reading compiled contract from a file.
-        :param search_paths: a ``list`` of paths used by starknet_compile to resolve dependencies within contracts.
+        :param compilation_source: String containing source code or a list of source files paths.
+        :param compiled_contract:
+            String containing compiled contract. Useful for reading compiled contract from a file.
+
+            .. deprecated:: 0.14.0
+                Argument compilation_source is deprecated and will be removed in the future.
+                Consider using already compiled contracts.
+        :param search_paths: A ``list`` of paths used by starknet_compile to resolve dependencies within contracts.
         :raises: `ValueError` if neither compilation_source nor compiled_contract is provided.
-        :return: class_hash of the contract.
+        :return: Class_hash of the contract.
         """
         warnings.warn(
             "Argument compilation_source is deprecated and will be removed in the future. "


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #727 


## Introduced changes
<!-- A brief description of the changes -->


- Documented deprecated parameters in Contract's methods
- Added a link to migration guide in readme


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


