### PR TITLE
output error data on RPC exception

### DIFF
--- a/starknet_py/net/http_client.py
+++ b/starknet_py/net/http_client.py
@@ -80,7 +80,8 @@ class RpcHttpClient(HttpClient):
         if "error" not in result:
             raise ServerError(body=result)
         raise ClientError(
-            code=result["error"]["code"], message=result["error"]["message"]
+            code=result["error"]["code"],
+            message=f'{result["error"]["message"]}, {result["error"].get("data","")}',
         )
 
     async def handle_request_error(self, request: ClientResponse):


### PR DESCRIPTION
## Introduced changes
Also output error data on RPC errors to include useful error as for why a transaction failed. Current message is generic and does not provide any information besides the fact that the transaction has failed.