### PR TITLE
Deprecate `wait_for_accept` parameter 

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -74,6 +74,14 @@ RPC related changes:
 
 9. :class:`StarknetChainId` changed from ``Enum`` to ``IntEnum``.
 
+
+Deprecations
+------------
+.. currentmodule:: starknet_py
+
+1. `wait_for_accept` parameter in :meth:`net.client.Client.wait_for_tx` and :meth:`contract.Contract.wait_for_acceptance` have been deprecated.
+
+
 Bugfixes
 --------
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -79,7 +79,7 @@ Deprecations
 ------------
 .. currentmodule:: starknet_py
 
-1. `wait_for_accept` parameter in :meth:`net.client.Client.wait_for_tx` and :meth:`contract.Contract.wait_for_acceptance` have been deprecated.
+1. `wait_for_accept` parameter in :meth:`net.client.Client.wait_for_tx` and :meth:`contract.SentTransaction.wait_for_acceptance` have been deprecated.
 
 
 Bugfixes

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -77,9 +77,9 @@ RPC related changes:
 
 Deprecations
 ------------
-.. currentmodule:: starknet_py
+.. currentmodule:: starknet_py.net.client
 
-1. `wait_for_accept` parameter in :meth:`net.client.Client.wait_for_tx` and :meth:`contract.SentTransaction.wait_for_acceptance` have been deprecated.
+1. `wait_for_accept` parameter in :meth:`Client.wait_for_tx` and :meth:`SentTransaction.wait_for_acceptance` have been deprecated.
 
 
 Bugfixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ compile_contracts_v1 = "bash starknet_py/tests/e2e/mock/compile_contracts_v1.sh"
 compile_contracts_v2 = "bash starknet_py/tests/e2e/mock/compile_contracts_v2.sh"
 circular_imports_check.shell = "poetry run pytest circular.py"
 ci = ["lint", "format_check", "typecheck", "test_ci"]
+precommit.sequence = ["format", "lint", "typecheck"]
+precommit.ignore_fail = true
 
 [tool.poetry.build]
 generate-setup-file = true

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -117,7 +117,8 @@ class SentTransaction:
     async def wait_for_acceptance(
         self: TypeSentTransaction,
         wait_for_accept: Optional[bool] = None,
-        check_interval=5,
+        check_interval: int = 5,
+        retries: int = 200
     ) -> TypeSentTransaction:
         """
         Waits for transaction to be accepted on chain till ``ACCEPTED`` status.
@@ -132,6 +133,7 @@ class SentTransaction:
         block_number, status = await self._client.wait_for_tx(
             self.hash,
             check_interval=check_interval,
+            retries=retries,
         )
         return dataclasses.replace(
             self,

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -117,7 +117,7 @@ class SentTransaction:
     async def wait_for_acceptance(
         self: TypeSentTransaction,
         wait_for_accept: Optional[bool] = None,
-        check_interval: int = 5,
+        check_interval: float = 5,
         retries: int = 200,
     ) -> TypeSentTransaction:
         """

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Dict, List, Optional, Tuple, TypeVar, Union
@@ -115,17 +116,21 @@ class SentTransaction:
 
     async def wait_for_acceptance(
         self: TypeSentTransaction,
-        wait_for_accept: Optional[bool] = False,
+        wait_for_accept: Optional[bool] = None,
         check_interval=5,
     ) -> TypeSentTransaction:
         """
-        Waits for transaction to be accepted on chain. By default, returns when status is ``PENDING`` -
-        use ``wait_for_accept`` to wait till ``ACCEPTED`` status.
+        Waits for transaction to be accepted on chain till ``ACCEPTED`` status.
         Returns a new SentTransaction instance, **does not mutate original instance**.
         """
