### PR TITLE
Remove `compute_invoke_hash`

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -27,5 +27,3 @@ Module containing base models and functions to operate on them.
 
 .. autoenum:: StarknetChainId
     :members:
-
-.. autofunction:: compute_invoke_hash

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -207,7 +207,7 @@ The only supported Python version is 3.9.
 
     - :class:`starknet_py.net.client_models.InvokeTransaction`
     - :class:`starknet_py.net.models.transaction.Invoke`
-    - :func:`starknet_py.net.models.transaction.compute_invoke_hash`
+    - ``compute_invoke_hash``
 13. Replaced ``BlockStateUpdate.state_diff.declared_contract_hashes`` is now a list of ``DeclaredContractHash`` representing new Cairo classes. Old declared contract classes are still available at ``BlockStateUpdate.state_diff.deprecated_declared_contract_hashes``.
 14. Removed ``version`` property from ``PreparedFunctionCall`` class.
 15. Removed deprecated ``max_steps`` in :class:`~starknet_py.proxy.contract_abi_resolver.ProxyConfig`.

--- a/starknet_py/hash/transaction_test.py
+++ b/starknet_py/hash/transaction_test.py
@@ -1,25 +1,20 @@
 import pytest
 
-from starknet_py.common import (
-    create_casm_class,
-    create_compiled_contract,
-    create_sierra_compiled_contract,
-)
-from starknet_py.hash.casm_class_hash import compute_casm_class_hash
+from starknet_py.common import create_compiled_contract
 from starknet_py.hash.transaction import (
     TransactionHashPrefix,
     compute_declare_transaction_hash,
     compute_declare_v2_transaction_hash,
     compute_deploy_account_transaction_hash,
+    compute_invoke_transaction_hash,
     compute_transaction_hash,
 )
 from starknet_py.net.models import StarknetChainId
-from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_COMPILED_V1_DIR
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 
 
 @pytest.mark.parametrize(
-    "data, calculated_hash",
+    "data, expected_hash",
     (
         (
             [TransactionHashPrefix.INVOKE, 2, 3, 4, [5], 6, 7, [8]],
@@ -29,27 +24,44 @@ from starknet_py.tests.e2e.fixtures.misc import read_contract
             [TransactionHashPrefix.L1_HANDLER, 15, 39, 74, [74], 39, 15, [28]],
             1226653506056503634668815848352741482067480791322607584496401451909331743178,
         ),
+        (
+            [
+                TransactionHashPrefix.INVOKE,
+                0x0,
+                0x2A,
+                0x64,
+                [],
+                0x0,
+                StarknetChainId.TESTNET.value,
+            ],
+            0x7D260744DE9D8C55E7675A34512D1951A7B262C79E685D26599EDD2948DE959,
+        ),
     ),
 )
-def test_compute_transaction_hash(data, calculated_hash):
-    assert compute_transaction_hash(*data) == calculated_hash
+def test_compute_transaction_hash(data, expected_hash):
+    assert compute_transaction_hash(*data) == expected_hash
 
 
 @pytest.mark.parametrize(
-    "data, calculated_hash",
+    "data, expected_hash",
     (
         (
-            [2, 3, 4, [5], 6, 7, 8, 9],
-            3319639522829811634906602140344071246050815451799261765214603967516640029516,
-        ),
-        (
-            [12, 23, 34, [45], 56, 67, 78, 89],
-            1704331554042454954615983716430494560849200211800542196314933915246556687567,
+            {
+                "contract_address": 2,
+                "class_hash": 3,
+                "constructor_calldata": [4],
+                "salt": 5,
+                "version": 6,
+                "max_fee": 7,
+                "chain_id": 8,
+                "nonce": 9,
+            },
+            0x6199E956E541CBB06589C4A63C2578A8ED6B697C0FA35B002F48923DFE648EE,
         ),
     ),
 )
