### PR TITLE
Use newest devnet - set `--cairo-compiler-manifest` option

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -128,7 +128,7 @@ jobs:
 
 
       - name: Build compiler
-        if: cache-rust.cache-hir != true
+        if: cache-rust.cache-hit != true
         working-directory: ./cairo
         run: |
           cargo build
@@ -203,7 +203,7 @@ jobs:
 
 
       - name: Build compiler
-        if: cache-rust.cache-hir != true
+        if: cache-rust.cache-hit != true
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,7 +116,14 @@ jobs:
           persist-credentials: false
           ref: v1.0.0-alpha.6
           path: cairo
+
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+
       - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build
@@ -179,7 +186,14 @@ jobs:
           persist-credentials: false
           ref: v1.0.0-alpha.6
           path: cairo
+
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+
       - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,10 +120,11 @@ jobs:
 
       - name: Cache rust dependencies
         id: cache-rust
+        working-directory: ./cairo
         uses: actions/cache@v3
         with:
           path: |
-            .cairo/target
+            ./target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
@@ -195,10 +196,11 @@ jobs:
 
       - name: Cache rust dependencies
         id: cache-rust
+        working-directory: ./cairo
         uses: actions/cache@v3
         with:
           path: |
-            .cairo/target
+            ./target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,11 +120,10 @@ jobs:
 
       - name: Cache rust dependencies
         id: cache-rust
-        working-directory: ./cairo
         uses: actions/cache@v3
         with:
           path: |
-            ./target
+            .cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
@@ -196,11 +195,10 @@ jobs:
 
       - name: Cache rust dependencies
         id: cache-rust
-        working-directory: ./cairo
         uses: actions/cache@v3
         with:
           path: |
-            ./target
+            .cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Check circular imports
         run: |
           poetry run poe circular_imports_check
+          
 
       - name: Install rust
         run: |
@@ -116,6 +117,20 @@ jobs:
           ref: v1.0.0-alpha.6
           path: cairo
 
+
+      - name: Cache rust dependencies
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: cairo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+
+      - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        working-directory: ./cairo
+        run: |
+          cargo build
       - name: Build starknet-compile
         working-directory: ./cairo
         run: |
@@ -124,6 +139,9 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
+          
+      
+          
 
       - name: Unit & e2e test
         run: |
@@ -167,6 +185,7 @@ jobs:
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         run: |
           poetry run poe compile_contracts
+          
 
       - name: Install rust
         run: |
@@ -179,6 +198,20 @@ jobs:
           ref: v1.0.0-alpha.6
           path: cairo
 
+
+      - name: Cache rust dependencies
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: cairo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+
+      - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        working-directory: ./cairo
+        run: |
+          cargo build
       - name: Build starknet-compile
         working-directory: ./cairo
         run: |
@@ -187,6 +220,7 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
+          
 
       - name: Docs test
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,11 +119,12 @@ jobs:
 
 
       - name: Cache rust dependencies
+        id: rust-cache
         uses: Swatinem/rust-cache@v2
 
 
       - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build
@@ -189,11 +190,12 @@ jobs:
 
 
       - name: Cache rust dependencies
+        id: rust-cache
         uses: Swatinem/rust-cache@v2
 
 
       - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
+        if: steps.rust-cache.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,6 +31,38 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install
+      
+
+      - name: Install rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Clone Cairo1 compiler repository
+        uses: actions/checkout@v3
+        with:
+          repository: starkware-libs/cairo
+          persist-credentials: false
+          ref: v1.0.0-alpha.6
+          path: cairo
+      - name: Cache rust dependencies
+        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        working-directory: ./cairo
+        run: |
+          cargo build
+      - name: Create manifest file
+        run: |
+          readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
 
   lint:
     name: Check lock, formatting, linting and typing

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,9 +120,13 @@ jobs:
         id: cache-rust
         uses: actions/cache@v3
         with:
-          path: cairo
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
 
       - name: Build compiler
         if: steps.cache-rust.outputs.cache-hit != 'true'
@@ -196,7 +200,12 @@ jobs:
         id: cache-rust
         uses: actions/cache@v3
         with:
