### PR TITLE
Do not mutate `contract_class` in `compute_class_hash`

### DIFF
--- a/starknet_py/hash/class_hash.py
+++ b/starknet_py/hash/class_hash.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import re
 from typing import List
@@ -31,7 +32,7 @@ def compute_class_hash(contract_class: ContractClass) -> int:
     ]
     builtins_hash = compute_hash_on_elements(_encoded_builtins)
 
-    hinted_class_hash = _compute_hinted_class_hash(contract_class)
+    hinted_class_hash = _compute_hinted_class_hash(copy.deepcopy(contract_class))
 
     program_data_hash = compute_hash_on_elements(
         [int(data_, 0) for data_ in contract_class.program["data"]]

--- a/starknet_py/hash/class_hash_test.py
+++ b/starknet_py/hash/class_hash_test.py
@@ -1,5 +1,7 @@
 # pylint: disable=line-too-long
 # fmt: off
+import copy
+
 import pytest
 
 from starknet_py.common import create_contract_class
@@ -21,6 +23,8 @@ from starknet_py.tests.e2e.fixtures.misc import read_contract
 def test_compute_class_hash(contract_source, expected_class_hash):
     compiled_contract = read_contract(contract_source)
     contract_class = create_contract_class(compiled_contract)
+    initial_contract_class = copy.deepcopy(contract_class)
     class_hash = compute_class_hash(contract_class)
 
     assert class_hash == expected_class_hash
+    assert contract_class == initial_contract_class


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Fixed spotted in [kakarot](https://github.com/kkrt-labs/kakarot/pull/588) bug where the `contract_class` would be mutated in `compute_class_hash`


## Introduced changes
<!-- A brief description of the changes -->


- Compute `hinted class hash` on a copy of contract_class


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


