### PR TITLE
add `sign_declare_v2_transaction` function

### DIFF
--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -98,23 +98,33 @@ class BaseAccount(ABC):
 
     @abstractmethod
     async def sign_declare_transaction(
-        self,
-        compiled_contract: str,
-        *,
-        compiled_class_hash: Optional[int] = None,
-        max_fee: Optional[int] = None,
-        auto_estimate: bool = False,
+            self,
+            compiled_contract: str,
+            *,
+            max_fee: Optional[int] = None,
+            auto_estimate: bool = False,
     ) -> Union[Declare, DeclareV2]:
         """
         Create and sign declare transaction.
 
         :param compiled_contract: string containing a compiled Starknet contract. Supports both new (compiled to sierra)
             and old cairo contracts.
-        :param compiled_class_hash: a class hash of the sierra compiled contract used in the declare transaction.
-            Must be passed only when using new cairo contracts. Computed from casm compiled contract.
         :param max_fee: Max amount of Wei to be paid when executing transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Signed Declare transaction.
+        """
+
+    @abstractmethod
+    async def sign_declare_v2_transaction(
+            self,
+            compiled_contract: str,
+            *,
+            compiled_class_hash,
+            max_fee: Optional[int] = None,
+            auto_estimate: bool = False,
+    ) -> Union[Declare, DeclareV2]:
+        """
+
         """
 
     @abstractmethod


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes 
[#850](https://github.com/software-mansion/starknet.py/issues/850)

## Introduced changes
<!-- A brief description of the changes -->

- removed compiled class hash parameter from `sign_declare_transaction`
- add `sign_declare_v2_transaction` function, which accepts compiled class hash as a parameter and uses `_make_declare_v2_transaction`


## Breaking changes
- `sign_declare_transaction` no longer accepts `compiled_class_hash: Optional[int] = None` as a parameter

After adding three more tests fail after running `poetry run poe test_ci`.
Before:
> 33 failed, 474 passed, 3277 warnings, 33 errors in 160.52s (0:02:40) 

After:
> 36 failed, 471 passed, 3277 warnings, 36 errors in 149.80s (0:02:29) 