-          path: cairo
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build compiler

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,38 +31,6 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install
-      
-
-      - name: Install rust
-        run: |
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
-      - name: Clone Cairo1 compiler repository
-        uses: actions/checkout@v3
-        with:
-          repository: starkware-libs/cairo
-          persist-credentials: false
-          ref: v1.0.0-alpha.6
-          path: cairo
-      - name: Cache rust dependencies
-        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-        id: cache-rust
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
-        working-directory: ./cairo
-        run: |
-          cargo build
-      - name: Create manifest file
-        run: |
-          readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
 
   lint:
     name: Check lock, formatting, linting and typing
@@ -136,6 +104,40 @@ jobs:
       - name: Check circular imports
         run: |
           poetry run poe circular_imports_check
+          
+
+      - name: Install rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Clone Cairo1 compiler repository
+        uses: actions/checkout@v3
+        with:
+          repository: starkware-libs/cairo
+          persist-credentials: false
+          ref: v1.0.0-alpha.6
+          path: cairo
+      - name: Cache rust dependencies
+        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        working-directory: ./cairo
+        run: |
+          cargo build
+      - name: Create manifest file
+        run: |
+          readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
+          
+
       - name: Unit & e2e test
         run: |
           poetry run poe test_ci
@@ -178,6 +180,40 @@ jobs:
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         run: |
           poetry run poe compile_contracts
+          
+
+      - name: Install rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Clone Cairo1 compiler repository
+        uses: actions/checkout@v3
+        with:
+          repository: starkware-libs/cairo
+          persist-credentials: false
+          ref: v1.0.0-alpha.6
+          path: cairo
+      - name: Cache rust dependencies
+        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build compiler
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        working-directory: ./cairo
+        run: |
+          cargo build
+      - name: Create manifest file
+        run: |
+          readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
+          
+
       - name: Docs test
         run: |
           poetry run poe test_ci_docs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -128,7 +128,7 @@ jobs:
 
 
       - name: Build compiler
-        if: cache-rust.cache-hit != true
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build
@@ -203,7 +203,7 @@ jobs:
 
 
       - name: Build compiler
-        if: cache-rust.cache-hit != true
+        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,12 +119,19 @@ jobs:
 
 
       - name: Cache rust dependencies
-        id: rust-cache
-        uses: Swatinem/rust-cache@v2
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
       - name: Build compiler
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build
@@ -190,12 +197,19 @@ jobs:
 
 
       - name: Cache rust dependencies
-        id: rust-cache
-        uses: Swatinem/rust-cache@v2
+        id: cache-rust
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
       - name: Build compiler
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            .cairo/target
+            ./cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
@@ -198,7 +198,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            .cairo/target
+            ./cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,20 +116,7 @@ jobs:
           persist-credentials: false
           ref: v1.0.0-alpha.6
           path: cairo
-      - name: Cache rust dependencies
-        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-        id: cache-rust
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build
@@ -192,20 +179,7 @@ jobs:
           persist-credentials: false
           ref: v1.0.0-alpha.6
           path: cairo
-      - name: Cache rust dependencies
-        # Taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-        id: cache-rust
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Check circular imports
         run: |
           poetry run poe circular_imports_check
-          
 
       - name: Install rust
         run: |
@@ -116,7 +115,6 @@ jobs:
           persist-credentials: false
           ref: v1.0.0-alpha.6
           path: cairo
-
 
       - name: Cache rust dependencies
         id: cache-rust
@@ -139,9 +137,6 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
-          
-      
-          
 
       - name: Unit & e2e test
         run: |
@@ -185,7 +180,6 @@ jobs:
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         run: |
           poetry run poe compile_contracts
-          
 
       - name: Install rust
         run: |
@@ -198,14 +192,12 @@ jobs:
           ref: v1.0.0-alpha.6
           path: cairo
 
-
       - name: Cache rust dependencies
         id: cache-rust
         uses: actions/cache@v3
         with:
           path: cairo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
 
       - name: Build compiler
         if: steps.cache-rust.outputs.cache-hit != 'true'
@@ -220,7 +212,6 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
-          
 
       - name: Docs test
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Check circular imports
         run: |
           poetry run poe circular_imports_check
-          
 
       - name: Install rust
         run: |