+        if wait_for_accept is not None:
+            warnings.warn(
+                "Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted, "
+                "it goes straight into ACCEPTED_ON_L2 status."
+            )
+
         block_number, status = await self._client.wait_for_tx(
             self.hash,
-            wait_for_accept=wait_for_accept,
             check_interval=check_interval,
         )
         return dataclasses.replace(

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -118,7 +118,7 @@ class SentTransaction:
         self: TypeSentTransaction,
         wait_for_accept: Optional[bool] = None,
         check_interval: int = 5,
-        retries: int = 200
+        retries: int = 200,
     ) -> TypeSentTransaction:
         """
         Waits for transaction to be accepted on chain till ``ACCEPTED`` status.

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -126,8 +126,8 @@ class SentTransaction:
         """
         if wait_for_accept is not None:
             warnings.warn(
-                "Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted, "
-                "it goes straight into ACCEPTED_ON_L2 status."
+                "Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING"
+                " block have status ACCEPTED_ON_L2."
             )
 
         block_number, status = await self._client.wait_for_tx(

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -149,7 +149,7 @@ class Client(ABC):
                 Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted,
                 it goes straight into ACCEPTED_ON_L2 status.
         :param check_interval: Defines interval between checks.
-        :param retries: Defines how many times the transaction is checked until an error is thrown
+        :param retries: Defines how many times the transaction is checked until an error is thrown.
         :return: Tuple containing block number and transaction status.
         """
         if check_interval <= 0:

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -154,6 +154,8 @@ class Client(ABC):
         """
         if check_interval <= 0:
             raise ValueError("Argument check_interval has to be greater than 0.")
+        if retries <= 0:
+            raise ValueError("Argument retries has to be greater than 0.")
         if wait_for_accept is not None:
             warnings.warn(
                 "Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted, "

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -137,7 +137,7 @@ class Client(ABC):
         self,
         tx_hash: Hash,
         wait_for_accept: Optional[bool] = None,  # pylint: disable=unused-argument
-        check_interval: float =5,
+        check_interval: float = 5,
         retries: int = 200,
     ) -> Tuple[int, TransactionStatus]:
         # pylint: disable=too-many-branches
@@ -147,8 +147,8 @@ class Client(ABC):
         :param tx_hash: Transaction's hash.
         :param wait_for_accept:
             .. deprecated:: 0.17.0
-                Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted,
-                it goes straight into ACCEPTED_ON_L2 status.
+                Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING
+                block have status ACCEPTED_ON_L2.
         :param check_interval: Defines interval between checks.
         :param retries: Defines how many times the transaction is checked until an error is thrown.
         :return: Tuple containing block number and transaction status.
@@ -159,8 +159,8 @@ class Client(ABC):
             raise ValueError("Argument retries has to be greater than 0.")
         if wait_for_accept is not None:
             warnings.warn(
-                "Parameter `wait_for_accept` and `PENDING` status have been deprecated - if a transaction is accepted, "
-                "it goes straight into ACCEPTED_ON_L2 status."
+                "Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING"
+                " block have status ACCEPTED_ON_L2."
             )
 
         while True:

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -137,7 +137,7 @@ class Client(ABC):
         tx_hash: Hash,
         wait_for_accept: Optional[bool] = None,  # pylint: disable=unused-argument
         check_interval: int = 5,
-        retries: int = 200
+        retries: int = 200,
     ) -> Tuple[int, TransactionStatus]:
         # pylint: disable=too-many-branches
         """

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -175,8 +175,9 @@ class Client(ABC):
                     raise TransactionRejectedError(
                         message=result.rejection_reason,
                     )
-                if status == TransactionStatus.NOT_RECEIVED and retries == 0:
-                    raise TransactionNotReceivedError()
+                if status == TransactionStatus.NOT_RECEIVED:
+                    if retries == 0:
+                        raise TransactionNotReceivedError()
                 elif status != TransactionStatus.RECEIVED:
                     # This will never get executed with current possible transactions statuses
                     raise TransactionFailedError(

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -104,7 +104,7 @@ class L2toL1MessageSchema(Schema):
 
 class TransactionReceiptSchema(Schema):
     hash = Felt(data_key="transaction_hash", required=True)
-    status = StatusField(data_key="status", required=True)
+    status = StatusField(data_key="status", load_default=None)
     block_number = fields.Integer(data_key="block_number", load_default=None)
     block_hash = Felt(data_key="block_hash", load_default=None)
     actual_fee = Felt(data_key="actual_fee", required=True)

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -345,9 +345,7 @@ async def test_deploy_account(client, deploy_account_details_factory, map_contra
         ),
         max_fee=MAX_FEE,
     )
-    _, status = await account.client.wait_for_tx(
-        res.transaction_hash, wait_for_accept=True
-    )
+    _, status = await account.client.wait_for_tx(res.transaction_hash)
 
     assert status in (
         TransactionStatus.ACCEPTED_ON_L1,

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -369,9 +369,7 @@ async def test_wait_for_tx_cancelled(client, get_tx_receipt, request):
             type=TransactionType.INVOKE,
         )
         client = request.getfixturevalue(client)
-        task = asyncio.create_task(
-            client.wait_for_tx(tx_hash=0x1, wait_for_accept=True)
-        )
+        task = asyncio.create_task(client.wait_for_tx(tx_hash=0x1))
         await asyncio.sleep(1)
         task.cancel()
 

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -156,15 +156,6 @@ async def test_get_storage_at_incorrect_address_full_node_client(full_node_clien
         )
 
 
-@pytest.mark.asyncio
-async def test_wait_for_tx_invalid_tx_hash(full_node_client):
-    with pytest.raises(
-        ClientError,
-        match="Nodes can't access pending transactions, try using parameter 'wait_for_accept=True'.",
-    ):
-        _ = await full_node_client.wait_for_tx(tx_hash=0x123456789)
-
-
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
 async def test_get_events_without_following_continuation_token(

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -112,7 +112,7 @@ async def test_prepare_without_max_fee(map_contract):
 @pytest.mark.parametrize("key, value", ((2, 13), (412312, 32134), (12345, 3567)))
 async def test_invoke_and_call(key, value, map_contract):
     invocation = await map_contract.functions["put"].invoke(key, value, max_fee=MAX_FEE)
-    await invocation.wait_for_acceptance(wait_for_accept=True)
+    await invocation.wait_for_acceptance()
     (response,) = await map_contract.functions["get"].call(key)
 
     assert response == value

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -10,9 +10,7 @@ async def test_declare_tx(account, map_compiled_contract):
     )
     result = await account.client.declare(declare_tx)
 
-    await account.client.wait_for_tx(
-        tx_hash=result.transaction_hash, wait_for_accept=True
-    )
+    await account.client.wait_for_tx(tx_hash=result.transaction_hash)
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -25,7 +25,7 @@ async def declare_cairo1_contract(
     assert declare_tx.version == 2
 
     resp = await account.client.declare(declare_tx)
-    await account.client.wait_for_tx(resp.transaction_hash, wait_for_accept=True)
+    await account.client.wait_for_tx(resp.transaction_hash)
 
     return resp.class_hash, resp.transaction_hash
 


### PR DESCRIPTION
## Introduced changes
<!-- A brief description of the changes -->


- `wait_for_accept` parameter in `Client.wait_for_tx` and `Contract.wait_for_acceptance` methods is now deprecated
- added `retries` parameter

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


