### PR TITLE
 Remove `Deployer.create_deployment_call`

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -30,7 +30,7 @@ Breaking changes
 
 .. currentmodule:: starknet_py.net.udc_deployer.deployer
 
-2. Removed ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
+2. Removed deprecated ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
 
 
 Minor changes

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,26 @@ Migration guide
 ===============
 
 ****************************
+0.17.0 Migration guide
+****************************
+
+Breaking changes
+----------------
+
+.. currentmodule:: starknet_py.net.udc_deployer.deployer
+
+1. Removed ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
+
+
+|
+
+.. raw:: html
+
+  <hr>
+
+|
+
+****************************
 0.17.0-alpha Migration guide
 ****************************
 
@@ -23,14 +43,14 @@ To create an instance of such contract, a keyword parameter ``cairo_version=1`` 
     In such case, please open an issue at our `GitHub <https://github.com/software-mansion/starknet.py/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBUG%5D+%3Ctitle%3E>`_ or contract us on `Starknet Discord server <https://starknet.io/discord>`_ in ``#🐍 | starknet-py`` channel.
 
 
-Breaking changes
-----------------
+0.17.0-alpha Breaking changes
+-----------------------------
 
 1. Deprecated function ``compute_invoke_hash`` in :mod:`starknet_py.net.models.transaction` has been removed in favor of :func:`starknet_py.hash.transaction.compute_invoke_transaction_hash`.
 
 
-Minor changes
--------------
+0.17.0-alpha Minor changes
+--------------------------
 
 1. :meth:`DeclareResult.deploy`, :meth:`PreparedFunctionCall.invoke`, :meth:`PreparedFunctionCall.estimate_fee`, :meth:`ContractFunction.invoke`, :meth:`Contract.declare` and :meth:`Contract.deploy_contract` can now accept custom ``nonce`` parameter.
 
@@ -53,8 +73,8 @@ RPC related changes:
 8. :meth:`FullNodeClient.get_events` ``keys`` parameter can now also accept integers as felts.
 
 
-Bugfixes
---------
+0.17.0-alpha Bugfixes
+---------------------
 
 .. currentmodule:: starknet_py.hash.class_hash
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -1,29 +1,9 @@
 Migration guide
 ===============
 
-****************************
+**********************
 0.17.0 Migration guide
-****************************
-
-Breaking changes
-----------------
-
-.. currentmodule:: starknet_py.net.udc_deployer.deployer
-
-1. Removed ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
-
-
-|
-
-.. raw:: html
-
-  <hr>
-
-|
-
-****************************
-0.17.0-alpha Migration guide
-****************************
+**********************
 
 .. currentmodule:: starknet_py.net.full_node_client
 
@@ -43,14 +23,20 @@ To create an instance of such contract, a keyword parameter ``cairo_version=1`` 
     In such case, please open an issue at our `GitHub <https://github.com/software-mansion/starknet.py/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBUG%5D+%3Ctitle%3E>`_ or contract us on `Starknet Discord server <https://starknet.io/discord>`_ in ``#🐍 | starknet-py`` channel.
 
 
-0.17.0-alpha Breaking changes
------------------------------
+Breaking changes
+----------------
 
 1. Deprecated function ``compute_invoke_hash`` in :mod:`starknet_py.net.models.transaction` has been removed in favor of :func:`starknet_py.hash.transaction.compute_invoke_transaction_hash`.
 
+.. currentmodule:: starknet_py.net.udc_deployer.deployer
 
-0.17.0-alpha Minor changes
---------------------------
+2. Removed ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
+
+
+Minor changes
+-------------
+
+.. currentmodule:: starknet_py.contract
 
 1. :meth:`DeclareResult.deploy`, :meth:`PreparedFunctionCall.invoke`, :meth:`PreparedFunctionCall.estimate_fee`, :meth:`ContractFunction.invoke`, :meth:`Contract.declare` and :meth:`Contract.deploy_contract` can now accept custom ``nonce`` parameter.
 
@@ -73,8 +59,8 @@ RPC related changes:
 8. :meth:`FullNodeClient.get_events` ``keys`` parameter can now also accept integers as felts.
 
 
