### PR TITLE
Change `NewContractClass` abi type to str

### DIFF
--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -395,7 +395,7 @@ class NewContractClass:
     contract_class_version: str
     sierra_program: List[str]
     entry_points_by_type: NewEntryPointsByType
-    abi: Optional[AbiDictList] = None  # TODO: verify AbiDictList actually works here
+    abi: str
 
 
 @dataclass

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -395,7 +395,7 @@ class NewContractClass:
     contract_class_version: str
     sierra_program: List[str]
     entry_points_by_type: NewEntryPointsByType
-    abi: str
+    abi: Optional[str] = None
 
 
 @dataclass

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -1,7 +1,6 @@
-import json
 from typing import Any, Dict, List
 
-from marshmallow import EXCLUDE, Schema, fields, post_load, pre_load
+from marshmallow import EXCLUDE, Schema, fields, post_load
 from marshmallow_oneofschema import OneOfSchema
 
 from starknet_py.net.client_models import (
@@ -455,14 +454,7 @@ class NewContractClassSchema(Schema):
     entry_points_by_type = fields.Nested(
         NewEntryPointsByTypeSchema(), data_key="entry_points_by_type", required=True
     )
-    abi = fields.List(fields.Dict(), data_key="abi")
-
-    @pre_load
-    def load_abi(self, data, **kwargs):
-        if "abi" in data:
-            data["abi"] = json.loads(data["abi"])
-
-        return data
+    abi = fields.String(data_key="abi")
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> NewContractClass:

--- a/starknet_py/proxy/contract_abi_resolver.py
+++ b/starknet_py/proxy/contract_abi_resolver.py
@@ -94,6 +94,11 @@ class ContractAbiResolver:
         :raises AbiNotFoundError: when abi is not present in contract class at address
         """
         contract_class = await _get_class_at(address=self.address, client=self.client)
+        if isinstance(contract_class, NewContractClass):
+            # TODO: Consider better handling
+            raise ProxyResolutionError(
+                "Proxy resolver does not currently support new Cairo ABIs."
+            )
         if contract_class.abi is None:
             raise AbiNotFoundError()
         return contract_class.abi
@@ -118,6 +123,11 @@ class ContractAbiResolver:
                         address=implementation, client=self.client
                     )
 
+                if isinstance(contract_class, NewContractClass):
+                    # TODO: Consider better handling
+                    raise ProxyResolutionError(
+                        "Proxy resolver does not currently support new Cairo ABIs."
+                    )
                 if contract_class.abi is None:
                     # Some contract_class has been found, but it does not have abi
                     raise AbiNotFoundError()
@@ -174,8 +184,10 @@ class ProxyResolutionError(Exception):
     Error while resolving proxy using ProxyChecks.
     """
 
-    def __init__(self):
-        self.message = "Couldn't resolve proxy using given ProxyChecks."
+    def __init__(
+        self, message: str = "Couldn't resolve proxy using given ProxyChecks."
+    ):
+        self.message = message
         super().__init__(self.message)
 
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->

Sequencer can accept malformed abis that then will be returned as-is. This PR changes type of `NewContractClass` abi to `str` to better reflect this (it is already typed like this in the RPC master branch). We cannot expect the abi to always be correct.


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->


