### PR TITLE
Remove cairo_version parameter from BaseAccount

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -28,7 +28,7 @@ Version 0.18.3 of **starknet.py** comes with support for RPC 0.5.0!
 
 3. :class:`PendingStarknetBlock` field ``parent_hash`` is now named ``parent_block_hash``.
 4. :class:`FunctionInvocation` fields ``events`` and ``messages`` have been changed from ``List[Event]`` and ``List[L2toL1Message]`` to ``List[OrderedEvent]`` and ``List[OrderedMessage]`` respectively.
-
+5. ``cairo_version`` parameter in :meth:`Account.sign_invoke_transaction` and :meth:`Account.execute` has been removed.
 
 0.18.3 Minor changes
 --------------------

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -272,7 +272,7 @@ class Account(BaseAccount):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False
+        auto_estimate: bool = False,
     ) -> Invoke:
         execute_tx = await self._prepare_invoke(
             calls,
@@ -404,7 +404,7 @@ class Account(BaseAccount):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False
+        auto_estimate: bool = False,
     ) -> SentTransactionResponse:
         execute_transaction = await self.sign_invoke_transaction(
             calls,

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -272,18 +272,8 @@ class Account(BaseAccount):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False,
-        # TODO (#1184): remove that
-        cairo_version: Optional[int] = None,
+        auto_estimate: bool = False
     ) -> Invoke:
-        # TODO (#1184): remove that
-        if cairo_version is not None:
-            warnings.warn(
-                "Parameter 'cairo_version' has been deprecated. It is calculated automatically based on your account's "
-                "contract class.",
-                category=DeprecationWarning,
-            )
-
         execute_tx = await self._prepare_invoke(
             calls,
             nonce=nonce,
@@ -414,18 +404,8 @@ class Account(BaseAccount):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False,
-        # TODO (#1184): remove that
-        cairo_version: Optional[int] = None,
+        auto_estimate: bool = False
     ) -> SentTransactionResponse:
-        # TODO (#1184): remove that
-        if cairo_version is not None:
-            warnings.warn(
-                "Parameter 'cairo_version' has been deprecated. It is calculated automatically based on your account's "
-                "contract class.",
-                category=DeprecationWarning,
-            )
-
         execute_transaction = await self.sign_invoke_transaction(
             calls,
             nonce=nonce,

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -108,7 +108,7 @@ class BaseAccount(ABC):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False
+        auto_estimate: bool = False,
     ) -> Invoke:
         """
         Takes calls and creates signed Invoke.
@@ -194,7 +194,7 @@ class BaseAccount(ABC):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False
+        auto_estimate: bool = False,
     ) -> SentTransactionResponse:
         """
         Takes calls and executes transaction.

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -108,9 +108,7 @@ class BaseAccount(ABC):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False,
-        # TODO (#1184): remove that and docstring
-        cairo_version: Optional[int] = None,
+        auto_estimate: bool = False
     ) -> Invoke:
         """
         Takes calls and creates signed Invoke.
@@ -119,12 +117,6 @@ class BaseAccount(ABC):
         :param nonce: Nonce of the transaction.
         :param max_fee: Max amount of Wei to be paid when executing transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
-        :param cairo_version:
-            Cairo version of the account used.
-
-            .. deprecated:: 0.18.2
-                Parameter `cairo_version` has been deprecated - it is calculated automatically based on
-                your account's contract class.
         :return: Invoke created from the calls.
         """
 