-0.17.0-alpha Bugfixes
----------------------
+Bugfixes
+--------
 
 .. currentmodule:: starknet_py.hash.class_hash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,13 @@ starknet-devnet = {version = "0.5.4", python = ">=3.9,<3.10"}
 [tool.poe.tasks]
 test.shell = "pytest -n auto -v --reruns 10 --only-rerun aiohttp.client_exceptions.ClientConnectorError --cov=starknet_py starknet_py"
 
-test_ci.shell = "coverage run -m pytest -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
+test_ci = ["test_ci_gateway", "test_ci_full_node"]
 test_ci_gateway.shell = "coverage run -m pytest --client=gateway -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
 test_ci_full_node.shell = "coverage run -m pytest --client=full_node -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
-test_ci_both = ["test_ci_gateway", "test_ci_full_node"]
 
-test_ci_docs.shell = "coverage run -m pytest -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
+test_ci_docs = ["test_ci_docs_gateway", "test_ci_docs_full_node"]
 test_ci_docs_gateway.shell = "coverage run -m pytest --client=gateway -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
 test_ci_docs_full_node.shell = "coverage run -m pytest --client=full_node -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
-test_ci_docs_both = ["test_ci_docs_gateway", "test_ci_docs_full_node"]
 
 test_unit.shell = "pytest -n auto -v starknet_py --ignore=starknet_py/tests/e2e"
 test_e2e.shell = "pytest -n auto -v starknet_py/tests/e2e --ignore=starknet_py/tests/e2e/docs"
@@ -81,7 +79,7 @@ typecheck = "pyright starknet_py"
 compile_contracts = "bash starknet_py/tests/e2e/mock/compile_contracts.sh"
 compile_contracts_v1 = "bash starknet_py/tests/e2e/mock/compile_contracts_v1.sh"
 circular_imports_check.shell = "poetry run pytest circular.py"
-ci = ["lint", "format_check", "typecheck", "test_ci_both"]
+ci = ["lint", "format_check", "typecheck", "test_ci"]
 
 [tool.poetry.build]
 generate-setup-file = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,12 @@ test.shell = "pytest -n auto -v --reruns 10 --only-rerun aiohttp.client_exceptio
 test_ci.shell = "coverage run -m pytest -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
 test_ci_gateway.shell = "coverage run -m pytest --client=gateway -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
 test_ci_full_node.shell = "coverage run -m pytest --client=full_node -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/core"
+test_ci_both = ["test_ci_gateway", "test_ci_full_node"]
 
 test_ci_docs.shell = "coverage run -m pytest -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
 test_ci_docs_gateway.shell = "coverage run -m pytest --client=gateway -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
 test_ci_docs_full_node.shell = "coverage run -m pytest --client=full_node -v --reruns 5 --only-rerun aiohttp.client_exceptions.ClientConnectorError starknet_py/tests/e2e/docs"
+test_ci_docs_both = ["test_ci_docs_gateway", "test_ci_docs_full_node"]
 
 test_unit.shell = "pytest -n auto -v starknet_py --ignore=starknet_py/tests/e2e"
 test_e2e.shell = "pytest -n auto -v starknet_py/tests/e2e --ignore=starknet_py/tests/e2e/docs"
@@ -79,7 +81,7 @@ typecheck = "pyright starknet_py"
 compile_contracts = "bash starknet_py/tests/e2e/mock/compile_contracts.sh"
 compile_contracts_v1 = "bash starknet_py/tests/e2e/mock/compile_contracts_v1.sh"
 circular_imports_check.shell = "poetry run pytest circular.py"
-ci = ["lint", "format_check", "typecheck", "test_ci"]
+ci = ["lint", "format_check", "typecheck", "test_ci_both"]
 
 [tool.poetry.build]
 generate-setup-file = true

--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -55,31 +55,6 @@ class Deployer:
         self.account_address = account_address
         self._unique = account_address is not None
 
