### PR TITLE
Change `KeyPair` type from `int` to `Hash`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
           pip install poetry
           python --version
           poetry --version
-          poetry config installer.modern-installation false
+#          poetry config installer.modern-installation false
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,13 +23,9 @@ jobs:
 
       - name: Install poetry
         run: |
-          python --version
           python -m pip install --upgrade pip
-          python --version
-          pip install poetry
-          python --version
-          poetry --version
-#          poetry config installer.modern-installation false
+          pip install poetry==1.5.1
+          poetry config installer.modern-installation false
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,8 +23,12 @@ jobs:
 
       - name: Install poetry
         run: |
+          python --version
           python -m pip install --upgrade pip
+          python --version
           pip install poetry
+          python --version
+          poetry --version
           poetry config installer.modern-installation false
 
       - name: Set up Python 3.9

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -39,10 +39,13 @@ This version of starknet.py brings support Starknet 0.12.1 and `RPC v0.4.0 <http
 
 6. Added fields to dataclasses that previously were missing (e.g. ``contract_address_salt`` in :class:`DeployTransaction`).
 
-.. currentmodule:; starknet_py.cairo.felt
+.. currentmodule:: starknet_py.cairo.felt
 
 7. :func:`decode_shortstring` now is returned without ``\x00`` in front of the decoded string.
 
+.. currentmodule:: starknet_py.net.signer.stark_curve_signer
+
+8. :class:`KeyPair` and :meth:`KeyPair.from_private_key` now can accept keys in string representation.
 
 0.18.0 Bugfixes
 ---------------

--- a/starknet_py/net/signer/stark_curve_signer.py
+++ b/starknet_py/net/signer/stark_curve_signer.py
@@ -32,8 +32,13 @@ class KeyPair:
     def __init__(self, private_key: Hash, public_key: Hash):
         if isinstance(private_key, str):
             self.private_key = int(private_key, 0)
+        else:
+            self.private_key = private_key
+
         if isinstance(public_key, str):
             self.public_key = int(public_key, 0)
+        else:
+            self.public_key = public_key
 
     @staticmethod
     def from_private_key(key: Hash) -> "KeyPair":

--- a/starknet_py/net/signer/stark_curve_signer.py
+++ b/starknet_py/net/signer/stark_curve_signer.py
@@ -11,6 +11,7 @@ from starknet_py.hash.transaction import (
     compute_transaction_hash,
 )
 from starknet_py.hash.utils import message_signature, private_to_stark_key
+from starknet_py.net.client_models import Hash
 from starknet_py.net.models import AddressRepresentation, StarknetChainId, parse_address
 from starknet_py.net.models.transaction import (
     AccountTransaction,
@@ -28,8 +29,16 @@ class KeyPair:
     private_key: int
     public_key: int
 
+    def __init__(self, private_key: Hash, public_key: Hash):
+        if isinstance(private_key, str):
+            self.private_key = int(private_key, 0)
+        if isinstance(public_key, str):
+            self.public_key = int(public_key, 0)
+
     @staticmethod
-    def from_private_key(key: int) -> "KeyPair":
+    def from_private_key(key: Hash) -> "KeyPair":
+        if isinstance(key, str):
+            key = int(key, 0)
         return KeyPair(private_key=key, public_key=private_to_stark_key(key))
 
 

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -57,29 +57,3 @@ def test_sign_transaction(transaction):
     assert len(signature) > 0
     assert all(isinstance(i, int) for i in signature)
     assert all(i != 0 for i in signature)
-
-
-def test_keypair():
-    key_pair = KeyPair(private_key="0x123", public_key="0x456")
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)
-
-    key_pair = KeyPair(private_key="0x123", public_key=0x456)
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)
-
-    key_pair = KeyPair(private_key=0x123, public_key="0x456")
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)
-
-    key_pair = KeyPair(private_key=0x123, public_key=0x456)
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)
-
-    key_pair = KeyPair.from_private_key("0x123")
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)
-
-    key_pair = KeyPair.from_private_key(0x123)
-    assert isinstance(key_pair.public_key, int)
-    assert isinstance(key_pair.private_key, int)

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -57,3 +57,12 @@ def test_sign_transaction(transaction):
     assert len(signature) > 0
     assert all(isinstance(i, int) for i in signature)
     assert all(i != 0 for i in signature)
+
+
+def test_keypair():
+    _ = KeyPair(private_key="0x123", public_key="0x456")
+    _ = KeyPair(private_key="0x123", public_key=0x456)
+    _ = KeyPair(private_key=0x123, public_key="0x456")
+    _ = KeyPair(private_key=0x123, public_key=0x456)
+    _ = KeyPair.from_private_key("0x123")
+    _ = KeyPair.from_private_key(0x123)

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -60,9 +60,26 @@ def test_sign_transaction(transaction):
 
 
 def test_keypair():
-    _ = KeyPair(private_key="0x123", public_key="0x456")
-    _ = KeyPair(private_key="0x123", public_key=0x456)
-    _ = KeyPair(private_key=0x123, public_key="0x456")
-    _ = KeyPair(private_key=0x123, public_key=0x456)
-    _ = KeyPair.from_private_key("0x123")
-    _ = KeyPair.from_private_key(0x123)
+    key_pair = KeyPair(private_key="0x123", public_key="0x456")
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)
+
+    key_pair = KeyPair(private_key="0x123", public_key=0x456)
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)
+
+    key_pair = KeyPair(private_key=0x123, public_key="0x456")
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)
+
+    key_pair = KeyPair(private_key=0x123, public_key=0x456)
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)
+
+    key_pair = KeyPair.from_private_key("0x123")
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)
+
+    key_pair = KeyPair.from_private_key(0x123)
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -57,3 +57,10 @@ def test_sign_transaction(transaction):
     assert len(signature) > 0
     assert all(isinstance(i, int) for i in signature)
     assert all(i != 0 for i in signature)
+
+
+def test_key_pair():
+    key_pair = KeyPair(public_key="0x123", private_key="0x456")
+
+    assert isinstance(key_pair.public_key, int)
+    assert isinstance(key_pair.private_key, int)

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
@@ -25,7 +25,7 @@ async def test_creating_account():
     # There is another way of creating key_pair
     key_pair = KeyPair.from_private_key(key=123)
     # or
-    key_pair = KeyPair.from_private_key(key="123")
+    key_pair = KeyPair.from_private_key(key="0x123")
 
     # Instead of providing key_pair it is possible to specify a signer
     signer = StarkCurveSigner("0x1234", key_pair, StarknetChainId.TESTNET)

--- a/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_creating_account.py
@@ -24,6 +24,8 @@ async def test_creating_account():
 
     # There is another way of creating key_pair
     key_pair = KeyPair.from_private_key(key=123)
+    # or
+    key_pair = KeyPair.from_private_key(key="123")
 
     # Instead of providing key_pair it is possible to specify a signer
     signer = StarkCurveSigner("0x1234", key_pair, StarknetChainId.TESTNET)


### PR DESCRIPTION

<!-- Reference any GitHub issues resolved by this PR -->

Closes #1153


## Introduced changes
<!-- A brief description of the changes -->


- `KeyPair` constructor accepts `Hash` type
- `KeyPair.from_private_key` accepts `Hash` type


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