@@ -202,9 +194,7 @@ class BaseAccount(ABC):
         *,
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
-        auto_estimate: bool = False,
-        # TODO (#1184): remove that and docstring
-        cairo_version: Optional[int] = None,
+        auto_estimate: bool = False
     ) -> SentTransactionResponse:
         """
         Takes calls and executes transaction.
@@ -213,12 +203,6 @@ class BaseAccount(ABC):
         :param nonce: Nonce of the transaction.
         :param max_fee: Max amount of Wei to be paid when executing transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
-        :param cairo_version:
-            Cairo version of the account used.
-
-            .. deprecated:: 0.18.2
-                Parameter `cairo_version` has been deprecated - it is calculated automatically based on
-                your account's contract class.
         :return: SentTransactionResponse.
         """
 

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -667,26 +667,3 @@ async def test_argent_cairo1_account_execute(
 
     assert get_balance[0] == value
 
-
-# TODO (#1184): remove that
-@pytest.mark.asyncio
-async def test_cairo1_account_deprecations(
-    deployed_balance_contract,
-    argent_cairo1_account: BaseAccount,
-):
-    call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
-        calldata=[20],
-    )
-    with pytest.warns(
-        DeprecationWarning,
-        match="Parameter 'cairo_version' has been deprecated. It is calculated automatically based on your account's "
-        "contract class.",
-    ):
-        _ = await argent_cairo1_account.execute(
-            calls=call, max_fee=int(1e16), cairo_version=1
-        )
-        _ = await argent_cairo1_account.sign_invoke_transaction(
-            calls=call, max_fee=int(1e16), cairo_version=1
-        )

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -666,4 +666,3 @@ async def test_argent_cairo1_account_execute(
     )
 
     assert get_balance[0] == value
-

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -16,14 +16,8 @@ from starknet_py.net.client_models import (
     TransactionStatus,
 )
 from starknet_py.net.gateway_client import GatewayClient