-    def create_deployment_call(
-        self,
-        class_hash: Hash,
-        *,
-        salt: Optional[int] = None,
-        abi: Optional[List] = None,
-        calldata: Optional[Union[List, dict]] = None,
-    ) -> ContractDeployment:
-        """
-        Creates deployment call to the UDC contract
-
-         .. deprecated:: 0.15.0
-            Function create_deployment_call is deprecated and will be removed in the future.
-            Use :meth:`create_contract_deployment` instead.
-
-        :param class_hash: The class_hash of the contract to be deployed
-        :param salt: The salt for a contract to be deployed. Random value is selected if it is not provided
-        :param abi: ABI of the contract to be deployed
-        :param calldata: Constructor args of the contract to be deployed
-        :return: NamedTuple with call and address of the contract to be deployed
-        """
-        return self.create_contract_deployment(
-            class_hash, salt=salt, abi=abi, calldata=calldata
-        )
-
     def create_contract_deployment(
         self,
         class_hash: Hash,
@@ -109,29 +84,6 @@ class Deployer:
 
         return self.create_contract_deployment_raw(
             class_hash=class_hash, salt=salt, raw_calldata=raw_calldata
-        )
-
-    def create_deployment_call_raw(
-        self,
-        class_hash: Hash,
-        *,
-        salt: Optional[int] = None,
-        raw_calldata: Optional[List[int]] = None,
-    ) -> ContractDeployment:
-        """
-        Creates deployment call to the UDC contract with plain Cairo calldata
-
-         .. deprecated:: 0.15.0
-            Function create_deployment_call_raw is deprecated and will be removed in the future.
-            Use :meth:`create_contract_deployment_raw` instead.
-
-        :param class_hash: The class_hash of the contract to be deployed
-        :param salt: The salt for a contract to be deployed. Random value is selected if it is not provided
-        :param raw_calldata: Plain Cairo constructor args of the contract to be deployed
-        :return: NamedTuple with call and address of the contract to be deployed
-        """
-        return self.create_contract_deployment_raw(
-            class_hash, salt=salt, raw_calldata=raw_calldata
         )
 
     def create_contract_deployment_raw(

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -585,7 +585,7 @@ async def test_state_update_deployed_contracts(
 ):
     # setup
     deployer = Deployer()
-    contract_deployment = deployer.create_deployment_call(class_hash=class_hash)
+    contract_deployment = deployer.create_contract_deployment(class_hash=class_hash)
     deploy_invoke_tx = await account.sign_invoke_transaction(
         contract_deployment.call, max_fee=MAX_FEE
     )

--- a/starknet_py/tests/e2e/core/fixtures.py
+++ b/starknet_py/tests/e2e/core/fixtures.py
@@ -171,7 +171,7 @@ async def core_map_contract(
     core_declare_map_response: DeclareTransactionResponse,
 ):
     deployer = Deployer()
-    call, address = deployer.create_deployment_call(
+    call, address = deployer.create_contract_deployment(
         core_declare_map_response.class_hash
     )
 

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -12,7 +12,7 @@ from starknet_py.utils.contructor_args_translator import translate_constructor_a
 async def test_default_deploy_with_class_hash(account, map_class_hash):
     deployer = Deployer()
 
-    contract_deployment = deployer.create_deployment_call(class_hash=map_class_hash)
+    contract_deployment = deployer.create_contract_deployment(class_hash=map_class_hash)
 
     deploy_invoke_tx = await account.sign_invoke_transaction(
         contract_deployment.call, max_fee=MAX_FEE
@@ -29,7 +29,9 @@ async def test_throws_when_calldata_provided_without_abi(map_class_hash):
     deployer = Deployer()
 
     with pytest.raises(ValueError, match="calldata was provided without an ABI."):
-        deployer.create_deployment_call(class_hash=map_class_hash, calldata=[12, 34])
+        deployer.create_contract_deployment(
+            class_hash=map_class_hash, calldata=[12, 34]
+        )
 
 
 @pytest.mark.asyncio
@@ -40,7 +42,7 @@ async def test_throws_when_calldata_not_provided(constructor_with_arguments_abi)
         ValueError,
         match="Provided contract has a constructor and no arguments were provided.",
     ):
-        deployer.create_deployment_call(
+        deployer.create_contract_deployment(
             class_hash=1234, abi=constructor_with_arguments_abi
         )
 
@@ -66,7 +68,7 @@ async def test_constructor_arguments_contract_deploy(
 ):
     deployer = Deployer(account_address=account.address)
 
-    deploy_call, contract_address = deployer.create_deployment_call(
+    deploy_call, contract_address = deployer.create_contract_deployment(
         class_hash=constructor_with_arguments_class_hash,
         abi=constructor_with_arguments_abi,
         calldata=calldata,
@@ -106,7 +108,7 @@ async def test_address_computation(salt, pass_account_address, account, map_clas
         # transactions have to be different for each account
         salt += 1
 
-    deploy_call, computed_address = deployer.create_deployment_call(
+    deploy_call, computed_address = deployer.create_contract_deployment(
         class_hash=map_class_hash,
         salt=salt,
     )
@@ -151,7 +153,7 @@ async def test_create_deployment_call_raw(
     (
         deploy_call,
         contract_address,
-    ) = deployer.create_deployment_call_raw(
+    ) = deployer.create_contract_deployment_raw(
         class_hash=constructor_with_arguments_class_hash,
         raw_calldata=raw_calldata,
     )
@@ -194,7 +196,7 @@ async def test_create_deployment_call_raw_supports_seed_0(
     (
         deploy_call,
         contract_address,
-    ) = deployer.create_deployment_call_raw(
+    ) = deployer.create_contract_deployment_raw(
         class_hash=constructor_with_arguments_class_hash,
         raw_calldata=raw_calldata,
         salt=0,

--- a/starknet_py/tests/e2e/docs/code_examples/test_deployer.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_deployer.py
@@ -12,11 +12,11 @@ def test_init():
     # docs-end: init
 
 
-def test_create_deployment_call_raw():
+def test_create_contract_deployment_raw():
     deployer = Deployer()
 
     # docs-start: create_deployment_call_raw
-    contract_deployment = deployer.create_deployment_call_raw(
+    contract_deployment = deployer.create_contract_deployment_raw(
         class_hash=0x123, salt=1, raw_calldata=[3, 1, 2, 3]
     )
     # docs-end: create_deployment_call_raw

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
@@ -13,8 +13,10 @@ async def test_deploying_in_multicall(account, map_class_hash, map_compiled_cont
     # First, create Deployer instance. For more details see previous paragraph
     deployer = Deployer()
 
-    # Create deployment call. We will be deploying the `map` contract
-    deploy_call, address = deployer.create_deployment_call(class_hash=map_class_hash)
+    # Create contract deployment. We will be deploying the `map` contract
+    deploy_call, address = deployer.create_contract_deployment(
+        class_hash=map_class_hash
+    )
     # docs: end
 
     map_abi = create_compiled_contract(compiled_contract=map_compiled_contract).abi

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -29,8 +29,8 @@ async def test_deploying_with_udc(
     deployer = Deployer(account_address=account.address)
 
     # If contract we want to deploy does not have constructor, or the constructor
-    # does not have arguments, abi is not a required parameter of `deployer.create_deployment_call` method
-    deploy_call, address = deployer.create_deployment_call(
+    # does not have arguments, abi is not a required parameter of `deployer.create_contract_deployment` method
+    deploy_call, address = deployer.create_contract_deployment(
         class_hash=map_class_hash, salt=salt
     )
 
@@ -51,9 +51,9 @@ async def test_deploying_with_udc(
     """
 
     # If contract constructor accepts arguments, as shown above,
-    # abi needs to be passed to `deployer.create_deployment_call`
+    # abi needs to be passed to `deployer.create_contract_deployment`
     # Note that this method also returns address of the contract we want to deploy
-    deploy_call, address = deployer.create_deployment_call(
+    deploy_call, address = deployer.create_contract_deployment(
         class_hash=contract_with_constructor_class_hash,
         abi=contract_with_constructor_abi,
         calldata={
@@ -68,7 +68,7 @@ async def test_deploying_with_udc(
     resp = await account.execute(deploy_call, max_fee=int(1e16))
 
     # docs: end
-    deploy_call, _ = deployer.create_deployment_call(
+    deploy_call, _ = deployer.create_contract_deployment(
         class_hash=contract_with_constructor_class_hash,
         abi=contract_with_constructor_abi,
         calldata={


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #925 


## Introduced changes
<!-- A brief description of the changes -->


- Removed `Deployer.create_deployment_call` and `Deployer.create_deployment_call_raw`
- swapped those methods in tests for `Deployer.create_contract_deployment` and `Deployer.create_contract_deployment_raw`
- added 0.17.0 migration guide
- added poetry commands to run both clients one after another


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->

- `Deployer.create_deployment_call` and `Deployer.create_deployment_call_raw` methods have been removed