@@ -117,20 +116,6 @@ jobs:
           ref: v1.0.0-alpha.6
           path: cairo
 
-
-      - name: Cache rust dependencies
-        id: cache-rust
-        uses: actions/cache@v3
-        with:
-          path: cairo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-
-      - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
-        working-directory: ./cairo
-        run: |
-          cargo build
       - name: Build starknet-compile
         working-directory: ./cairo
         run: |
@@ -139,9 +124,6 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
-          
-      
-          
 
       - name: Unit & e2e test
         run: |
@@ -185,7 +167,6 @@ jobs:
         if: steps.cache-contracts.outputs.cache-hit != 'true'
         run: |
           poetry run poe compile_contracts
-          
 
       - name: Install rust
         run: |
@@ -198,20 +179,6 @@ jobs:
           ref: v1.0.0-alpha.6
           path: cairo
 
-
-      - name: Cache rust dependencies
-        id: cache-rust
-        uses: actions/cache@v3
-        with:
-          path: cairo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-
-      - name: Build compiler
-        if: steps.cache-rust.outputs.cache-hit != 'true'
-        working-directory: ./cairo
-        run: |
-          cargo build
       - name: Build starknet-compile
         working-directory: ./cairo
         run: |
@@ -220,7 +187,6 @@ jobs:
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
-          
 
       - name: Docs test
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -123,15 +123,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
+            .cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
       - name: Build compiler
+        if: cache-rust.cache-hir != true
         working-directory: ./cairo
         run: |
           cargo build
@@ -201,15 +198,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
+            .cairo/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
       - name: Build compiler
+        if: cache-rust.cache-hir != true
         working-directory: ./cairo
         run: |
           cargo build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,9 +131,16 @@ jobs:
         working-directory: ./cairo
         run: |
           cargo build
+      - name: Build starknet-compile
+        working-directory: ./cairo
+        run: |
+          cargo run --bin starknet-compile -- --version
+          cargo run --bin starknet-sierra-compile -- --version
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path
+          
+      
           
 
       - name: Unit & e2e test
@@ -205,6 +212,11 @@ jobs:
         working-directory: ./cairo
         run: |
           cargo build
+      - name: Build starknet-compile
+        working-directory: ./cairo
+        run: |
+          cargo run --bin starknet-compile -- --version
+          cargo run --bin starknet-sierra-compile -- --version
       - name: Create manifest file
         run: |
           readlink -f cairo/Cargo.toml >> starknet_py/tests/e2e/manifest-path

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -122,8 +122,7 @@ jobs:
         id: cache-rust
         uses: actions/cache@v3
         with:
-          path: |
-            ./cairo/target
+          path: cairo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 
@@ -197,8 +196,7 @@ jobs:
         id: cache-rust
         uses: actions/cache@v3
         with:
-          path: |
-            ./cairo/target
+          path: cairo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2988,14 +2988,14 @@ test = ["pytest"]
 
 [[package]]
 name = "starknet-devnet"
-version = "0.5.0a0"
+version = "0.5.0a1"
 description = "A local testnet for Starknet"
 category = "dev"
 optional = false
 python-versions = ">=3.9,<3.10"
 files = [
-    {file = "starknet_devnet-0.5.0a0-py3-none-any.whl", hash = "sha256:1c20d52dd8d2d3da16854481ffb255bb5eef04a9d66d9136dca2492aa8a746e6"},
-    {file = "starknet_devnet-0.5.0a0.tar.gz", hash = "sha256:1cee022dedbf2688ece0756db9b5394ef6e31e2d99dde35457808411f03d6792"},
+    {file = "starknet_devnet-0.5.0a1-py3-none-any.whl", hash = "sha256:647fea26262f8d15f9289b8485005eabefafd10e84b025d374407cc4921295ad"},
+    {file = "starknet_devnet-0.5.0a1.tar.gz", hash = "sha256:81399c0e51f137c1b58eeaa3509c4f6f22ab15631f8c0123cc67af428119af77"},
 ]
 
 [package.dependencies]
