### PR TITLE
Add block_number to Contract methods

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -256,26 +256,32 @@ class PreparedFunctionCall(Call):
     async def call_raw(
         self,
         block_hash: Optional[str] = None,
+        block_number: Optional[Union[int, Tag]] = None,
     ) -> List[int]:
         """
         Calls a method without translating the result into python values.
 
         :param block_hash: Optional block hash.
+        :param block_number: Optional block number.
         :return: list of ints.
         """
-        return await self._client.call_contract(call=self, block_hash=block_hash)
+        return await self._client.call_contract(
+            call=self, block_hash=block_hash, block_number=block_number
+        )
 
     async def call(
         self,
         block_hash: Optional[str] = None,
+        block_number: Optional[Union[int, Tag]] = None,
     ) -> TupleDataclass:
         """
         Calls a method.
 
         :param block_hash: Optional block hash.
+        :param block_number: Optional block number.
         :return: TupleDataclass representing call result.
         """
-        result = await self.call_raw(block_hash=block_hash)
+        result = await self.call_raw(block_hash=block_hash, block_number=block_number)
         return self._payload_transformer.deserialize(result)
 
     async def invoke(
@@ -387,6 +393,7 @@ class ContractFunction:
         self,
         *args,
         block_hash: Optional[str] = None,
+        block_number: Optional[Union[int, Tag]] = None,
         **kwargs,
     ) -> TupleDataclass:
         """
@@ -395,9 +402,10 @@ class ContractFunction:
         Equivalent of ``.prepare(*args, **kwargs).call()``.
 
         :param block_hash: Block hash to perform the call to the contract at specific point of time.
+        :param block_number: Block number to perform the call to the contract at specific point of time.
         """
         return await self.prepare(max_fee=0, *args, **kwargs).call(
-            block_hash=block_hash
+            block_hash=block_hash, block_number=block_number
         )
 
     async def invoke(

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -167,7 +167,7 @@ async def test_call_contract(client, contract_address):
         calldata=[],
     )
 
-    result = await client.call_contract(call, block_hash="latest")
+    result = await client.call_contract(call, block_number="latest")
 
     assert result == [1234]
 

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -82,7 +82,7 @@ async def test_constructor_arguments_contract_deploy(
         provider=account,
     )
 
-    result = await contract.functions["get"].call(block_hash="latest")
+    result = await contract.functions["get"].call(block_number="latest")
 
     assert result == (
         10,

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract_function.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract_function.py
@@ -15,7 +15,7 @@ async def test_call(map_contract: Contract):
     # docs-start: call
     call_result = map_contract.functions["get"].call(key=10)
     # or when call has to be done at specific block
-    call_result = map_contract.functions["get"].call(key=10, block_hash="latest")
+    call_result = map_contract.functions["get"].call(key=10, block_number="latest")
     # docs-end: call
 
 

--- a/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_call.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_call.py
@@ -8,7 +8,7 @@ from starknet_py.contract import Contract
 async def test_call_raw(map_contract: Contract):
     prepared_function_call = map_contract.functions["get"].prepare(key=10)
     # docs-start: call_raw
-    raw_response = await prepared_function_call.call_raw(block_hash="latest")
+    raw_response = await prepared_function_call.call_raw(block_number="latest")
     # or
     raw_response = await prepared_function_call.call_raw()
     # docs-end: call_raw
@@ -18,7 +18,7 @@ async def test_call_raw(map_contract: Contract):
 async def test_call(map_contract: Contract):
     prepared_function_call = map_contract.functions["get"].prepare(key=10)
     # docs-start: call
-    response = await prepared_function_call.call(block_hash="latest")
+    response = await prepared_function_call.call(block_number="latest")
     # or
     response = await prepared_function_call.call()
     # docs-end: call


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #823 

It would be best to have both `block_number` and `block_hash` as *keyword only* parameters, however it would be breaking.

