### PR TITLE
Add method to get gas price

### DIFF
--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -24,6 +24,7 @@ from starknet_py.net.client_models import (
     PendingBlockStateUpdate,
     PendingStarknetBlock,
     PendingStarknetBlockWithTxHashes,
+    ResourcePrice,
     SentTransactionResponse,
     SierraContractClass,
     SimulatedTransaction,
@@ -159,6 +160,16 @@ class FullNodeClient(Client):
             StarknetBlockWithTxHashes,
             StarknetBlockWithTxHashesSchema().load(res, unknown=EXCLUDE),
         )
+
+    async def get_gas_price(
+        self,
+        block_hash: Optional[Union[Hash, Tag]] = None,
+        block_number: Optional[Union[int, Tag]] = None,
+    ) -> Optional[ResourcePrice]:
+        # TODO (#1179): remove optional
+        return (
+            await self.get_block(block_hash=block_hash, block_number=block_number)
+        ).l1_gas_price
 
     # TODO (#809): add tests with multiple emitted keys
     async def get_events(

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -8,6 +8,7 @@ from starknet_py.net.client_errors import ClientError
 from starknet_py.net.client_models import (
     Call,
     EstimatedFee,
+    ResourcePrice,
     SignatureOnStateDiff,
     StateUpdateWithBlock,
     TransactionExecutionStatus,
@@ -534,3 +535,12 @@ async def test_get_tx_receipt_new_fields(full_node_client_testnet):
 
     assert receipt.execution_resources is not None
     assert len(receipt.execution_resources.keys()) in [8, 9]
+
+
+@pytest.mark.asyncio
+async def test_get_gas_price(full_node_client_testnet):
+    gas_price = await full_node_client_testnet.get_gas_price(block_number="latest")
+    assert isinstance(gas_price, ResourcePrice)
+    assert gas_price.price_in_strk is None
+    assert gas_price.price_in_wei is not None
+    assert gas_price.price_in_wei > 0


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1140 


## Introduced changes
<!-- A brief description of the changes -->


- Function to get gas price for a given block
- If `block_hash` and `block_number` are not specified then it returns a price for current `pending` block

Note: For now `price_in_strk` is always `None`

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


