### PR TITLE
Remove deprecated `client` argument from Contract methods

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -439,9 +439,7 @@ class Contract:
         self,
         address: AddressRepresentation,
         abi: list,
-        provider: Union[BaseAccount, Client] = None,  # pyright: ignore
-        *,
-        client: Optional[Client] = None,
+        provider: Union[BaseAccount, Client],
     ):
         """
         Should be used instead of ``from_address`` when ABI is known statically.
@@ -451,13 +449,8 @@ class Contract:
         :param address: contract's address.
         :param abi: contract's abi.
         :param provider: BaseAccount or Client used to perform transactions.
-        :param client:
-            Client used to perform transactions.
-
-             .. deprecated:: 0.13.0
-                Argument client has been deprecated. Use provider instead.
         """
-        client, account = _unpack_provider(provider, client)
+        client, account = _unpack_provider(provider)
 
         self.account: Optional[BaseAccount] = account
         self.client: Client = client
@@ -481,8 +474,6 @@ class Contract:
         address: AddressRepresentation,
         provider: Union[BaseAccount, Client] = None,  # pyright: ignore
         proxy_config: Union[bool, ProxyConfig] = False,
-        *,
-        client: Optional[Client] = None,
     ) -> Contract:
         """
         Fetches ABI for given contract and creates a new Contract instance with it. If you know ABI statically you
@@ -501,15 +492,10 @@ class Contract:
             If set to ``False``, :meth:`Contract.from_address` will not resolve proxies.
 
             If a valid :class:`starknet_py.contract_abi_resolver.ProxyConfig` is provided, will use its values instead.
-        :param client:
-            Client used to fetch contract.
-
-             .. deprecated:: 0.13.0
-                Argument client has been deprecated. Use provider instead.
 
         :return: an initialized Contract instance.
         """
-        client, account = _unpack_provider(provider, client)
+        client, account = _unpack_provider(provider)
 
         address = parse_address(address)
         proxy_config = Contract._create_proxy_config(proxy_config)
@@ -712,28 +698,14 @@ class Contract:
 
 
 def _unpack_provider(
-    provider: Union[BaseAccount, Client], client: Optional[Client] = None
+    provider: Union[BaseAccount, Client]
 ) -> Tuple[Client, Optional[BaseAccount]]:
     """
     Get the client and optional account to be used by Contract.
 
     If provided with Client, returns this Client and None.
-    If provided with Account, returns underlying Client and the account.
+    If provided with BaseAccount, returns underlying Client and the account.
     """
-    if client is not None:
-        warnings.warn(
-            "Argument client has been deprecated. Use provider instead.",
-            category=DeprecationWarning,
-        )
-
-    if provider is not None and client is not None:
-        raise ValueError("Arguments provider and client are mutually exclusive.")
-
-    if provider is None and client is None:
-        raise ValueError("One of provider or client must be provided.")
-
-    provider = provider or client
-
     if isinstance(provider, Client):
         return provider, None
 

--- a/starknet_py/contract_test.py
+++ b/starknet_py/contract_test.py
@@ -142,18 +142,6 @@ def test_deploy_result_post_init(gateway_client):
         )
 
 
-def test_contract_raises_on_no_provider_and_client():
-    with pytest.raises(ValueError, match="One of provider or client must be provided."):
-        Contract(address=1234, abi=[])
-
-
-def test_contract_raises_on_both_provider_and_client(gateway_account, gateway_client):
-    with pytest.raises(
-        ValueError, match="Arguments provider and client are mutually exclusive."
-    ):
-        Contract(address=1234, abi=[], provider=gateway_account, client=gateway_client)
-
-
 def test_contract_raises_on_incorrect_provider_type():
     with pytest.raises(ValueError, match="Argument provider is not of accepted type."):
         Contract(address=0x1, abi=[], provider=1)  # pyright: ignore
@@ -168,9 +156,5 @@ def test_contract_create_with_base_account(gateway_account):
 
 def test_contract_create_with_client(gateway_client):
     contract = Contract(address=0x1, abi=[], provider=gateway_client)
-    assert contract.account is None
-    assert contract.client == gateway_client
-
-    contract = Contract(address=0x1, abi=[], client=gateway_client)
     assert contract.account is None
     assert contract.client == gateway_client

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -224,10 +224,3 @@ async def test_deploy_contract_flow(account, map_compiled_contract, map_class_ha
 
     assert isinstance(contract.address, int)
     assert len(contract.functions) != 0
-
-
-def test_contract_raises_on_both_client_and_account(gateway_client, gateway_account):
-    with pytest.raises(
-        ValueError, match="Arguments provider and client are mutually exclusive"
-    ):
-        Contract(address=1234, abi=[], client=gateway_client, provider=gateway_account)

--- a/starknet_py/tests/e2e/docs/guide/test_resolving_proxies.py
+++ b/starknet_py/tests/e2e/docs/guide/test_resolving_proxies.py
@@ -16,7 +16,7 @@ from starknet_py.proxy.proxy_check import (
 
 @pytest.mark.asyncio
 async def test_resolving_proxies(
-    gateway_client,
+    account,
     map_contract,
     deploy_proxy_to_contract_exposed,
     deploy_proxy_to_contract_oz_argent,
@@ -29,7 +29,7 @@ async def test_resolving_proxies(
     address = map_contract.address
     # docs-1: start
     # Getting the direct contract from address
-    contract = await Contract.from_address(address=address, client=gateway_client)
+    contract = await Contract.from_address(address=address, provider=account)
 
     # docs-1: end
     address = deploy_proxy_to_contract_oz_argent.deployed_contract.address
@@ -37,7 +37,7 @@ async def test_resolving_proxies(
     # To use contract behind a proxy as a regular contract, set proxy_config to True
     # It will check if your proxy is OpenZeppelin or ArgentX proxy
     contract = await Contract.from_address(
-        address=address, client=gateway_client, proxy_config=True
+        address=address, provider=account, proxy_config=True
     )
 
     # After that contract can be used as usual
@@ -77,7 +77,7 @@ async def test_resolving_proxies(
     address = deploy_proxy_to_contract_exposed.deployed_contract.address
     # docs-2: start
     contract = await Contract.from_address(
-        address=address, client=gateway_client, proxy_config=proxy_config
+        address=address, provider=account, proxy_config=proxy_config
     )
     # docs-2: end
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #632 


## Introduced changes
<!-- A brief description of the changes -->


- 
- 


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->

- Removed `client` argument from `Contract.__init__`
- Removed `client` argument from `Contract.from_address`