-def test_compute_deploy_account_transaction_hash(data, calculated_hash):
-    assert compute_deploy_account_transaction_hash(*data) == calculated_hash
+def test_compute_deploy_account_transaction_hash(data, expected_hash):
+    assert compute_deploy_account_transaction_hash(**data) == expected_hash
 
 
 @pytest.mark.parametrize(
@@ -69,29 +81,41 @@ def test_compute_declare_transaction_hash(contract_json, data):
 
 
 @pytest.mark.parametrize(
-    "sierra_contract_class_source",
-    ["account_compiled", "erc20_compiled", "minimal_contract_compiled"],
+    "data, expected_hash",
+    (
+        (
+            {
+                "class_hash": 2,
+                "sender_address": 3,
+                "version": 4,
+                "max_fee": 5,
+                "chain_id": 6,
+                "nonce": 7,
+                "compiled_class_hash": 8,
+            },
+            0x67EA411072DD2EF3BA36D9680F040A02E599F80F4770E204ECBB2C47C226793,
+        ),
+    ),
 )
-def test_compute_declare_v2_transaction_hash(sierra_contract_class_source):
-    compiled_contract = read_contract(
-        f"{sierra_contract_class_source}.json", directory=CONTRACTS_COMPILED_V1_DIR
-    )
-    compiled_contract_casm = read_contract(
-        f"{sierra_contract_class_source}.casm", directory=CONTRACTS_COMPILED_V1_DIR
-    )
-    casm_class = create_casm_class(compiled_contract_casm)
-    casm_class_hash = compute_casm_class_hash(casm_class)
+def test_compute_declare_v2_transaction_hash(data, expected_hash):
+    assert compute_declare_v2_transaction_hash(**data) == expected_hash
 
-    compiled_contract = create_sierra_compiled_contract(compiled_contract)
 
-    declare_v2_hash = compute_declare_v2_transaction_hash(
-        contract_class=compiled_contract,
-        compiled_class_hash=casm_class_hash,
-        chain_id=StarknetChainId.TESTNET.value,
-        sender_address=0x1,
-        max_fee=2000,
-        version=2,
-        nonce=23,
-    )
-
-    assert declare_v2_hash > 0
+@pytest.mark.parametrize(
+    "data, expected_hash",
+    (
+        (
+            {
+                "sender_address": 3,
+                "version": 4,
+                "calldata": [5],
+                "max_fee": 6,
+                "chain_id": 7,
+                "nonce": 8,
+            },
+            0x505BBF7CD810531C53526631078DAA314BFD036C80C7C6E3A02C608DB8E31DE,
+        ),
+    ),
+)
+def test_compute_invoke_transaction_hash(data, expected_hash):
+    assert compute_invoke_transaction_hash(**data) == expected_hash

--- a/starknet_py/net/models/__init__.py
+++ b/starknet_py/net/models/__init__.py
@@ -7,5 +7,4 @@ from .transaction import (
     DeployAccount,
     Invoke,
     Transaction,
-    compute_invoke_hash,
 )

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -2,44 +2,16 @@ import re
 import typing
 from typing import cast
 
-import pytest
-
-from starknet_py.common import (
-    create_compiled_contract,
-    create_contract_class,
-    create_sierra_compiled_contract,
-)
+from starknet_py.common import create_contract_class
 from starknet_py.net.client_models import TransactionType
-from starknet_py.net.models import StarknetChainId
 from starknet_py.net.models.transaction import (
     Declare,
     DeclareSchema,
-    DeclareV2,
-    DeployAccount,
     Invoke,
     InvokeSchema,
-    compute_invoke_hash,
 )
 from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_COMPILED_V1_DIR
 from starknet_py.tests.e2e.fixtures.misc import read_contract
-
-
-def test_invoke_hash():
-    for selector in [
-        "increase_balance",
-        1530486729947006463063166157847785599120665941190480211966374137237989315360,
-    ]:
-        assert (
-            compute_invoke_hash(
-                entry_point_selector=selector,
-                sender_address=0x03606DB92E563E41F4A590BC01C243E8178E9BA8C980F8E464579F862DA3537C,
-                calldata=[1234],
-                chain_id=StarknetChainId.TESTNET,
-                version=0,
-                max_fee=0,
-            )
-            == 0xD0A52D6E77B836613B9F709AD7F4A88297697FEFBEF1ADA3C59692FF46702C
-        )
 
 
 def test_declare_compress_program(balance_contract):
@@ -71,67 +43,6 @@ compiled_contract = read_contract("erc20_compiled.json")
 sierra_compiled_contract = read_contract(
     "minimal_contract_compiled.json", directory=CONTRACTS_COMPILED_V1_DIR
 )
-
-
-@pytest.mark.parametrize(
-    "transaction, calculated_hash",
-    [
-        (
-            Invoke(
-                sender_address=0x1,
-                calldata=[1, 2, 3],
-                max_fee=10000,
-                signature=[],
-                nonce=23,
-                version=1,
-            ),
-            3484767022419258107070028252604380065385354331198975073942248877262069264133,
-        ),
-        (
-            DeployAccount(
-                class_hash=0x1,
-                contract_address_salt=0x2,
-                constructor_calldata=[1, 2, 3, 4],
-                max_fee=10000,
-                signature=[],
-                nonce=23,
-                version=1,
-            ),
-            1258460340144554539989794559757396219553018532617589681714052999991876798273,
-        ),
-        (
-            Declare(
-                contract_class=create_compiled_contract(
-                    compiled_contract=compiled_contract
-                ),
-                sender_address=123,
-                max_fee=10000,
-                signature=[],
-                nonce=23,
-                version=1,
-            ),
-            548241482519463597399416578757678814995754071952538857702978733086902207659,
-        ),
-        (
-            DeclareV2(
-                contract_class=create_sierra_compiled_contract(
-                    compiled_contract=sierra_compiled_contract
-                ),
-                compiled_class_hash=0x1,
-                max_fee=1000,
-                nonce=20,
-                sender_address=0x1234,
-                signature=[0x1, 0x2],
-                version=2,
-            ),
-            2391287073123315831211443928603796208441862227055564920937005298570351208379,
-        ),
-    ],
-)
-def test_calculate_transaction_hash(transaction, calculated_hash):
-    assert (
-        transaction.calculate_hash(chain_id=StarknetChainId.TESTNET) == calculated_hash
-    )
 
 
 def test_serialize_deserialize_invoke():


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #768 


## Introduced changes
<!-- A brief description of the changes -->


- Remove `compute_invoke_hash`
- Add `compute_invoke_transaction_hash` to `hash.transaction` module
- Refactor tests to make them more isolated from context


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->


