### PR TITLE
Fix reverted error message in wait_for_tx

### DIFF
--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -179,7 +179,10 @@ class Client(ABC):
                     raise TransactionRejectedError(message=tx_receipt.rejection_reason)
 
                 if execution_status == TransactionExecutionStatus.REVERTED:
-                    raise TransactionRevertedError(message=tx_receipt.revert_error)
+                    # TODO (#1047): message should be always revert_reason once GatewayClient is deprecated
+                    raise TransactionRevertedError(
+                        message=(tx_receipt.revert_reason or tx_receipt.revert_error)
+                    )
 
                 if execution_status == TransactionExecutionStatus.SUCCEEDED:
                     return tx_receipt

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -66,7 +66,7 @@ async def test_wait_for_tx_reverted_full_node(full_node_account_integration):
     sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
     invoke = await account.client.send_transaction(sign_invoke)
 
-    with pytest.raises(TransactionRevertedError, match=r".*reverted.*"):
+    with pytest.raises(TransactionRevertedError, match="Input too long for arguments"):
         await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
 
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1203


## Introduced changes
<!-- A brief description of the changes -->


- Provide correct error message for both clients in `TransactionRevertedError` in function `wait_for_tx`

Some tests from `tests_ci_on_network` expected to fail at this point. It should be fixed once #1201 is merged.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


