### PR TITLE
fix Deployer to support the value 0 in salt

### DIFF
--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -146,7 +146,7 @@ class Deployer:
         :param raw_calldata: Plain Cairo constructor args of the contract to be deployed.
         :return: NamedTuple with call and address of the contract to be deployed.
         """
-        salt = cast(int, salt or _get_random_salt())
+        salt = cast(int, _get_random_salt() if salt is None else salt)
         class_hash = int_from_hex(class_hash)
 
         calldata = _deployer_serializer.serialize(

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from starknet_py.contract import Contract
+from starknet_py.hash.address import compute_address
 from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.utils.contructor_args_translator import translate_constructor_args
@@ -143,7 +144,7 @@ async def test_create_deployment_call_raw(
     deployer = Deployer(account_address=account.address)
 
     raw_calldata = translate_constructor_args(
-        abi=constructor_with_arguments_abi or [], constructor_args=calldata
+        abi=constructor_with_arguments_abi, constructor_args=calldata
     )
 
     (
@@ -162,3 +163,48 @@ async def test_create_deployment_call_raw(
 
     assert isinstance(contract_address, int)
     assert contract_address != 0
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_call_raw_supports_seed_0(
+    gateway_account,
+    constructor_with_arguments_abi,
+    constructor_with_arguments_class_hash,
+):
+    sample_calldata = {
+        "single_value": 10,
+        "tuple": (1, (2, 3)),
+        "arr": [1, 2, 3],
+        "dict": {"value": 12, "nested_struct": {"value": 99}},
+    }
+    deployer = Deployer()
+
+    raw_calldata = translate_constructor_args(
+        abi=constructor_with_arguments_abi, constructor_args=sample_calldata
+    )
+
+    expected_address = compute_address(
+        class_hash=constructor_with_arguments_class_hash,
+        constructor_calldata=raw_calldata,
+        salt=0,
+    )
+
+    (
+        deploy_call,
+        contract_address,
+    ) = deployer.create_deployment_call_raw(
+        class_hash=constructor_with_arguments_class_hash,
+        raw_calldata=raw_calldata,
+        salt=0,
+    )
+
+    deploy_invoke_transaction = await gateway_account.sign_invoke_transaction(
+        deploy_call, max_fee=MAX_FEE
+    )
+    resp = await gateway_account.client.send_transaction(deploy_invoke_transaction)
+    await gateway_account.client.wait_for_tx(resp.transaction_hash)
+
+    assert isinstance(contract_address, int)
+    assert (
+        contract_address == expected_address
+    ), f"Expected address {expected_address}, got {contract_address}."


### PR DESCRIPTION
## Introduced changes


- Prior to this PR, when sending `salt=0`, the `Deployer` would actually use a random salt.
This PR fixes that by using a random salt only when the salt parameter equals `None`.


##

