### PR TITLE
Add `header_only` parameter to `GatewayClient`'s `get_block`

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -21,6 +21,18 @@ Version 0.18.3 of **starknet.py** comes with support for ...
 1. Support for ``TESTNET2`` network has been removed.
 
 
+0.18.3 Minor changes
+--------------------
+
+.. currentmodule:: starknet_py.net.gateway_client
+
+1. :meth:`GatewayClient.get_block` now accepts ``header_only`` boolean parameter. Method then returns only ``block_hash`` and ``block_number`` inside ``GatewayBlock``.
+
+.. currentmodule:: starknet_py.net.client_models
+
+2. :class:`GatewayBlock` now has all fields optional.
+
+
 |
 
 .. raw:: html

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -334,13 +334,13 @@ class GatewayBlock:
     """
 
     # pylint: disable=too-many-instance-attributes
-    gas_price: int
-    status: BlockStatus
-    transactions: List[Transaction]
-    transaction_receipts: List[GatewayBlockTransactionReceipt]
+    gas_price: Optional[int] = None
+    status: Optional[BlockStatus] = None
+    transactions: Optional[List[Transaction]] = None
+    transaction_receipts: Optional[List[GatewayBlockTransactionReceipt]] = None
 
-    timestamp: int
-    parent_block_hash: int
+    timestamp: Optional[int] = None
+    parent_block_hash: Optional[int] = None
 
     root: Optional[int] = None
     block_number: Optional[int] = None

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -117,13 +117,27 @@ class GatewayClient(Client):
         self,
         block_hash: Optional[Union[Hash, Tag]] = None,
         block_number: Optional[Union[int, Tag]] = None,
+        header_only: bool = False,
     ) -> GatewayBlock:
+        """
+        Retrieve the block's data by its number or hash
+
+        :param block_hash: Block's hash or literals `"pending"` or `"latest"`
+        :param block_number: Block's number or literals `"pending"` or `"latest"`
+        :param header_only: [Gateway-only param] Flag deciding if header (block number and hash)
+            should only be returned.
+        :return: StarknetBlock object representing retrieved block
+        """
         block_identifier = get_block_identifier(
             block_hash=block_hash, block_number=block_number
         )
+        params = {
+            "headerOnly": str(header_only).lower(),
+            **block_identifier,
+        }
 
         res = await self._feeder_gateway_client.call(
-            method_name="get_block", params=block_identifier
+            method_name="get_block", params=params
         )
         return StarknetBlockSchema().load(res, unknown=EXCLUDE)  # pyright: ignore
 

--- a/starknet_py/net/gateway_client.py
+++ b/starknet_py/net/gateway_client.py
@@ -120,7 +120,7 @@ class GatewayClient(Client):
         header_only: bool = False,
     ) -> GatewayBlock:
         """
-        Retrieve the block's data by its number or hash
+        Retrieve the block's data by its number or hash.
 
         :param block_hash: Block's hash or literals `"pending"` or `"latest"`
         :param block_number: Block's number or literals `"pending"` or `"latest"`

--- a/starknet_py/net/schemas/gateway.py
+++ b/starknet_py/net/schemas/gateway.py
@@ -257,24 +257,24 @@ class GatewayBlockTransactionReceiptSchema(Schema):
 
 
 class StarknetBlockSchema(Schema):
-    block_hash = Felt(data_key="block_hash")
-    parent_block_hash = Felt(data_key="parent_block_hash", required=True)
-    block_number = fields.Integer(data_key="block_number")
-    status = BlockStatusField(data_key="status", required=True)
-    root = Felt(data_key="state_root")
+    block_hash = Felt(data_key="block_hash", load_default=None)
+    parent_block_hash = Felt(data_key="parent_block_hash", load_default=None)
+    block_number = fields.Integer(data_key="block_number", load_default=None)
+    status = BlockStatusField(data_key="status", load_default=None)
+    root = Felt(data_key="state_root", load_default=None)
     transactions = fields.List(
         fields.Nested(TypesOfTransactionsSchema(unknown=EXCLUDE)),
         data_key="transactions",
-        required=True,
+        load_default=None,
     )
-    timestamp = fields.Integer(data_key="timestamp", required=True)
+    timestamp = fields.Integer(data_key="timestamp", load_default=None)
     gas_price = Felt(data_key="gas_price", load_default=None)
     sequencer_address = Felt(data_key="sequencer_address", load_default=None)
     starknet_version = fields.String(data_key="starknet_version", load_default=None)
     transaction_receipts = fields.List(
         fields.Nested(GatewayBlockTransactionReceiptSchema()),
         data_key="transaction_receipts",
-        required=True,
+        load_default=None,
     )
 
     @post_load

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -94,6 +94,7 @@ async def test_get_block_by_hash(
     assert len(block.transactions) != 0
 
     if isinstance(block, GatewayBlock):
+        assert block.gas_price is not None
         assert block.gas_price > 0
 
 
@@ -110,6 +111,7 @@ async def test_get_block_by_number(
     assert len(block.transactions) != 0
 
     if isinstance(block, GatewayBlock):
+        assert block.gas_price is not None
         assert block.gas_price > 0
 
 

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -450,3 +450,16 @@ async def test_get_state_update_with_block(gateway_client_integration):
 
     assert res.block == block
     assert res.state_update is not None
+
+
+@pytest.mark.asyncio
+async def test_get_block_header_only(gateway_client_integration):
+    res = await gateway_client_integration.get_block(
+        block_number=300000, header_only=True
+    )
+
+    assert res.block_number is not None
+    assert res.block_hash is not None
+
+    assert res.transactions is None
+    assert res.transaction_receipts is None


### PR DESCRIPTION
## Introduced changes
<!-- A brief description of the changes -->


- `GatewayBlock` dataclass now has all fields optional


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


