### PR TITLE
Remove `supported_transaction_version` property 

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -1,9 +1,9 @@
 Migration guide
 ===============
 
-****************************
-0.17.0-alpha Migration guide
-****************************
+**********************
+0.17.0 Migration guide
+**********************
 
 .. currentmodule:: starknet_py.net.full_node_client
 
@@ -28,9 +28,15 @@ Breaking changes
 
 1. Deprecated function ``compute_invoke_hash`` in :mod:`starknet_py.net.models.transaction` has been removed in favor of :func:`starknet_py.hash.transaction.compute_invoke_transaction_hash`.
 
+.. currentmodule:: starknet_py.net.udc_deployer.deployer
+
+2. Removed ``Deployer.create_deployment_call`` and ``Deployer.create_deployment_call_raw`` in favor of :meth:`Deployer.create_contract_deployment` and :meth:`Deployer.create_contract_deployment_raw`.
+3. Removed ``BaseAccount.supported_transaction_version`` property.
 
 Minor changes
 -------------
+
+.. currentmodule:: starknet_py.contract
 
 1. :meth:`DeclareResult.deploy`, :meth:`PreparedFunctionCall.invoke`, :meth:`PreparedFunctionCall.estimate_fee`, :meth:`ContractFunction.invoke`, :meth:`Contract.declare` and :meth:`Contract.deploy_contract` can now accept custom ``nonce`` parameter.
 

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -100,14 +100,6 @@ class Account(BaseAccount):
     def client(self) -> Client:
         return self._client
 
-    @property
-    def supported_transaction_version(self) -> int:
-        warnings.warn(
-            "Property supported_transaction_version is deprecated and will be removed in the future.",
-            category=DeprecationWarning,
-        )
-        return 1
-
     async def _get_max_fee(
         self,
         transaction: AccountTransaction,

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -35,16 +35,6 @@ class BaseAccount(ABC):
         Get the Client used by the Account.
         """
 
-    @property
-    @abstractmethod
-    def supported_transaction_version(self) -> int:
-        """
-        Get transaction version supported by the account.
-
-            .. deprecated :: 0.15.0
-                Property supported_transaction_version is deprecated and will be removed in the future.
-        """
-
     @abstractmethod
     async def get_nonce(
         self,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #921 


## Introduced changes
<!-- A brief description of the changes -->


- 
- 


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->

- Removed BaseAccount.supported_transaction_version property.