@@ -3425,4 +3425,4 @@ eth-tester = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.10"
-content-hash = "3237e7adc55469ae82c8b384e0cc86fb6b097424478923e62da12be0366e3396"
+content-hash = "d06fd7318a50c80da769c56fcf629f1098ce8c2330fe109dd96fc74f875fa68a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pyright = "^1.1.298"
 pytest-cov = "^4.0.0"
 isort = "^5.11.4"
 pytest-rerunfailures = "^11.1"
-starknet-devnet = "0.5.0a0"
+starknet-devnet = "0.5.0a1"
 
 [tool.poe.tasks]
 test.shell = "pytest -n auto -v --reruns 10 --only-rerun aiohttp.client_exceptions.ClientConnectorError --cov=starknet_py starknet_py"

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -107,7 +107,7 @@ sierra_compiled_contract = read_contract("precompiled/minimal_contract_compiled.
                 nonce=23,
                 version=1,
             ),
-            1776701039358694529566359362817648865558278416991419471593609530610231748730,
+            1982828244129856379059233231530778257766878379971394245598825266532206245993,
         ),
         (
             DeclareV2(

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -107,7 +107,7 @@ sierra_compiled_contract = read_contract("precompiled/minimal_contract_compiled.
                 nonce=23,
                 version=1,
             ),
-            1982828244129856379059233231530778257766878379971394245598825266532206245993,
+            1776701039358694529566359362817648865558278416991419471593609530610231748730,
         ),
         (
             DeclareV2(

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -15,9 +15,12 @@ async def test_declare_tx(account, map_compiled_contract):
     )
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
-async def test_declare_v2_tx(account, sierra_minimal_compiled_contract_and_class_hash):
+async def test_declare_v2_tx(
+    gateway_account, sierra_minimal_compiled_contract_and_class_hash
+):
+    # TODO: use account when RPC 0.3.0 is supported
+    account = gateway_account
     (
         compiled_contract,
         compiled_class_hash,

--- a/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
+++ b/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
@@ -6,12 +6,13 @@ from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_cairo1_contract(
-    account, sierra_minimal_compiled_contract_and_class_hash, gateway_client
+    gateway_account, sierra_minimal_compiled_contract_and_class_hash, gateway_client
 ):
     # pylint: disable=import-outside-toplevel, too-many-locals
+    # TODO: use account when RPC 0.3.0 is supported
+    account = gateway_account
     (
         compiled_contract,
         compiled_class_hash,

--- a/starknet_py/tests/e2e/fixtures/devnet.py
+++ b/starknet_py/tests/e2e/fixtures/devnet.py
@@ -1,8 +1,10 @@
+import os
 import socket
 import subprocess
 import time
 from contextlib import closing
-from typing import Generator
+from pathlib import Path
+from typing import Generator, List
 
 import pytest
 
@@ -12,6 +14,22 @@ def get_available_port() -> int:
         sock.bind(("", 0))
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return sock.getsockname()[1]
+
+
+def get_compiler_manifest() -> List[str]:
+    """
+    Load manifest-path file and return it as --cairo-compiler-manifest flag to starknet-devnet.
+    To configure manifest locally, install Cairo 1 compiler https://github.com/starkware-libs/cairo
+    and create manifest-path containing a path to top-level Cargo.toml file in cairo 1 compiler directory
+    file from manifest-path.template.
+    """
+    try:
+        manifest_file_path = Path(os.path.dirname(__file__)) / "../manifest-path"
+        manifest = manifest_file_path.read_text("utf-8").splitlines()[0]
+
+        return ["--cairo-compiler-manifest", manifest]
+    except (IndexError, FileNotFoundError):
+        return []
 
 
 def start_devnet():
@@ -29,6 +47,7 @@ def start_devnet():
         str(1),
         "--seed",  # generates same accounts each time
         str(1),
+        *get_compiler_manifest(),
     ]
     # pylint: disable=consider-using-with
     proc = subprocess.Popen(command)

--- a/starknet_py/tests/e2e/manifest-path.template
+++ b/starknet_py/tests/e2e/manifest-path.template
@@ -1,0 +1,1 @@
+path_to_cairo1_compiler/Cargo.toml


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #893 

## Introduced changes
<!-- A brief description of the changes -->

- Setup rust on CI, create manifest-path.template
- Use the newest devnet
- Restore declare_v2 tests


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


