### PR TITLE
`Client.net` deprecation

### DIFF
--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -218,9 +218,13 @@ class Account(BaseAccount):
         )
 
     async def get_balance(
-        self, token_address: Optional[AddressRepresentation] = None, chain_id: Optional[StarknetChainId] = None,
+        self,
+        token_address: Optional[AddressRepresentation] = None,
+        chain_id: Optional[StarknetChainId] = None,
     ) -> int:
-        token_address = token_address or default_token_address_for_chain(chain_id or self._chain_id)
+        token_address = token_address or default_token_address_for_chain(
+            chain_id or self._chain_id
+        )
 
         low, high = await self._client.call_contract(
             Call(

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import OrderedDict
-from typing import Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from starknet_py.common import create_compiled_contract
 from starknet_py.constants import FEE_CONTRACT_ADDRESS, QUERY_VERSION_BASE
@@ -70,9 +70,6 @@ class Account(BaseAccount):
         :param key_pair: Key pair that will be used to create a default `Signer`.
         :param chain: ChainId of the chain used to create the default signer.
         """
-        if chain is None and signer is None:
-            raise ValueError("One of chain or signer must be provided.")
-
         self._address = parse_address(address)
         self._client = client
 
@@ -84,13 +81,13 @@ class Account(BaseAccount):
                 raise ValueError(
                     "Either a signer or a key_pair must be provided in Account constructor."
                 )
+            if chain is None:
+                raise ValueError("One of chain or signer must be provided.")
 
             signer = StarkCurveSigner(
                 account_address=self.address,
                 key_pair=key_pair,
-                chain_id=cast(
-                    StarknetChainId, chain
-                ),  # cast is required, because pyright doesn't know chain is not None here
+                chain_id=chain
             )
         self.signer: BaseSigner = signer
         self._chain_id = chain

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -222,9 +222,9 @@ class Account(BaseAccount):
         token_address: Optional[AddressRepresentation] = None,
         chain_id: Optional[StarknetChainId] = None,
     ) -> int:
-        token_address = token_address or default_token_address_for_chain(
-            chain_id or self._chain_id
-        )
+        if token_address is None:
+            chain_id = chain_id or self._chain_id
+            token_address = default_token_address_for_chain(chain_id)
 
         low, high = await self._client.call_contract(
             Call(

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -218,9 +218,9 @@ class Account(BaseAccount):
         )
 
     async def get_balance(
-        self, token_address: Optional[AddressRepresentation] = None
+        self, token_address: Optional[AddressRepresentation] = None, chain_id: Optional[StarknetChainId] = None,
     ) -> int:
-        token_address = token_address or default_token_address_for_chain(self._chain_id)
+        token_address = token_address or default_token_address_for_chain(chain_id or self._chain_id)
 
         low, high = await self._client.call_contract(
             Call(

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -85,9 +85,7 @@ class Account(BaseAccount):
                 raise ValueError("One of chain or signer must be provided.")
 
             signer = StarkCurveSigner(
-                account_address=self.address,
-                key_pair=key_pair,
-                chain_id=chain
+                account_address=self.address, key_pair=key_pair, chain_id=chain
             )
         self.signer: BaseSigner = signer
         self._chain_id = chain

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -410,7 +410,9 @@ class Account(BaseAccount):
             hash=result.transaction_hash, account=account, _client=account.client
         )
 
-    def _default_token_address_for_chain(self, chain_id: Optional[StarknetChainId] = None) -> str:
+    def _default_token_address_for_chain(
+        self, chain_id: Optional[StarknetChainId] = None
+    ) -> str:
         if (chain_id or self._chain_id) not in [
             StarknetChainId.TESTNET,
             StarknetChainId.TESTNET2,

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -51,7 +51,9 @@ class BaseAccount(ABC):
 
     @abstractmethod
     async def get_balance(
-        self, token_address: Optional[AddressRepresentation] = None, chain_id: Optional[StarknetChainId] = None
+        self,
+        token_address: Optional[AddressRepresentation] = None,
+        chain_id: Optional[StarknetChainId] = None,
     ) -> int:
         """
         Checks account's balance of specified token.

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -61,6 +61,7 @@ class BaseAccount(ABC):
         :param token_address: Address of the ERC20 contract.
         :param chain_id: Identifier of the Starknet chain used.
             If token_address is not specified it will be used to determine network's payment token address.
+            If token_address is provided, chain_id will be omitted.
         :return: Token balance.
         """
 

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from starknet_py.net.client import Client
 from starknet_py.net.client_models import Calls, SentTransactionResponse
-from starknet_py.net.models import AddressRepresentation
+from starknet_py.net.models import AddressRepresentation, StarknetChainId
 from starknet_py.net.models.transaction import (
     Declare,
     DeployAccount,
@@ -51,13 +51,14 @@ class BaseAccount(ABC):
 
     @abstractmethod
     async def get_balance(
-        self, token_address: Optional[AddressRepresentation] = None
+        self, token_address: Optional[AddressRepresentation] = None, chain_id: Optional[StarknetChainId] = None
     ) -> int:
         """
         Checks account's balance of specified token.
 
         :param token_address: Address of the ERC20 contract.
-            If not specified it will be payment token address.
+        :param chain_id: Identifier of the Starknet chain used.
+            If token_address is not specified it will be used to determine network's payment token address.
         :return: Token balance.
         """
 

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -41,7 +41,10 @@ class Client(ABC):
     @abstractmethod
     def net(self) -> Network:
         """
-        Network of the client
+        Network of the client.
+
+         .. deprecated:: 0.15.0
+            Parameter net of the Client interface is deprecated.
         """
 
     @abstractmethod

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -44,7 +44,7 @@ class Client(ABC):
         Network of the client.
 
          .. deprecated:: 0.15.0
-            Parameter net of the Client interface is deprecated.
+            Property net of the Client interface is deprecated.
         """
 
     @abstractmethod

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from typing import Dict, List, Optional, Union, cast
 
 import aiohttp
@@ -52,7 +53,7 @@ class FullNodeClient(Client):
     def __init__(
         self,
         node_url: str,
-        net: Network,
+        net: Optional[Network] = None,
         session: Optional[aiohttp.ClientSession] = None,
     ):
         """
@@ -65,10 +66,14 @@ class FullNodeClient(Client):
         """
         self.url = node_url
         self._client = RpcHttpClient(url=node_url, session=session)
+
+        if net is not None:
+            warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
         self._net = net
 
     @property
     def net(self) -> Network:
+        warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
         return self._net
 
     async def get_block(

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -73,7 +73,10 @@ class FullNodeClient(Client):
 
     @property
     def net(self) -> Optional[Network]:
-        warnings.warn("Property net is deprecated in the FullNodeClient.", category=DeprecationWarning)
+        warnings.warn(
+            "Property net is deprecated in the FullNodeClient.",
+            category=DeprecationWarning,
+        )
         return self._net
 
     async def get_block(

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -73,7 +73,7 @@ class FullNodeClient(Client):
 
     @property
     def net(self) -> Optional[Network]:
-        warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
+        warnings.warn("Property net is deprecated in the FullNodeClient.", category=DeprecationWarning)
         return self._net
 
     async def get_block(

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -72,7 +72,7 @@ class FullNodeClient(Client):
         self._net = net
 
     @property
-    def net(self) -> Network:
+    def net(self) -> Optional[Network]:
         warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
         return self._net
 

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -86,7 +86,7 @@ class GatewayClient(Client):
 
     @property
     def net(self) -> Network:
-        warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
+        warnings.warn("Property net is deprecated in the GatewayClient.", category=DeprecationWarning)
         return self._net
 
     async def get_block(

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, List, Optional, Union, cast
 
 import aiohttp
@@ -85,6 +86,7 @@ class GatewayClient(Client):
 
     @property
     def net(self) -> Network:
+        warnings.warn("Parameter net is deprecated.", category=DeprecationWarning)
         return self._net
 
     async def get_block(

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -86,7 +86,10 @@ class GatewayClient(Client):
 
     @property
     def net(self) -> Network:
-        warnings.warn("Property net is deprecated in the GatewayClient.", category=DeprecationWarning)
+        warnings.warn(
+            "Property net is deprecated in the GatewayClient.",
+            category=DeprecationWarning,
+        )
         return self._net
 
     async def get_block(

--- a/starknet_py/net/models/chains.py
+++ b/starknet_py/net/models/chains.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import Optional
 
 from starknet_py.common import int_from_bytes
-from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2, Network
 
 
@@ -28,16 +27,3 @@ def chain_from_network(
         raise ValueError("Chain is required when not using predefined networks.")
 
     return chain
-
-
-def default_token_address_for_chain(chain_id: Optional[StarknetChainId] = None) -> str:
-    if chain_id not in [
-        StarknetChainId.TESTNET,
-        StarknetChainId.TESTNET2,
-        StarknetChainId.MAINNET,
-    ]:
-        raise ValueError(
-            "Argument token_address must be specified when using a custom network."
-        )
-
-    return FEE_CONTRACT_ADDRESS

--- a/starknet_py/net/models/chains.py
+++ b/starknet_py/net/models/chains.py
@@ -37,7 +37,7 @@ def default_token_address_for_chain(chain_id: Optional[StarknetChainId] = None) 
         StarknetChainId.MAINNET,
     ]:
         raise ValueError(
-            "Argument token_address must be specified when using a custom net."
+            "Argument token_address must be specified when using a custom network."
         )
 
     return FEE_CONTRACT_ADDRESS

--- a/starknet_py/net/models/chains.py
+++ b/starknet_py/net/models/chains.py
@@ -31,7 +31,7 @@ def chain_from_network(
 
 
 def default_token_address_for_chain(chain_id: Optional[StarknetChainId] = None) -> str:
-    if chain_id is None or chain_id not in [
+    if chain_id not in [
         StarknetChainId.TESTNET,
         StarknetChainId.TESTNET2,
         StarknetChainId.MAINNET,

--- a/starknet_py/net/models/chains.py
+++ b/starknet_py/net/models/chains.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from starknet_py.common import int_from_bytes
+from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2, Network
 
 
@@ -27,3 +28,16 @@ def chain_from_network(
         raise ValueError("Chain is required when not using predefined networks.")
 
     return chain
+
+
+def default_token_address_for_chain(chain_id: Optional[StarknetChainId] = None) -> str:
+    if chain_id is None or chain_id not in [
+        StarknetChainId.TESTNET,
+        StarknetChainId.TESTNET2,
+        StarknetChainId.MAINNET,
+    ]:
+        raise ValueError(
+            "Argument token_address must be specified when using a custom net."
+        )
+
+    return FEE_CONTRACT_ADDRESS

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from starknet_py.net.client_models import (
 )
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models import StarknetChainId
+from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.transaction_exceptions import TransactionRejectedError
 
@@ -23,11 +25,17 @@ from starknet_py.transaction_exceptions import TransactionRejectedError
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
 async def test_get_balance_throws_when_token_not_specified(account):
+    modified_account = Account(
+        address=account.address,
+        client=GatewayClient(net="custom.net"),
+        key_pair=KeyPair(1, 2),
+        chain=cast(StarknetChainId, 1),
+    )
     with pytest.raises(
         ValueError,
-        match="Argument token_address must be specified when using a custom net address",
+        match="Argument token_address must be specified when using a custom net.",
     ):
-        await account.get_balance()
+        await modified_account.get_balance()
 
 
 @pytest.mark.asyncio
@@ -303,7 +311,7 @@ async def test_deploy_account_passes_on_enough_funds(deploy_account_details_fact
 
 @pytest.mark.asyncio
 async def test_deploy_account_uses_custom_calldata(
-    client, deploy_account_details_factory
+    client, deploy_account_details_factory, fee_contract
 ):
     _, key_pair, salt, class_hash = await deploy_account_details_factory.get()
     calldata = [1, 2, 3, 4]
@@ -313,6 +321,11 @@ async def test_deploy_account_uses_custom_calldata(
         constructor_calldata=calldata,
         deployer_address=0,
     )
+
+    res = await fee_contract.functions["transfer"].invoke(
+        recipient=address, amount=int(1e25), max_fee=MAX_FEE
+    )
+    await res.wait_for_acceptance()
 
     deploy_result = await Account.deploy_account(
         address=address,

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -33,7 +33,7 @@ async def test_get_balance_throws_when_token_not_specified(account):
     )
     with pytest.raises(
         ValueError,
-        match="Argument token_address must be specified when using a custom net.",
+        match="Argument token_address must be specified when using a custom network.",
     ):
         await modified_account.get_balance()
 

--- a/starknet_py/tests/e2e/client/gateway_test.py
+++ b/starknet_py/tests/e2e/client/gateway_test.py
@@ -14,9 +14,7 @@ from starknet_py.net.client_models import (
     TransactionStatusResponse,
 )
 from starknet_py.net.gateway_client import GatewayClient
-from starknet_py.net.models.transaction import Declare, Invoke
 from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2, CustomGatewayUrls
-from starknet_py.net.networks import MAINNET, TESTNET, CustomGatewayUrls
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 

--- a/starknet_py/tests/e2e/client/gateway_test.py
+++ b/starknet_py/tests/e2e/client/gateway_test.py
@@ -15,7 +15,7 @@ from starknet_py.net.client_models import (
 )
 from starknet_py.net.gateway_client import GatewayClient
 from starknet_py.net.models.transaction import Declare, Invoke
-from starknet_py.net.networks import MAINNET, TESTNET, CustomGatewayUrls
+from starknet_py.net.networks import MAINNET, TESTNET, TESTNET2, CustomGatewayUrls
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 
 
@@ -138,13 +138,13 @@ async def test_get_transaction_status(invoke_transaction_hash, gateway_client):
     "net, net_address",
     (
         (TESTNET, "https://alpha4.starknet.io"),
+        (TESTNET2, "https://alpha4-2.starknet.io"),
         (MAINNET, "https://alpha-mainnet.starknet.io"),
     ),
 )
 def test_creating_client_from_predefined_network(net, net_address):
     gateway_client = GatewayClient(net=net)
 
-    assert gateway_client.net == net
     assert gateway_client._feeder_gateway_client.url == f"{net_address}/feeder_gateway"
     assert gateway_client._gateway_client.url == f"{net_address}/gateway"
 
@@ -153,7 +153,6 @@ def test_creating_client_with_custom_net():
     custom_net = "custom.net"
     gateway_client = GatewayClient(net=custom_net)
 
-    assert gateway_client.net == custom_net
     assert gateway_client._feeder_gateway_client.url == f"{custom_net}/feeder_gateway"
     assert gateway_client._gateway_client.url == f"{custom_net}/gateway"
 
@@ -167,7 +166,6 @@ def test_creating_client_with_custom_net_dict():
 
     gateway_client = GatewayClient(net=net)
 
-    assert gateway_client.net == net
     assert gateway_client._feeder_gateway_client.url == net["feeder_gateway_url"]
     assert gateway_client._gateway_client.url == net["gateway_url"]
 

--- a/starknet_py/tests/e2e/docs/code_examples/test_account.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_account.py
@@ -29,7 +29,7 @@ def test_init():
     # or
     account = Account(
         address=0x123,
-        client=FullNodeClient(node_url="your.node.url", net="testnet"),
+        client=FullNodeClient(node_url="your.node.url"),
         key_pair=KeyPair(12, 34),
         chain=StarknetChainId.TESTNET,
     )

--- a/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
@@ -5,12 +5,11 @@ from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.hash.storage import get_storage_var_address
 from starknet_py.net.client_models import Call
 from starknet_py.net.full_node_client import FullNodeClient
-from starknet_py.net.networks import TESTNET
 
 
 def test_init():
     # docs-start: init
-    full_node_client = FullNodeClient(node_url="https://your.node.url", net=TESTNET)
+    full_node_client = FullNodeClient(node_url="https://your.node.url")
     # docs-end: init
 
 

--- a/starknet_py/tests/e2e/docs/guide/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/guide/test_full_node_client.py
@@ -1,7 +1,5 @@
 import pytest
 
-from starknet_py.net.networks import TESTNET
-
 
 @pytest.mark.asyncio
 async def test_full_node_client(full_node_client, map_contract):
@@ -12,7 +10,7 @@ async def test_full_node_client(full_node_client, map_contract):
     from starknet_py.net.full_node_client import FullNodeClient
 
     node_url = "https://your.node.url"
-    full_node_client = FullNodeClient(node_url=node_url, net=TESTNET)
+    full_node_client = FullNodeClient(node_url=node_url)
     # docs: end
 
     await map_contract.functions["put"].prepare(key=10, value=10).invoke(

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_full_node_client.py
@@ -1,7 +1,6 @@
 import pytest
 
 from starknet_py.net.client_models import StarknetBlock, Transaction
-from starknet_py.net.networks import TESTNET
 
 
 @pytest.mark.run_on_devnet
@@ -14,7 +13,7 @@ async def test_using_full_node_client(full_node_client, map_contract):
     from starknet_py.net.full_node_client import FullNodeClient
 
     node_url = "https://your.node.url"
-    full_node_client = FullNodeClient(node_url=node_url, net=TESTNET)
+    full_node_client = FullNodeClient(node_url=node_url)
     # docs: end
 
     await map_contract.functions["put"].prepare(key=10, value=10).invoke(

--- a/starknet_py/tests/e2e/fixtures/accounts.py
+++ b/starknet_py/tests/e2e/fixtures/accounts.py
@@ -35,6 +35,7 @@ from starknet_py.tests.e2e.utils import (
 async def devnet_account_details(
     account: BaseAccount,
     class_hash: int,
+    network: str,
 ) -> Tuple[str, str]:
     """
     Deploys an Account and adds fee tokens to its balance (only on devnet).
@@ -50,7 +51,7 @@ async def devnet_account_details(
         deployer_address=0,
     )
 
-    http_client = GatewayHttpClient(account.client.net)
+    http_client = GatewayHttpClient(network)
     await http_client.post(
         method_name="mint",
         payload={
@@ -64,7 +65,7 @@ async def devnet_account_details(
         key_pair=key_pair,
         salt=salt,
         class_hash=class_hash,
-        network=account.client.net,
+        network=network,
     )
 
     account = Account(
@@ -84,6 +85,7 @@ async def address_and_private_key(
     pytestconfig,
     pre_deployed_account_with_validate_deploy: BaseAccount,
     account_with_validate_deploy_class_hash: int,
+    network: str,
 ) -> Tuple[str, str]:
     """
     Returns address and private key of an account, depending on the network.
@@ -102,6 +104,7 @@ async def address_and_private_key(
         return await devnet_account_details(
             pre_deployed_account_with_validate_deploy,
             account_with_validate_deploy_class_hash,
+            network,
         )
     return account_details[net]
 

--- a/starknet_py/tests/e2e/fixtures/clients.py
+++ b/starknet_py/tests/e2e/fixtures/clients.py
@@ -21,7 +21,7 @@ def create_full_node_client(network: str) -> FullNodeClient:
     """
     Creates and returns FullNodeClient.
     """
-    return FullNodeClient(node_url=network + "/rpc", net=network)
+    return FullNodeClient(node_url=network + "/rpc")
 
 
 def net_to_clients() -> List[str]:

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -37,7 +37,7 @@ async def get_deploy_account_details(
     )
 
     res = await fee_contract.functions["transfer"].invoke(
-        recipient=address, amount=int(1e15), max_fee=MAX_FEE
+        recipient=address, amount=int(1e20), max_fee=MAX_FEE
     )
     await res.wait_for_acceptance()
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->

- Client.net is deprecated
- Account.get_balance has chain_id parameter
- net parameter in FullNodeClient's constructor is deprecated


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->


