### PR TITLE
Require `setup.py` in sdist build output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ circular_imports_check.shell = "poetry run pytest circular.py"
 requirements_check.shell = "poetry export -f requirements.txt --without-hashes --extras docs | cmp - requirements.txt"
 ci = ["lint", "format_check", "typecheck", "requirements_check", "test_ci"]
 
+[tool.poetry.build]
+generate-setup-file = true
+
 [tool.coverage.run]
 source = ["starknet_py"]
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->


Poetry 1.4.0 no longer includes setup.py in sdist build by default which causes issues when distributing through pypi.
This PR configures the build so setup.py is generated.

https://github.com/python-poetry/poetry-core/pull/318

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


