### PR TITLE
Remove hardcoded version from `Account.sign_for_fee_estimate`

### DIFF
--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -233,7 +233,7 @@ class Account(BaseAccount):
     async def sign_for_fee_estimate(
         self, transaction: TypeAccountTransaction
     ) -> TypeAccountTransaction:
-        version = self.supported_transaction_version + QUERY_VERSION_BASE
+        version = transaction.version + QUERY_VERSION_BASE
         transaction = dataclasses.replace(transaction, version=version)
 
         signature = self.signer.sign_transaction(transaction)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #842 


## Introduced changes
<!-- A brief description of the changes -->


- `Account.sign_for_fee_estimate` now uses version of transaction + 2**128 instead of using hardcoded supported_transaction_version (1) + 2**128

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


