### PR TITLE
Circular imports detection

### DIFF
--- a/circular.py
+++ b/circular.py
@@ -1,0 +1,19 @@
+import importlib
+import importlib.util
+import os
+import sys
+
+
+def _import_from_path(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+
+def test_circular_imports():
+    for path, subdirs, files in os.walk("starknet_py"):
+        py_files = [f for f in files if f.endswith(".py")]
+        for file_ in py_files:
+            file_path = os.path.join(path, file_)
+            _import_from_path(file_, file_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ format_check.shell = "isort --check . && black --check ."
 format_diff.shell = "isort --diff . && black --diff ."
 typecheck = "pyright starknet_py"
 compile_contracts = "bash starknet_py/tests/e2e/mock/compile_contracts.sh"
+circular_imports_check.shell = "poetry run pytest circular.py"
 requirements_check.shell = "poetry export -f requirements.txt --without-hashes --extras docs | cmp - requirements.txt"
 ci = ["lint", "format_check", "typecheck", "requirements_check", "test_ci"]
 

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -17,8 +17,8 @@ from starknet_py.constants import DEFAULT_DEPLOYER_ADDRESS
 from starknet_py.hash.address import compute_address
 from starknet_py.hash.class_hash import compute_class_hash
 from starknet_py.hash.selector import get_selector_from_name
-from starknet_py.net import AccountClient
 from starknet_py.net.account._account_proxy import AccountProxy
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
 from starknet_py.net.client_models import Call, Hash, Tag

--- a/starknet_py/net/__init__.py
+++ b/starknet_py/net/__init__.py
@@ -1,1 +1,0 @@
-from .account.account_client import AccountClient, KeyPair

--- a/starknet_py/net/account/_account_proxy.py
+++ b/starknet_py/net/account/_account_proxy.py
@@ -4,7 +4,7 @@ import dataclasses
 from typing import List, Optional
 
 from starknet_py.constants import QUERY_VERSION_BASE
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
 from starknet_py.net.client_models import Calls, SentTransactionResponse

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -8,7 +8,6 @@ from starkware.starknet.public.abi import get_selector_from_name
 from starknet_py.common import create_compiled_contract
 from starknet_py.constants import QUERY_VERSION_BASE
 from starknet_py.hash.address import compute_address
-from starknet_py.net import KeyPair
 from starknet_py.net.account.account_deployment_result import AccountDeploymentResult
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
@@ -42,7 +41,7 @@ from starknet_py.net.networks import (
     default_token_address_for_network,
 )
 from starknet_py.net.signer import BaseSigner
-from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
+from starknet_py.net.signer.stark_curve_signer import KeyPair, StarkCurveSigner
 from starknet_py.serialization.data_serializers.array_serializer import ArraySerializer
 from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
 from starknet_py.serialization.data_serializers.payload_serializer import (

--- a/starknet_py/net/account/account_client_test.py
+++ b/starknet_py/net/account/account_client_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 
 
 def test_account_client_raises_on_no_chain_and_signer(gateway_client):

--- a/starknet_py/net/account/account_test.py
+++ b/starknet_py/net/account/account_test.py
@@ -3,12 +3,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
-from starknet_py.net import KeyPair
 from starknet_py.net.account.account import Account
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId, parse_address
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2
-from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
+from starknet_py.net.signer.stark_curve_signer import KeyPair, StarkCurveSigner
 
 
 @pytest.mark.asyncio

--- a/starknet_py/serialization/__init__.py
+++ b/starknet_py/serialization/__init__.py
@@ -1,6 +1,5 @@
 # PayloadSerializer and FunctionSerializationAdapter would mostly be used by users
-from .data_serializers.cairo_data_serializer import CairoDataSerializer
-from .data_serializers.payload_serializer import PayloadSerializer
+from .data_serializers import CairoDataSerializer, PayloadSerializer
 from .errors import (
     CairoSerializerException,
     InvalidTypeException,

--- a/starknet_py/serialization/data_serializers/__init__.py
+++ b/starknet_py/serialization/data_serializers/__init__.py
@@ -1,0 +1,2 @@
+from .cairo_data_serializer import CairoDataSerializer
+from .payload_serializer import PayloadSerializer

--- a/starknet_py/tests/e2e/account/account_client_test.py
+++ b/starknet_py/tests/e2e/account/account_client_test.py
@@ -5,11 +5,12 @@ import pytest
 
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.contract import Contract
-from starknet_py.net import AccountClient, KeyPair
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.client_models import Call
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId, parse_address
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.transaction_exceptions import TransactionRejectedError
 

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -5,9 +5,9 @@ from starkware.starknet.public.abi import get_selector_from_name
 
 from starknet_py.contract import Contract
 from starknet_py.hash.address import compute_address
-from starknet_py.net import AccountClient, KeyPair
 from starknet_py.net.account._account_proxy import AccountProxy
 from starknet_py.net.account.account import Account
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
 from starknet_py.net.client_errors import ClientError
@@ -19,6 +19,7 @@ from starknet_py.net.client_models import (
 )
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.transaction_exceptions import TransactionRejectedError
 

--- a/starknet_py/tests/e2e/client/fixtures/prepare_net_for_gateway_test.py
+++ b/starknet_py/tests/e2e/client/fixtures/prepare_net_for_gateway_test.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from starknet_py.contract import Contract
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.tests.e2e.utils import (
     AccountToBeDeployedDetails,

--- a/starknet_py/tests/e2e/client/fixtures/prepare_network.py
+++ b/starknet_py/tests/e2e/client/fixtures/prepare_network.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 
 from starknet_py.hash.selector import get_selector_from_name
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.tests.e2e.client.fixtures.prepare_net_for_gateway_test import (
     PreparedNetworkData,
     prepare_net_for_tests,

--- a/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
+++ b/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
@@ -17,11 +17,11 @@ async def test_deploy_prefunded_account(
     # pylint: disable=import-outside-toplevel, too-many-locals
     # docs: start
     from starknet_py.hash.address import compute_address
-    from starknet_py.net import KeyPair
     from starknet_py.net.account.account import Account
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.net.models import StarknetChainId
     from starknet_py.net.networks import TESTNET
+    from starknet_py.net.signer.stark_curve_signer import KeyPair
 
     # First, make sure to generate private key and salt
     # docs: end

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract.py
@@ -2,11 +2,11 @@
 import pytest
 
 from starknet_py.contract import Contract
-from starknet_py.net import KeyPair
 from starknet_py.net.account.account import Account
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId
 from starknet_py.net.networks import TESTNET
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 
 def test_init():

--- a/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
+++ b/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
@@ -13,11 +13,11 @@ async def test_custom_nonce(gateway_client):
     private_key = 0x1
 
     # docs: start
-    from starknet_py.net import KeyPair
     from starknet_py.net.account.account import Account
     from starknet_py.net.client import Client
     from starknet_py.net.models import AddressRepresentation, StarknetChainId
     from starknet_py.net.signer import BaseSigner
+    from starknet_py.net.signer.stark_curve_signer import KeyPair
 
     class MyAccount(Account):
         def __init__(

--- a/starknet_py/tests/e2e/docs/guide/test_sign_offchain_message.py
+++ b/starknet_py/tests/e2e/docs/guide/test_sign_offchain_message.py
@@ -6,10 +6,10 @@ async def test_sign_offchain_message(account):
     # pylint: disable=import-outside-toplevel, duplicate-code, unused-variable
 
     # docs: start
-    from starknet_py.net import KeyPair
     from starknet_py.net.account.account import Account
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.net.models import StarknetChainId
+    from starknet_py.net.signer.stark_curve_signer import KeyPair
     from starknet_py.utils.typed_data import TypedData
 
     # Create a TypedData dictionary

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
@@ -7,10 +7,11 @@ from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner
 async def test_creating_account(network):
     # pylint: disable=import-outside-toplevel, unused-variable
     # docs: start
-    from starknet_py.net import AccountClient, KeyPair
     from starknet_py.net.account.account import Account
+    from starknet_py.net.account.account_client import AccountClient
     from starknet_py.net.gateway_client import GatewayClient
     from starknet_py.net.models.chains import StarknetChainId
+    from starknet_py.net.signer.stark_curve_signer import KeyPair
 
     testnet = "testnet"
     chain_id = StarknetChainId.TESTNET

--- a/starknet_py/tests/e2e/fixtures/account_clients.py
+++ b/starknet_py/tests/e2e/fixtures/account_clients.py
@@ -10,15 +10,16 @@ import pytest_asyncio
 from starknet_py.constants import DEFAULT_DECLARE_SENDER_ADDRESS
 from starknet_py.contract import Contract
 from starknet_py.hash.address import compute_address
-from starknet_py.net import AccountClient, KeyPair
 from starknet_py.net.account._account_proxy import AccountProxy
 from starknet_py.net.account.account import Account
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.http_client import GatewayHttpClient
 from starknet_py.net.models import AddressRepresentation, StarknetChainId
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.tests.e2e.fixtures.constants import (
     DEVNET_PRE_DEPLOYED_ACCOUNT_ADDRESS,

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -7,8 +7,8 @@ import pytest_asyncio
 from starknet_py.common import create_compiled_contract
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.contract import Contract
-from starknet_py.net import AccountClient
 from starknet_py.net.account._account_proxy import AccountProxy
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.account.compiled_account_contract import COMPILED_ACCOUNT_CONTRACT
 from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_DIR, MAX_FEE

--- a/starknet_py/tests/e2e/fixtures/misc.py
+++ b/starknet_py/tests/e2e/fixtures/misc.py
@@ -7,7 +7,7 @@ import pytest
 import pytest_asyncio
 
 from starknet_py.contract import Contract
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.models.typed_data import TypedData
 from starknet_py.tests.e2e.fixtures.constants import (
     CONTRACTS_COMPILED_DIR,

--- a/starknet_py/tests/e2e/fixtures/proxy.py
+++ b/starknet_py/tests/e2e/fixtures/proxy.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 
 from starknet_py.contract import Contract, DeployResult
 from starknet_py.hash.selector import get_selector_from_name
-from starknet_py.net import AccountClient
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_PRECOMPILED_DIR, MAX_FEE
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -4,12 +4,13 @@ from typing import Optional, Tuple, cast
 from starknet_py.constants import EC_ORDER
 from starknet_py.contract import Contract
 from starknet_py.hash.address import compute_address
-from starknet_py.net import AccountClient, KeyPair
+from starknet_py.net.account.account_client import AccountClient
 from starknet_py.net.client import Client
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId
 from starknet_py.net.models.transaction import DeployAccount
 from starknet_py.net.networks import Network
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 AccountToBeDeployedDetails = Tuple[int, KeyPair, int, int]
 MAX_FEE = int(1e20)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #749


## Introduced changes
<!-- A brief description of the changes -->


1. Add `circular.py` in the root of the project
2. Add `poe circular_imports_check` command
- [ ] TODO: add the above command as a check in CI

3. Split 2-level deep imports in `starknet_py.serialization` into two 1-level deep imports:

***old***:
```
# starknet_py.serialization
from .data_serializers.cairo_data_serializer import CairoDataSerializer
```
***new***:
```
# starknet_py.serialization
from .data_serializers import CairoDataSerializer

# starknet_py.serialization.data_serializers
from .cairo_data_serializer import CairoDataSerializer
```

##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->
1. Remove import from `starknet_py.net.__init__.py`:

***old***:
```
 from starknet_py.net import AccountClient, KeyPair
```
***new***:
```
from starknet_py.net.account.account_client import AccountClient
from starknet_py.net.signer.stark_curve_signer import KeyPair
```