-from starknet_py.tests.e2e.fixtures.constants import (
-    PREDEPLOYED_EMPTY_CONTRACT_ADDRESS,
-    PREDEPLOYED_MAP_CONTRACT_ADDRESS,
-)
-from starknet_py.transaction_errors import (
-    TransactionRejectedError,
-    TransactionRevertedError,
-)
+from starknet_py.tests.e2e.fixtures.constants import PREDEPLOYED_EMPTY_CONTRACT_ADDRESS
+from starknet_py.transaction_errors import TransactionRevertedError
 
 
 @pytest.mark.parametrize(
@@ -53,7 +47,7 @@ async def test_get_transaction_receipt(client_integration, transaction_hash):
 # Same thing could happen when you run tests locally and then push to run them on CI.
 @pytest.mark.skipif(
     condition="--client=gateway" in sys.argv,
-    reason="Separate FullNode tests from Gateway ones.",
+    reason="Gateway client has been disabled on integration network.",
 )
 @pytest.mark.asyncio
 async def test_wait_for_tx_reverted_full_node(full_node_account_integration):
@@ -71,71 +65,10 @@ async def test_wait_for_tx_reverted_full_node(full_node_account_integration):
         await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
 
 
-@pytest.mark.skipif(
-    condition="--client=full_node" in sys.argv,
-    reason="Separate FullNode tests from Gateway ones.",
-)
-@pytest.mark.asyncio
-async def test_wait_for_tx_reverted_gateway(gateway_account_integration):
-    account = gateway_account_integration
-    # Calldata too long for the function (it has no parameters) to trigger REVERTED status
-    call = Call(
-        to_addr=int(PREDEPLOYED_EMPTY_CONTRACT_ADDRESS, 0),
-        selector=get_selector_from_name("empty"),
-        calldata=[0x1, 0x2, 0x3, 0x4, 0x5],
-    )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
-    invoke = await account.client.send_transaction(sign_invoke)
-
-    with pytest.raises(TransactionRevertedError, match="Input too long for arguments"):
-        await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
-
-
-# No same test for full_node, because nodes don't know about rejected transactions
-# https://community.starknet.io/t/efficient-utilization-of-sequencer-capacity-in-starknet-v0-12-1/95607#api-changes-3
-@pytest.mark.skipif(
-    condition="--client=full_node" in sys.argv,
-    reason="Separate FullNode tests from Gateway ones.",
-)
-@pytest.mark.asyncio
-async def test_wait_for_tx_rejected_gateway(gateway_account_integration):
-    account = gateway_account_integration
-    call = Call(
-        to_addr=int(PREDEPLOYED_MAP_CONTRACT_ADDRESS, 0),
-        selector=get_selector_from_name("put"),
-        calldata=[0x102, 0x125],
-    )
-    call2 = Call(
-        to_addr=int(
-            "0x05cd21d6b3952a869fda11fa9a5bd2657bd68080d3da255655ded47a81c8bd53", 0
-        ),
-        selector=get_selector_from_name("put"),
-        calldata=[0x103, 0x126],
-    )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
-    sign_invoke2 = await account.sign_invoke_transaction(calls=call2, max_fee=int(1e16))
-    # same nonces to trigger REJECTED error
-    assert sign_invoke2.nonce == sign_invoke.nonce
-
-    # this one should pass
-    invoke = await account.client.send_transaction(sign_invoke)
-    # this should be rejected
-    invoke2 = await account.client.send_transaction(sign_invoke2)
-
-    with pytest.raises(TransactionRejectedError):
-        _ = await account.client.wait_for_tx(tx_hash=invoke2.transaction_hash)
-
-    invoke2_receipt = await account.client.get_transaction_receipt(
-        tx_hash=invoke2.transaction_hash
-    )
-
-    assert invoke2_receipt.execution_status == TransactionExecutionStatus.REJECTED
-
-
 # Same here as in comment above 'test_wait_for_tx_reverted_full_node'
 @pytest.mark.skipif(
     condition="--client=gateway" in sys.argv,
-    reason="Separate FullNode tests from Gateway ones.",
+    reason="Gateway client has been disabled on integration network.",
 )
 @pytest.mark.asyncio
 async def test_wait_for_tx_full_node_accepted(full_node_account_integration):
@@ -155,26 +88,9 @@ async def test_wait_for_tx_full_node_accepted(full_node_account_integration):
 
 
 @pytest.mark.skipif(
-    condition="--client=full_node" in sys.argv,
-    reason="Separate FullNode tests from Gateway ones.",
+    condition="--client=gateway" in sys.argv,
+    reason="Gateway client has been disabled on integration network.",
 )
-@pytest.mark.asyncio
-async def test_wait_for_tx_gateway_accepted(gateway_account_integration):
-    account = gateway_account_integration
-    call = Call(
-        to_addr=int(PREDEPLOYED_EMPTY_CONTRACT_ADDRESS, 0),
-        selector=get_selector_from_name("empty"),
-        calldata=[],
-    )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
-    invoke = await account.client.send_transaction(sign_invoke)
-
-    result = await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
-
-    assert result.execution_status == TransactionExecutionStatus.SUCCEEDED
-    assert result.finality_status == TransactionFinalityStatus.ACCEPTED_ON_L2
-
-
 @pytest.mark.asyncio
 async def test_transaction_not_received_max_fee_too_small(account_integration):
     account = account_integration
@@ -192,6 +108,10 @@ async def test_transaction_not_received_max_fee_too_small(account_integration):
         _ = await account.client.send_transaction(sign_invoke)
 
 
+@pytest.mark.skipif(
+    condition="--client=gateway" in sys.argv,
+    reason="Gateway client has been disabled on integration network.",
+)
 @pytest.mark.asyncio
 async def test_transaction_not_received_max_fee_too_big(account_integration):
     account = account_integration
@@ -209,6 +129,10 @@ async def test_transaction_not_received_max_fee_too_big(account_integration):
         _ = await account.client.send_transaction(sign_invoke)
 
 
+@pytest.mark.skipif(
+    condition="--client=gateway" in sys.argv,
+    reason="Gateway client has been disabled on integration network.",
+)
 @pytest.mark.asyncio
 async def test_transaction_not_received_invalid_nonce(account_integration):
     account = account_integration
@@ -225,6 +149,10 @@ async def test_transaction_not_received_invalid_nonce(account_integration):
         _ = await account.client.send_transaction(sign_invoke)
 
 
+@pytest.mark.skipif(
+    condition="--client=gateway" in sys.argv,
+    reason="Gateway client has been disabled on integration network.",
+)
 @pytest.mark.asyncio
 async def test_transaction_not_received_invalid_signature(account_integration):
     account = account_integration


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1184 


## Introduced changes
<!-- A brief description of the changes -->

- Remove `cairo_version` from `BaseAccount.execute` and `BaseAccount.sign_invoke_transaction`
- Remove/skip some gateway tests in `tests_on_networks` because the gateway feeder has been disabled on integration network, it is related to #1047 

Note: A slight decrease in code coverage is expected.

##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->


