### PR TITLE
Support RPC v0.6.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,9 @@
 name: Checks
 
 env:
-  STARKNET_VERSION: "0.12.3"
-  RPC_SPEC_VERSION: "0.5.1"
-  DEVNET_SHA: "78527de"
+  STARKNET_VERSION: "0.13.0"
+  RPC_SPEC_VERSION: "0.6.0"
+  DEVNET_SHA: "1bd447d"
 
 on:
   push:

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -16,13 +16,22 @@ Module containing base models and functions to operate on them.
 .. autoclass:: DeployAccountV1
     :exclude-members: __init__, __new__
 
+.. autoclass:: DeployAccountV3
+    :exclude-members: __init__, __new__
+
 .. autoclass:: DeclareV1
     :exclude-members: __init__, __new__
 
 .. autoclass:: DeclareV2
     :exclude-members: __init__, __new__
 
+.. autoclass:: DeclareV3
+    :exclude-members: __init__, __new__
+
 .. autoclass:: InvokeV1
+    :exclude-members: __init__, __new__
+
+.. autoclass:: InvokeV3
     :exclude-members: __init__, __new__
 
 .. autoenum:: StarknetChainId

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -13,16 +13,16 @@ Module containing base models and functions to operate on them.
     :exclude-members: __init__, __new__
     :members:
 
-.. autoclass:: DeployAccount
+.. autoclass:: DeployAccountV1
     :exclude-members: __init__, __new__
 
-.. autoclass:: Declare
+.. autoclass:: DeclareV1
     :exclude-members: __init__, __new__
 
 .. autoclass:: DeclareV2
     :exclude-members: __init__, __new__
 
-.. autoclass:: Invoke
+.. autoclass:: InvokeV1
     :exclude-members: __init__, __new__
 
 .. autoenum:: StarknetChainId

--- a/docs/guide/deploying_contracts.rst
+++ b/docs/guide/deploying_contracts.rst
@@ -77,8 +77,8 @@ Declaring Cairo1 contracts
 
 | Starknet 0.11 introduced the ability to declare contracts written in Cairo1!
 
-To declare a new contract, Declare v2 transaction has to be sent.
-You can see the structure of the new Declare transaction `here <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#declare_v2>`_.
+To declare a new contract, Declare v2 or Declare v3 transaction has to be sent.
+You can see the structure of these transactions `here <https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/transactions/#declare-transaction>`_.
 
 The main differences in the structure of the transaction from its previous version are:
  - ``contract_class`` field is a ``SierraContractClass``

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,6 +5,43 @@ Migration guide
 0.19.0 Migration guide
 **********************
 
+Version 0.19.0 of **starknet.py** comes with support for RPC 0.6.0!
+
+.. currentmodule:: starknet_py.net.client_models
+
+New classes added to mirror the recent changes in the RPC v0.6.0 specification include:
+:class:`ResourceBoundsMapping`, :class:`ResourceBounds`, :class:`PriceUnit`, :class:`FeePayment`, :class:`DAMode`.
+
+Changes in the :class:`~starknet_py.net.account.account.Account`:
+
+.. currentmodule:: starknet_py.net.account.account
+
+- :meth:`~Account.execute_v3` has been added.
+- :meth:`~Account.sign_declare_v3_transaction`, :meth:`~Account.sign_deploy_account_v3_transaction` and :meth:`~Account.sign_invoke_v3_transaction` have been added.
+- :meth:`~Account.sign_declare_transaction`, :meth:`~Account.sign_deploy_account_transaction` and :meth:`~Account.sign_invoke_transaction` have been renamed to :meth:`~Account.sign_declare_v1_transaction`, :meth:`~Account.sign_deploy_account_v1_transaction` and :meth:`~Account.sign_invoke_v1_transaction` respectively.
+
+All new functions with ``v3`` in their name operate similarly to their ``v1`` and ``v2`` counterparts.
+Unlike their ``v1`` counterparts, ``v3`` transaction fees are paid in Fri (10^-18 STRK). Therefore,  ``max_fee`` parameter, which is typically set in Wei, is not applicable for ``v3`` functions. Instead, ``l1_resource_bounds`` parameter is utilized to limit the Fri amount used.
+
+Changes in the :class:`~starknet_py.net.full_node_client.FullNodeClient`:
+
+.. currentmodule:: starknet_py.net.full_node_client
+
+- :meth:`~FullNodeClient.estimate_fee` has a new parameter ``skip_validate``.
+- :meth:`~FullNodeClient.declare` accepts ``transaction`` argument of the type :class:`~starknet_py.net.models.transaction.DeclareV3`
+- :meth:`~FullNodeClient.send_transaction` accepts ``transaction`` argument of the type :class:`~starknet_py.net.models.transaction.InvokeV3`
+- :meth:`~FullNodeClient.deploy_account` accepts ``transaction`` argument of the type :class:`~starknet_py.net.models.transaction.DeployAccountV3`
+
+.. warning::
+    :class:`~starknet_py.contract.Contract` class does not support V3 transactions in the pre-release.
+
+
+0.19.0 Targeted versions
+------------------------
+
+- Starknet - `0.13.0 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.0>`_
+- RPC - `0.6.0 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.6.0>`_
+
 0.19.0 Breaking changes
 -----------------------
 
@@ -12,15 +49,27 @@ Migration guide
 
 1. :class:`GatewayClient` all related classes and fields have been removed.
 2. Client ``net`` property has been removed.
-3. :class:`TransactionReceipt` field ``execution_resources`` has been changed from ``dict`` to :class:`ExecutionResources`.
-4. :class:`TransactionReceipt` fields ``status`` and ``rejection_reason`` have been removed.
-5. :class:`TransactionStatus`, :class:`TransactionExecutionStatus` and :class:`TransactionFinalityStatus` have been changed to have the same structure as in RPC specification.
+3. :class:`Declare`, :class:`DeployAccount` and :class:`Invoke` have been renamed to :class:`~starknet_py.net.models.transaction.DeclareV1`, :class:`~starknet_py.net.models.transaction.DeployAccountV1` and :class:`~starknet_py.net.models.transaction.InvokeV1` respectively.
+4. :class:`TransactionReceipt` field ``execution_resources`` has been changed from ``dict`` to :class:`ExecutionResources`.
+5. :class:`TransactionReceipt` fields ``status`` and ``rejection_reason`` have been removed.
+6. :class:`TransactionStatus`, :class:`TransactionExecutionStatus` and :class:`TransactionFinalityStatus` have been changed to have the same structure as in RPC specification.
+7. :class:`EstimatedFee` has a new required field ``unit``.
+8. :class:`EstimatedFee` field ``gas_usage`` has been renamed to ``gas_consumed``.
+9. :class:`FunctionInvocation` has a new required field ``execution_resources``.
+10. :class:`ResourcePrice` field ``price_in_strk`` has been renamed to ``price_in_fri`` and has now become required.
+11. :class:`ResourceLimits` class has been renamed to :class:`ResourceBounds`.
 
 0.19.0 Minor changes
 --------------------
 
 1. :class:`L1HandlerTransaction` field ``nonce`` is now required.
-2. :class:`TransactionReceipt` fields ``finality_status``, ``execution_status`` and ``execution_resources`` are now required.
+2. :class:`TransactionReceipt` fields ``actual_fee``, ``finality_status``, ``execution_status``, ``execution_resources`` and ``type`` are now required.
+
+0.19.0 Development-related changes
+----------------------------------
+
+Test execution has been transitioned to the new `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_.
+To adapt to this change, it should be installed locally and added to the ``PATH``. Further information regarding this change can be found in the `Development <https://starknetpy.readthedocs.io/en/latest/development.html>`_ section.
 
 **********************
 0.18.3 Migration guide

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -34,7 +34,7 @@ from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client import Client
 from starknet_py.net.client_models import Call, EstimatedFee, Hash, Tag
-from starknet_py.net.models import AddressRepresentation, Invoke, parse_address
+from starknet_py.net.models import AddressRepresentation, InvokeV1, parse_address
 from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.proxy.contract_abi_resolver import (
     ContractAbiResolver,
@@ -153,7 +153,7 @@ class InvokeResult(SentTransaction):
     contract: ContractData = None  # pyright: ignore
     """Additional information about the Contract that made the transaction."""
 
-    invoke_transaction: Invoke = None  # pyright: ignore
+    invoke_transaction: InvokeV1 = None  # pyright: ignore
     """A InvokeTransaction instance used."""
 
     def __post_init__(self):

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -357,7 +357,7 @@ class PreparedFunctionCall(Call):
         if max_fee is not None:
             self.max_fee = max_fee
 
-        transaction = await self._account.sign_invoke_transaction(
+        transaction = await self._account.sign_invoke_v1_transaction(
             calls=self,
             nonce=nonce,
             max_fee=self.max_fee,
@@ -391,7 +391,7 @@ class PreparedFunctionCall(Call):
         :param nonce: Nonce of the transaction.
         :return: Estimated amount of Wei executing specified transaction will cost.
         """
-        tx = await self._account.sign_invoke_transaction(
+        tx = await self._account.sign_invoke_v1_transaction(
             calls=self, nonce=nonce, max_fee=0
         )
 
@@ -668,7 +668,7 @@ class Contract:
             )
         else:
             cairo_version = 0
-            declare_tx = await account.sign_declare_transaction(
+            declare_tx = await account.sign_declare_v1_transaction(
                 compiled_contract=compiled_contract,
                 nonce=nonce,
                 max_fee=max_fee,

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -312,13 +312,9 @@ def compute_declare_v2_transaction_hash(
     :param nonce: Nonce of the transaction.
     :return: Hash of the transaction.
     """
-    if contract_class is None and class_hash is None:
-        raise ValueError("Either contract_class or class_hash is required.")
-    if contract_class is not None and class_hash is not None:
-        raise ValueError("Both contract_class and class_hash passed.")
-
     if class_hash is None:
-        assert contract_class is not None
+        if contract_class is None:
+            raise ValueError("Either contract_class or class_hash is required.")
         class_hash = compute_sierra_class_hash(contract_class)
 
     return compute_transaction_hash(

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -53,7 +53,7 @@ class CommonTransactionV3Fields:
             self.tx_prefix,
             self.version,
             self.address,
-            poseidon_hash_many(tip, self.compute_resource_bounds_for_fee()),
+            poseidon_hash_many([self.tip, *self.compute_resource_bounds_for_fee()]),
             poseidon_hash_many(self.paymaster_data),
             self.chain_id,
             self.nonce,
@@ -178,7 +178,7 @@ def compute_invoke_v3_transaction_hash(
 ) -> int:
     return poseidon_hash_many(
         [
-            *common_fields.get_common_tx_fields(),
+            *common_fields.compute_common_tx_fields(),
             poseidon_hash_many(account_deployment_data),
             poseidon_hash_many(calldata),
         ]
@@ -229,7 +229,7 @@ def compute_deploy_account_v3_transaction_hash(
 ) -> int:
     return poseidon_hash_many(
         [
-            *common_fields.get_common_tx_fields(),
+            *common_fields.compute_common_tx_fields(),
             poseidon_hash_many(constructor_calldata),
             class_hash,
             contract_address_salt,
@@ -330,7 +330,7 @@ def compute_declare_v3_transaction_hash(
 
     return poseidon_hash_many(
         [
-            *common_fields.get_common_tx_fields(),
+            *common_fields.compute_common_tx_fields(),
             poseidon_hash_many(account_deployment_data),
             class_hash,
             compiled_class_hash,

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -53,14 +53,14 @@ class CommonTransactionV3Fields:
             self.tx_prefix,
             self.version,
             self.address,
-            self.compute_tip_resource_bounds_hash(),
+            poseidon_hash_many(tip, self.compute_resource_bounds_for_fee()),
             poseidon_hash_many(self.paymaster_data),
             self.chain_id,
             self.nonce,
             self.get_data_availability_modes(),
         ]
 
-    def compute_tip_resource_bounds_hash(self) -> int:
+    def compute_resource_bounds_for_fee(self) -> List[int]:
         l1_gas_bounds = (
             (L1_GAS_ENCODED << (128 + 64))
             + (self.resource_bounds.l1_gas.max_amount << 128)
@@ -73,7 +73,7 @@ class CommonTransactionV3Fields:
             + self.resource_bounds.l2_gas.max_price_per_unit
         )
 
-        return poseidon_hash_many([self.tip, l1_gas_bounds, l2_gas_bounds])
+        return [l1_gas_bounds, l2_gas_bounds]
 
     def get_data_availability_modes(self) -> int:
         return (

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -48,7 +48,7 @@ class CommonTransactionV3Fields:
     nonce_data_availability_mode: DAMode
     fee_data_availability_mode: DAMode
 
-    def get_common_tx_fields(self):
+    def compute_common_tx_fields(self):
         return [
             self.tx_prefix,
             self.version,

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -180,7 +180,7 @@ def compute_invoke_v3_transaction_hash(
     Computes hash of an Invoke transaction version 3.
 
     :param account_deployment_data: This will contain the class_hash, salt, and the calldata needed for the constructor.
-    Currently, this value is always empty.
+        Currently, this value is always empty.
     :param calldata: Calldata of the function.
     :param common_fields: Common fields for V3 transactions.
     :return: Hash of the transaction.
@@ -343,7 +343,7 @@ def compute_declare_v3_transaction_hash(
     :param contract_class: SierraContractClass of the contract.
     :param class_hash: Class hash of the contract.
     :param account_deployment_data: This will contain the class_hash and the calldata needed for the constructor.
-    Currently, this value is always empty.
+        Currently, this value is always empty.
     :param compiled_class_hash: Compiled class hash of the program.
     :param common_fields: Common fields for V3 transactions.
     :return: Hash of the transaction.

--- a/starknet_py/hash/transaction.py
+++ b/starknet_py/hash/transaction.py
@@ -148,7 +148,7 @@ def compute_invoke_transaction_hash(
     nonce: int,
 ) -> int:
     """
-    Computes hash of the Invoke transaction.
+    Computes hash of an Invoke transaction.
 
     :param version: The transaction's version.
     :param sender_address: Sender address.
@@ -176,6 +176,15 @@ def compute_invoke_v3_transaction_hash(
     calldata: List[int],
     common_fields: CommonTransactionV3Fields,
 ) -> int:
+    """
+    Computes hash of an Invoke transaction version 3.
+
+    :param account_deployment_data: This will contain the class_hash, salt, and the calldata needed for the constructor.
+    Currently, this value is always empty.
+    :param calldata: Calldata of the function.
+    :param common_fields: Common fields for V3 transactions.
+    :return: Hash of the transaction.
+    """
     return poseidon_hash_many(
         [
             *common_fields.compute_common_tx_fields(),
@@ -196,7 +205,7 @@ def compute_deploy_account_transaction_hash(
     chain_id: int,
 ) -> int:
     """
-    Computes hash of the DeployAccount transaction.
+    Computes hash of a DeployAccount transaction.
 
     :param version: The transaction's version.
     :param contract_address: Contract address.
@@ -227,6 +236,15 @@ def compute_deploy_account_v3_transaction_hash(
     contract_address_salt: int,
     common_fields: CommonTransactionV3Fields,
 ) -> int:
+    """
+    Computes hash of a DeployAccount transaction version 3.
+
+    :param class_hash: The class hash of the contract.
+    :param constructor_calldata: Constructor calldata of the contract.
+    :param contract_address_salt: A random salt that determines the account address.
+    :param common_fields: Common fields for V3 transactions.
+    :return: Hash of the transaction.
+    """
     return poseidon_hash_many(
         [
             *common_fields.compute_common_tx_fields(),
@@ -246,7 +264,7 @@ def compute_declare_transaction_hash(
     nonce: int,
 ) -> int:
     """
-    Computes hash of the Declare transaction.
+    Computes hash of a Declare transaction.
 
     :param contract_class: ContractClass of the contract.
     :param chain_id: The network's chain ID.
@@ -282,11 +300,11 @@ def compute_declare_v2_transaction_hash(
     nonce: int,
 ) -> int:
     """
-    Computes class hash of declare transaction version 2.
+    Computes class hash of a Declare transaction version 2.
 
     :param contract_class: SierraContractClass of the contract.
     :param class_hash: Class hash of the contract.
-    :param compiled_class_hash: compiled class hash of the program.
+    :param compiled_class_hash: Compiled class hash of the program.
     :param chain_id: The network's chain ID.
     :param sender_address: Address which sends the transaction.
     :param max_fee: The transaction's maximum fee.
@@ -323,6 +341,17 @@ def compute_declare_v3_transaction_hash(
     compiled_class_hash: int,
     common_fields: CommonTransactionV3Fields,
 ) -> int:
+    """
+    Computes class hash of a Declare transaction version 3.
+
+    :param contract_class: SierraContractClass of the contract.
+    :param class_hash: Class hash of the contract.
+    :param account_deployment_data: This will contain the class_hash and the calldata needed for the constructor.
+    Currently, this value is always empty.
+    :param compiled_class_hash: Compiled class hash of the program.
+    :param common_fields: Common fields for V3 transactions.
+    :return: Hash of the transaction.
+    """
     if class_hash is None:
         if contract_class is None:
             raise ValueError("Either contract_class or class_hash is required.")

--- a/starknet_py/hash/transaction_test.py
+++ b/starknet_py/hash/transaction_test.py
@@ -2,16 +2,29 @@ import pytest
 
 from starknet_py.common import create_compiled_contract
 from starknet_py.hash.transaction import (
+    CommonTransactionV3Fields,
     TransactionHashPrefix,
     compute_declare_transaction_hash,
     compute_declare_v2_transaction_hash,
+    compute_declare_v3_transaction_hash,
     compute_deploy_account_transaction_hash,
+    compute_deploy_account_v3_transaction_hash,
     compute_invoke_transaction_hash,
+    compute_invoke_v3_transaction_hash,
     compute_transaction_hash,
 )
+from starknet_py.net.client_models import DAMode, ResourceBounds, ResourceBoundsMapping
 from starknet_py.net.models import StarknetChainId
 from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_COMPILED_V0_DIR
 from starknet_py.tests.e2e.fixtures.misc import read_contract
+
+
+@pytest.fixture(name="default_resource_bounds")
+def get_resource_bounds():
+    return ResourceBoundsMapping(
+        l1_gas=ResourceBounds(max_amount=0x186A0, max_price_per_unit=0x5AF3107A4000),
+        l2_gas=ResourceBounds(max_amount=0, max_price_per_unit=0),
+    )
 
 
 @pytest.mark.parametrize(
@@ -120,3 +133,128 @@ def test_compute_declare_v2_transaction_hash(data, expected_hash):
 )
 def test_compute_invoke_transaction_hash(data, expected_hash):
     assert compute_invoke_transaction_hash(**data) == expected_hash
+
+
+@pytest.mark.parametrize(
+    "common_data, declare_data, expected_hash",
+    (
+        (
+            {
+                "address": 0x52125C1E043126C637D1436D9551EF6C4F6E3E36945676BBD716A56E3A41B7A,
+                "chain_id": StarknetChainId.TESTNET,
+                "nonce": 0x675,
+                "tip": 0x0,
+                "paymaster_data": [],
+                "nonce_data_availability_mode": DAMode.L1,
+                "fee_data_availability_mode": DAMode.L1,
+                "tx_prefix": TransactionHashPrefix.DECLARE,
+                "version": 0x3,
+            },
+            {
+                "class_hash": 0x2338634F11772EA342365ABD5BE9D9DC8A6F44F159AD782FDEBD3DB5D969738,
+                "compiled_class_hash": 0x17B5169C770D0E49100AB0FC672A49CA90CC572F21F79A640B5227B19D3A447,
+                "account_deployment_data": [],
+            },
+            0x7B31376D1C4F467242616530901E1B441149F1106EF765F202A50A6F917762B,
+        ),
+    ),
+)
+def test_compute_declare_v3_transaction_hash(
+    common_data, declare_data, expected_hash, default_resource_bounds
+):
+    assert (
+        compute_declare_v3_transaction_hash(
+            **declare_data,
+            common_fields=CommonTransactionV3Fields(
+                **common_data, resource_bounds=default_resource_bounds
+            ),
+        )
+        == expected_hash
+    )
+
+
+@pytest.mark.parametrize(
+    "common_data, invoke_data, expected_hash",
+    (
+        (
+            {
+                "address": 0x35ACD6DD6C5045D18CA6D0192AF46B335A5402C02D41F46E4E77EA2C951D9A3,
+                "chain_id": StarknetChainId.TESTNET,
+                "nonce": 0x5,
+                "tip": 0x0,
+                "paymaster_data": [],
+                "nonce_data_availability_mode": DAMode.L1,
+                "fee_data_availability_mode": DAMode.L1,
+                "tx_prefix": TransactionHashPrefix.INVOKE,
+                "version": 0x3,
+            },
+            {
+                "calldata": [
+                    0x2,
+                    0x6359ED638DF79B82F2F9DBF92ABBCB41B57F9DD91EAD86B1C85D2DEE192C,
+                    0xB17D8A2731BA7CA1816631E6BE14F0FC1B8390422D649FA27F0FBB0C91EEA8,
+                    0x0,
+                    0x3FE8E4571772BBE0065E271686BD655EFD1365A5D6858981E582F82F2C10313,
+                    0x2FD9126EE011F3A837CEA02E32AE4EE73342D827E216998E5616BAB88D8B7EA,
+                    0x1,
+                    0x2FD9126EE011F3A837CEA02E32AE4EE73342D827E216998E5616BAB88D8B7EA,
+                ],
+                "account_deployment_data": [],
+            },
+            0x15F2CF38832542602E2D1C8BF0634893E6B43ACB6879E8A8F892F5A9B03C907,
+        ),
+    ),
+)
+def test_compute_invoke_v3_transaction_hash(
+    common_data, invoke_data, expected_hash, default_resource_bounds
+):
+    assert (
+        compute_invoke_v3_transaction_hash(
+            **invoke_data,
+            common_fields=CommonTransactionV3Fields(
+                **common_data, resource_bounds=default_resource_bounds
+            ),
+        )
+        == expected_hash
+    )
+
+
+@pytest.mark.parametrize(
+    "common_data, deploy_account_data, expected_hash",
+    (
+        (
+            {
+                "address": 0x2FAB82E4AEF1D8664874E1F194951856D48463C3E6BF9A8C68E234A629A6F50,
+                "chain_id": StarknetChainId.TESTNET,
+                "nonce": 0x0,
+                "tip": 0x0,
+                "paymaster_data": [],
+                "nonce_data_availability_mode": DAMode.L1,
+                "fee_data_availability_mode": DAMode.L1,
+                "tx_prefix": TransactionHashPrefix.DEPLOY_ACCOUNT,
+                "version": 0x3,
+            },
+            {
+                "constructor_calldata": [
+                    0x5CD65F3D7DAEA6C63939D659B8473EA0C5CD81576035A4D34E52FB06840196C
+                ],
+                "contract_address_salt": 0x0,
+                "class_hash": 0x2338634F11772EA342365ABD5BE9D9DC8A6F44F159AD782FDEBD3DB5D969738,
+            },
+            0x29FD7881F14380842414CDFDD8D6C0B1F2174F8916EDCFEB1EDE1EB26AC3EF0,
+        ),
+    ),
+)
+def test_compute_deploy_account_v3_transaction_hash(
+    common_data, deploy_account_data, expected_hash, default_resource_bounds
+):
+    assert (
+        compute_deploy_account_v3_transaction_hash(
+            **deploy_account_data,
+            common_fields=CommonTransactionV3Fields(
+                **common_data,
+                resource_bounds=default_resource_bounds,
+            ),
+        )
+        == expected_hash
+    )

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -233,9 +233,9 @@ class Account(BaseAccount):
         """
         Takes calls and creates InvokeV3 from them.
 
-        :param calls: Single call or list of calls.
+        :param calls: Single call or a list of calls.
         :param resource_bounds: Max amount and price of Wei or Fri to be paid when executing transaction.
-        :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
+        :param auto_estimate: Use automatic fee estimation; not recommended as it may lead to high costs.
         :return: InvokeV3 created from the calls (without the signature).
         """
         if nonce is None:

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -27,12 +27,12 @@ from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.models import AddressRepresentation, StarknetChainId, parse_address
 from starknet_py.net.models.transaction import (
     AccountTransaction,
-    Declare,
+    DeclareV1,
     DeclareV2,
     DeclareV3,
-    DeployAccount,
+    DeployAccountV1,
     DeployAccountV3,
-    Invoke,
+    InvokeV1,
     InvokeV3,
     TypeAccountTransaction,
 )
@@ -195,7 +195,7 @@ class Account(BaseAccount):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> Invoke:
+    ) -> InvokeV1:
         """
         Takes calls and creates Invoke from them.
 
@@ -209,7 +209,7 @@ class Account(BaseAccount):
 
         wrapped_calldata = _parse_calls(await self.cairo_version, calls)
 
-        transaction = Invoke(
+        transaction = InvokeV1(
             calldata=wrapped_calldata,
             signature=[],
             max_fee=0,
@@ -336,7 +336,7 @@ class Account(BaseAccount):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> Invoke:
+    ) -> InvokeV1:
         execute_tx = await self._prepare_invoke(
             calls,
             nonce=nonce,
@@ -370,7 +370,7 @@ class Account(BaseAccount):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> Declare:
+    ) -> DeclareV1:
         if _is_sierra_contract(json.loads(compiled_contract)):
             raise ValueError(
                 "Signing sierra contracts requires using `sign_declare_v2_transaction` method."
@@ -430,13 +430,13 @@ class Account(BaseAccount):
 
     async def _make_declare_transaction(
         self, compiled_contract: str, *, nonce: Optional[int] = None
-    ) -> Declare:
+    ) -> DeclareV1:
         contract_class = create_compiled_contract(compiled_contract=compiled_contract)
 
         if nonce is None:
             nonce = await self.get_nonce()
 
-        declare_tx = Declare(
+        declare_tx = DeclareV1(
             contract_class=contract_class,
             sender_address=self.address,
             max_fee=0,
@@ -505,8 +505,8 @@ class Account(BaseAccount):
         nonce: int = 0,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> DeployAccount:
-        deploy_account_tx = DeployAccount(
+    ) -> DeployAccountV1:
+        deploy_account_tx = DeployAccountV1(
             class_hash=class_hash,
             contract_address_salt=contract_address_salt,
             constructor_calldata=(constructor_calldata or []),

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -354,14 +354,14 @@ class Account(BaseAccount):
         resource_bounds: Optional[ResourceBoundsMapping] = None,
         auto_estimate: bool = False,
     ) -> InvokeV3:
-        execute_tx = await self._prepare_invoke_v3(
+        invoke_tx = await self._prepare_invoke_v3(
             calls,
             resource_bounds=resource_bounds,
             nonce=nonce,
             auto_estimate=auto_estimate,
         )
-        signature = self.signer.sign_transaction(execute_tx)
-        return _add_signature_to_transaction(execute_tx, signature)
+        signature = self.signer.sign_transaction(invoke_tx)
+        return _add_signature_to_transaction(invoke_tx, signature)
 
     async def sign_declare_transaction(
         self,
@@ -571,14 +571,16 @@ class Account(BaseAccount):
     async def execute_v3(
         self,
         calls: Calls,
-        resource_bounds: ResourceBoundsMapping,
         *,
+        resource_bounds: Optional[ResourceBoundsMapping] = None,
         nonce: Optional[int] = None,
+        auto_estimate: bool = False,
     ) -> SentTransactionResponse:
         execute_transaction = await self.sign_invoke_v3_transaction(
             calls,
             resource_bounds=resource_bounds,
             nonce=nonce,
+            auto_estimate=auto_estimate,
         )
         return await self._client.send_transaction(execute_transaction)
 

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -329,7 +329,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(transaction)
         return _add_signature_to_transaction(tx=transaction, signature=signature)
 
-    async def sign_invoke_transaction(
+    async def sign_invoke_v1_transaction(
         self,
         calls: Calls,
         *,
@@ -363,7 +363,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(invoke_tx)
         return _add_signature_to_transaction(invoke_tx, signature)
 
-    async def sign_declare_transaction(
+    async def sign_declare_v1_transaction(
         self,
         compiled_contract: str,
         *,
@@ -376,7 +376,7 @@ class Account(BaseAccount):
                 "Signing sierra contracts requires using `sign_declare_v2_transaction` method."
             )
 
-        declare_tx = await self._make_declare_transaction(
+        declare_tx = await self._make_declare_v1_transaction(
             compiled_contract, nonce=nonce
         )
 
@@ -428,7 +428,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(declare_tx)
         return _add_signature_to_transaction(declare_tx, signature)
 
-    async def _make_declare_transaction(
+    async def _make_declare_v1_transaction(
         self, compiled_contract: str, *, nonce: Optional[int] = None
     ) -> DeclareV1:
         contract_class = create_compiled_contract(compiled_contract=compiled_contract)
@@ -496,7 +496,7 @@ class Account(BaseAccount):
         )
         return declare_tx
 
-    async def sign_deploy_account_transaction(
+    async def sign_deploy_account_v1_transaction(
         self,
         class_hash: int,
         contract_address_salt: int,
@@ -560,7 +560,7 @@ class Account(BaseAccount):
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
     ) -> SentTransactionResponse:
-        execute_transaction = await self.sign_invoke_transaction(
+        execute_transaction = await self.sign_invoke_v1_transaction(
             calls,
             nonce=nonce,
             max_fee=max_fee,
@@ -656,7 +656,7 @@ class Account(BaseAccount):
             chain=chain,
         )
 
-        deploy_account_tx = await account.sign_deploy_account_transaction(
+        deploy_account_tx = await account.sign_deploy_account_v1_transaction(
             class_hash=class_hash,
             contract_address_salt=salt,
             constructor_calldata=calldata,

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -2,13 +2,22 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Union
 
 from starknet_py.net.client import Client
-from starknet_py.net.client_models import Calls, Hash, SentTransactionResponse, Tag
+from starknet_py.net.client_models import (
+    Calls,
+    Hash,
+    ResourceBoundsMapping,
+    SentTransactionResponse,
+    Tag,
+)
 from starknet_py.net.models import AddressRepresentation, StarknetChainId
 from starknet_py.net.models.transaction import (
     Declare,
     DeclareV2,
+    DeclareV3,
     DeployAccount,
+    DeployAccountV3,
     Invoke,
+    InvokeV3,
     TypeAccountTransaction,
 )
 from starknet_py.net.models.typed_data import TypedData
@@ -121,6 +130,24 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
+    async def sign_invoke_v3_transaction(
+        self,
+        calls: Calls,
+        resource_bounds: ResourceBoundsMapping,
+        *,
+        nonce: Optional[int] = None,
+    ) -> InvokeV3:
+        """
+        Takes calls and creates signed Invoke.
+
+        :param calls: Single call or list of calls.
+        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param nonce: Nonce of the transaction.
+        :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
+        :return: Invoke created from the calls.
+        """
+
+    @abstractmethod
     async def sign_declare_transaction(
         self,
         compiled_contract: str,
@@ -163,6 +190,27 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
+    async def sign_declare_v3_transaction(
+        self,
+        compiled_contract: str,
+        compiled_class_hash: int,
+        resource_bounds: ResourceBoundsMapping,
+        *,
+        nonce: Optional[int] = None,
+    ) -> DeclareV3:
+        """
+        Create and sign declare transaction using sierra contract.
+
+        :param compiled_contract: string containing a compiled Starknet contract.
+            Supports new contracts (compiled to sierra).
+        :param compiled_class_hash: a class hash of the sierra compiled contract used in the declare transaction.
+            Computed from casm compiled contract.
+        :param nonce: Nonce of the transaction.
+        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :return: Signed DeclareV3 transaction.
+        """
+
+    @abstractmethod
     async def sign_deploy_account_transaction(
         self,
         class_hash: int,
@@ -188,6 +236,29 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
+    async def sign_deploy_account_v3_transaction(
+        self,
+        class_hash: int,
+        contract_address_salt: int,
+        resource_bounds: ResourceBoundsMapping,
+        *,
+        constructor_calldata: Optional[List[int]] = None,
+        nonce: int = 0,
+    ) -> DeployAccountV3:
+        """
+        Create and sign deploy account transaction.
+
+        :param class_hash: Class hash of the contract class to be deployed.
+        :param contract_address_salt: A salt used to calculate deployed contract address.
+        :param constructor_calldata: Calldata to be ed to contract constructor
+            and used to calculate deployed contract address.
+        :param nonce: Nonce of the transaction.
+        :param resource_bounds: Max amount of Wei or Fri to be paid  for deploying account transaction.
+            Enough tokens must be prefunded before sending the transaction for it to succeed.
+        :return: Signed DeployAccountV3 transaction.
+        """
+
+    @abstractmethod
     async def execute(
         self,
         calls: Calls,
@@ -203,6 +274,23 @@ class BaseAccount(ABC):
         :param nonce: Nonce of the transaction.
         :param max_fee: Max amount of Wei to be paid when executing transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
+        :return: SentTransactionResponse.
+        """
+
+    @abstractmethod
+    async def execute_v3(
+        self,
+        calls: Calls,
+        resource_bounds: ResourceBoundsMapping,
+        *,
+        nonce: Optional[int] = None,
+    ) -> SentTransactionResponse:
+        """
+        Takes calls and executes transaction.
+
+        :param calls: Single call or list of calls.
+        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param nonce: Nonce of the transaction.
         :return: SentTransactionResponse.
         """
 

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -111,7 +111,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_invoke_transaction(
+    async def sign_invoke_v1_transaction(
         self,
         calls: Calls,
         *,
@@ -149,7 +149,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_declare_transaction(
+    async def sign_declare_v1_transaction(
         self,
         compiled_contract: str,
         *,
@@ -158,7 +158,7 @@ class BaseAccount(ABC):
         auto_estimate: bool = False,
     ) -> DeclareV1:
         """
-        Create and sign declare transaction.
+        Create and sign declare transaction version 1.
 
         :param compiled_contract: string containing a compiled Starknet contract. Supports old contracts.
         :param nonce: Nonce of the transaction.
@@ -178,7 +178,7 @@ class BaseAccount(ABC):
         auto_estimate: bool = False,
     ) -> DeclareV2:
         """
-        Create and sign declare transaction using sierra contract.
+        Create and sign declare transaction version 2 using sierra contract.
 
         :param compiled_contract: string containing a compiled Starknet contract.
             Supports new contracts (compiled to sierra).
@@ -201,7 +201,7 @@ class BaseAccount(ABC):
         auto_estimate: bool = False,
     ) -> DeclareV3:
         """
-        Create and sign declare transaction using sierra contract.
+        Create and sign declare transaction version 3 using sierra contract.
 
         :param compiled_contract: string containing a compiled Starknet contract.
             Supports new contracts (compiled to sierra).
@@ -214,7 +214,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_deploy_account_transaction(
+    async def sign_deploy_account_v1_transaction(
         self,
         class_hash: int,
         contract_address_salt: int,
@@ -225,7 +225,7 @@ class BaseAccount(ABC):
         auto_estimate: bool = False,
     ) -> DeployAccountV1:
         """
-        Create and sign deploy account transaction.
+        Create and sign deploy account transaction version 1.
 
         :param class_hash: Class hash of the contract class to be deployed.
         :param contract_address_salt: A salt used to calculate deployed contract address.
@@ -250,7 +250,7 @@ class BaseAccount(ABC):
         auto_estimate: bool = False,
     ) -> DeployAccountV3:
         """
-        Create and sign deploy account transaction.
+        Create and sign deploy account transaction version 3.
 
         :param class_hash: Class hash of the contract class to be deployed.
         :param contract_address_salt: A salt used to calculate deployed contract address.

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -133,16 +133,17 @@ class BaseAccount(ABC):
     async def sign_invoke_v3_transaction(
         self,
         calls: Calls,
-        resource_bounds: ResourceBoundsMapping,
         *,
         nonce: Optional[int] = None,
+        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        auto_estimate: bool = False,
     ) -> InvokeV3:
         """
         Takes calls and creates signed Invoke.
 
         :param calls: Single call or list of calls.
-        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
         :param nonce: Nonce of the transaction.
+        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Invoke created from the calls.
         """
@@ -194,9 +195,10 @@ class BaseAccount(ABC):
         self,
         compiled_contract: str,
         compiled_class_hash: int,
-        resource_bounds: ResourceBoundsMapping,
         *,
         nonce: Optional[int] = None,
+        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        auto_estimate: bool = False,
     ) -> DeclareV3:
         """
         Create and sign declare transaction using sierra contract.
@@ -207,6 +209,7 @@ class BaseAccount(ABC):
             Computed from casm compiled contract.
         :param nonce: Nonce of the transaction.
         :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Signed DeclareV3 transaction.
         """
 
@@ -240,10 +243,11 @@ class BaseAccount(ABC):
         self,
         class_hash: int,
         contract_address_salt: int,
-        resource_bounds: ResourceBoundsMapping,
         *,
         constructor_calldata: Optional[List[int]] = None,
         nonce: int = 0,
+        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        auto_estimate: bool = False,
     ) -> DeployAccountV3:
         """
         Create and sign deploy account transaction.
@@ -255,6 +259,7 @@ class BaseAccount(ABC):
         :param nonce: Nonce of the transaction.
         :param resource_bounds: Max amount of Wei or Fri to be paid  for deploying account transaction.
             Enough tokens must be prefunded before sending the transaction for it to succeed.
+        :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Signed DeployAccountV3 transaction.
         """
 

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -286,9 +286,10 @@ class BaseAccount(ABC):
     async def execute_v3(
         self,
         calls: Calls,
-        resource_bounds: ResourceBoundsMapping,
         *,
+        resource_bounds: Optional[ResourceBoundsMapping] = None,
         nonce: Optional[int] = None,
+        auto_estimate: bool = False,
     ) -> SentTransactionResponse:
         """
         Takes calls and executes transaction.
@@ -296,6 +297,7 @@ class BaseAccount(ABC):
         :param calls: Single call or list of calls.
         :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
         :param nonce: Nonce of the transaction.
+        :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: SentTransactionResponse.
         """
 

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -5,7 +5,7 @@ from starknet_py.net.client import Client
 from starknet_py.net.client_models import (
     Calls,
     Hash,
-    ResourceBoundsMapping,
+    ResourceBounds,
     SentTransactionResponse,
     Tag,
 )
@@ -135,7 +135,7 @@ class BaseAccount(ABC):
         calls: Calls,
         *,
         nonce: Optional[int] = None,
-        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        l1_resource_bounds: Optional[ResourceBounds] = None,
         auto_estimate: bool = False,
     ) -> InvokeV3:
         """
@@ -143,7 +143,7 @@ class BaseAccount(ABC):
 
         :param calls: Single call or list of calls.
         :param nonce: Nonce of the transaction.
-        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param l1_resource_bounds: Max amount and max price per unit of L1 gas used in this transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Invoke created from the calls.
         """
@@ -197,7 +197,7 @@ class BaseAccount(ABC):
         compiled_class_hash: int,
         *,
         nonce: Optional[int] = None,
-        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        l1_resource_bounds: Optional[ResourceBounds] = None,
         auto_estimate: bool = False,
     ) -> DeclareV3:
         """
@@ -208,7 +208,7 @@ class BaseAccount(ABC):
         :param compiled_class_hash: a class hash of the sierra compiled contract used in the declare transaction.
             Computed from casm compiled contract.
         :param nonce: Nonce of the transaction.
-        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param l1_resource_bounds: Max amount and max price per unit of L1 gas used in this transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Signed DeclareV3 transaction.
         """
@@ -246,7 +246,7 @@ class BaseAccount(ABC):
         *,
         constructor_calldata: Optional[List[int]] = None,
         nonce: int = 0,
-        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        l1_resource_bounds: Optional[ResourceBounds] = None,
         auto_estimate: bool = False,
     ) -> DeployAccountV3:
         """
@@ -257,7 +257,7 @@ class BaseAccount(ABC):
         :param constructor_calldata: Calldata to be ed to contract constructor
             and used to calculate deployed contract address.
         :param nonce: Nonce of the transaction.
-        :param resource_bounds: Max amount of Wei or Fri to be paid  for deploying account transaction.
+        :param l1_resource_bounds: Max amount and max price per unit of L1 gas used in this transaction.
             Enough tokens must be prefunded before sending the transaction for it to succeed.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: Signed DeployAccountV3 transaction.
@@ -287,7 +287,7 @@ class BaseAccount(ABC):
         self,
         calls: Calls,
         *,
-        resource_bounds: Optional[ResourceBoundsMapping] = None,
+        l1_resource_bounds: Optional[ResourceBounds] = None,
         nonce: Optional[int] = None,
         auto_estimate: bool = False,
     ) -> SentTransactionResponse:
@@ -295,7 +295,7 @@ class BaseAccount(ABC):
         Takes calls and executes transaction.
 
         :param calls: Single call or list of calls.
-        :param resource_bounds: Max amount of Wei or Fri to be paid when executing transaction.
+        :param l1_resource_bounds: Max amount and max price per unit of L1 gas used in this transaction.
         :param nonce: Nonce of the transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         :return: SentTransactionResponse.

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -11,12 +11,12 @@ from starknet_py.net.client_models import (
 )
 from starknet_py.net.models import AddressRepresentation, StarknetChainId
 from starknet_py.net.models.transaction import (
-    Declare,
+    DeclareV1,
     DeclareV2,
     DeclareV3,
-    DeployAccount,
+    DeployAccountV1,
     DeployAccountV3,
-    Invoke,
+    InvokeV1,
     InvokeV3,
     TypeAccountTransaction,
 )
@@ -118,7 +118,7 @@ class BaseAccount(ABC):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> Invoke:
+    ) -> InvokeV1:
         """
         Takes calls and creates signed Invoke.
 
@@ -156,7 +156,7 @@ class BaseAccount(ABC):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> Declare:
+    ) -> DeclareV1:
         """
         Create and sign declare transaction.
 
@@ -223,7 +223,7 @@ class BaseAccount(ABC):
         nonce: Optional[int] = None,
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
-    ) -> DeployAccount:
+    ) -> DeployAccountV1:
         """
         Create and sign deploy account transaction.
 

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -28,11 +28,8 @@ from starknet_py.net.client_models import (
 from starknet_py.net.models.transaction import (
     AccountTransaction,
     Declare,
-    DeclareV2,
     DeployAccount,
-    DeployAccountV3,
     Invoke,
-    InvokeV3,
 )
 from starknet_py.transaction_errors import (
     TransactionNotReceivedError,
@@ -244,7 +241,7 @@ class Client(ABC):
     @abstractmethod
     async def send_transaction(
         self,
-        transaction: Union[Invoke, InvokeV3],
+        transaction: Invoke,
     ) -> SentTransactionResponse:
         """
         Send a transaction to the network
@@ -255,7 +252,7 @@ class Client(ABC):
 
     @abstractmethod
     async def deploy_account(
-        self, transaction: Union[DeployAccount, DeployAccountV3]
+        self, transaction: DeployAccount
     ) -> DeployAccountTransactionResponse:
         """
         Deploy a pre-funded account contract to the network
@@ -265,9 +262,7 @@ class Client(ABC):
         """
 
     @abstractmethod
-    async def declare(
-        self, transaction: Union[Declare, DeclareV2]
-    ) -> DeclareTransactionResponse:
+    async def declare(self, transaction: Declare) -> DeclareTransactionResponse:
         """
         Send a declare transaction
 

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -206,6 +206,7 @@ class Client(ABC):
     async def estimate_fee(
         self,
         tx: Union[AccountTransaction, List[AccountTransaction]],
+        skip_validate: bool = False,
         block_hash: Optional[Union[Hash, Tag]] = None,
         block_number: Optional[Union[int, Tag]] = None,
     ) -> Union[EstimatedFee, List[EstimatedFee]]:
@@ -216,6 +217,7 @@ class Client(ABC):
         For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.
 
         :param tx: Transaction to estimate
+        :param skip_validate: Flag checking whether the validation part of the transaction should be executed.
         :param block_hash: Block's hash or literals `"pending"` or `"latest"`.
         :param block_number: Block's number or literals `"pending"` or `"latest"`.
         :return: Estimated amount of Wei executing specified transaction will cost.

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -216,7 +216,7 @@ class Client(ABC):
         Estimates the resources required by a given sequence of transactions when applied on a given state.
         If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error),
         a TRANSACTION_EXECUTION_ERROR is returned.
-        For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.
+        For v0-2 transactions the estimate is given in Wei, and for v3 transactions it is given in Fri.
 
         :param tx: Transaction to estimate
         :param skip_validate: Flag checking whether the validation part of the transaction should be executed.

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -30,7 +30,9 @@ from starknet_py.net.models.transaction import (
     Declare,
     DeclareV2,
     DeployAccount,
+    DeployAccountV3,
     Invoke,
+    InvokeV3,
 )
 from starknet_py.transaction_errors import (
     TransactionNotReceivedError,
@@ -242,7 +244,7 @@ class Client(ABC):
     @abstractmethod
     async def send_transaction(
         self,
-        transaction: Invoke,
+        transaction: Union[Invoke, InvokeV3],
     ) -> SentTransactionResponse:
         """
         Send a transaction to the network
@@ -253,7 +255,7 @@ class Client(ABC):
 
     @abstractmethod
     async def deploy_account(
-        self, transaction: DeployAccount
+        self, transaction: Union[DeployAccount, DeployAccountV3]
     ) -> DeployAccountTransactionResponse:
         """
         Deploy a pre-funded account contract to the network

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -210,7 +210,10 @@ class Client(ABC):
         block_number: Optional[Union[int, Tag]] = None,
     ) -> Union[EstimatedFee, List[EstimatedFee]]:
         """
-        Estimate how much Wei it will cost to run provided transaction.
+        Estimates the resources required by a given sequence of transactions when applied on a given state.
+        If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error),
+        a TRANSACTION_EXECUTION_ERROR is returned.
+        For v0-2 transactions the estimate is given in wei, and for v3 transactions it is given in fri.
 
         :param tx: Transaction to estimate
         :param block_hash: Block's hash or literals `"pending"` or `"latest"`.

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -162,7 +162,7 @@ class TransactionV3(Transaction):
     fee_data_availability_mode: DAMode
 
     def __post_init__(self):
-        if self.__class__ == Transaction:
+        if self.__class__ == TransactionV3:
             raise TypeError("Cannot instantiate abstract TransactionV3 class.")
 
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -69,17 +69,55 @@ class ResourcePrice:
     """
 
     price_in_wei: int
-    price_in_strk: Optional[int]
+    price_in_fri: Optional[int]
 
 
 @dataclass
-class ResourceLimits:
+class ResourceBounds:
     """
-    Dataclass representing resource limits.
+    Dataclass representing max amount and price of the resource that can be used in the transaction.
     """
 
     max_amount: int
     max_price_per_unit: int
+
+
+@dataclass
+class ResourceBoundsMapping:
+    """
+    Dataclass representing resource limits that can be used in the transaction.
+    """
+
+    l1_gas: ResourceBounds
+    l2_gas: ResourceBounds
+
+
+class PriceUnit(Enum):
+    """
+    Enum representing price unit types.
+    """
+
+    WEI = "WEI"
+    FRI = "FRI"
+
+
+@dataclass
+class FeePayment:
+    """
+    Dataclass representing fee payment info as it appears in receipts.
+    """
+
+    amount: int
+    unit: PriceUnit
+
+
+class DAMode(Enum):
+    """
+    Specifies a storage domain in Starknet. Each domain has different guarantees regarding availability.
+    """
+
+    L1 = 0
+    L2 = 1
 
 
 class TransactionType(Enum):
@@ -104,8 +142,6 @@ class Transaction(ABC):
     # together with the rest of the data, it remains here (but is still Optional just in case as spec says)
     hash: Optional[int]
     signature: List[int]
-    # Optional for DECLARE_V3 and DEPLOY_ACCOUNT_V3, where there is no `max_fee` field, but `l1_gas`
-    max_fee: Optional[int]
     version: int
 
     def __post_init__(self):
@@ -114,11 +150,29 @@ class Transaction(ABC):
 
 
 @dataclass
+class TransactionV3(Transaction):
+    """
+    Dataclass representing common attributes of all transactions v3.
+    """
+
+    resource_bounds: ResourceBoundsMapping
+    paymaster_data: List[int]
+    tip: int
+    nonce_data_availability_mode: DAMode
+    fee_data_availability_mode: DAMode
+
+    def __post_init__(self):
+        if self.__class__ == Transaction:
+            raise TypeError("Cannot instantiate abstract TransactionV3 class.")
+
+
+@dataclass
 class InvokeTransaction(Transaction):
     """
     Dataclass representing invoke transaction.
     """
 
+    max_fee: int
     sender_address: int
     calldata: List[int]
     # This field is always None for transactions with version = 1
@@ -127,16 +181,40 @@ class InvokeTransaction(Transaction):
 
 
 @dataclass
+class InvokeTransactionV3(TransactionV3):
+    """
+    Dataclass representing invoke transaction v3.
+    """
+
+    sender_address: int
+    calldata: List[int]
+    account_deployment_data: List[int]
+    nonce: int
+
+
+@dataclass
 class DeclareTransaction(Transaction):
     """
     Dataclass representing declare transaction.
     """
 
+    max_fee: int
     class_hash: int  # Responses to getBlock and getTransaction include the class hash
     sender_address: int
     compiled_class_hash: Optional[int] = None  # only in DeclareV2, hence Optional
     nonce: Optional[int] = None
-    l1_gas: Optional[ResourceLimits] = None  # DECLARE_V3-only field, hence Optional
+
+
+@dataclass
+class DeclareTransactionV3(TransactionV3):
+    """
+    Dataclass representing declare transaction v3.
+    """
+
+    class_hash: int
+    compiled_class_hash: int
+    nonce: int
+    sender_address: int
 
 
 @dataclass
@@ -148,15 +226,25 @@ class DeployTransaction(Transaction):
     contract_address_salt: int
     constructor_calldata: List[int]
     class_hash: int
-    l1_gas: Optional[
-        ResourceLimits
-    ] = None  # DEPLOY_ACCOUNT_V3-only field, hence Optional
 
 
 @dataclass
 class DeployAccountTransaction(Transaction):
     """
     Dataclass representing deploy account transaction.
+    """
+
+    max_fee: int
+    contract_address_salt: int
+    class_hash: int
+    constructor_calldata: List[int]
+    nonce: int
+
+
+@dataclass
+class DeployAccountTransactionV3(TransactionV3):
+    """
+    Dataclass representing deploy account transaction v3.
     """
 
     contract_address_salt: int
@@ -171,6 +259,7 @@ class L1HandlerTransaction(Transaction):
     Dataclass representing l1 handler transaction.
     """
 
+    max_fee: int
     contract_address: int
     calldata: List[int]
     entry_point_selector: int
@@ -215,13 +304,13 @@ class ExecutionResources:
     # pylint: disable=too-many-instance-attributes
 
     steps: int
-    range_check_builtin_applications: int
-    pedersen_builtin_applications: int
-    poseidon_builtin_applications: int
-    ec_op_builtin_applications: int
-    ecdsa_builtin_applications: int
-    bitwise_builtin_applications: int
-    keccak_builtin_applications: int
+    range_check_builtin_applications: Optional[int] = None
+    pedersen_builtin_applications: Optional[int] = None
+    poseidon_builtin_applications: Optional[int] = None
+    ec_op_builtin_applications: Optional[int] = None
+    ecdsa_builtin_applications: Optional[int] = None
+    bitwise_builtin_applications: Optional[int] = None
+    keccak_builtin_applications: Optional[int] = None
     memory_holes: Optional[int] = None
 
 
@@ -238,16 +327,16 @@ class TransactionReceipt:
     execution_status: TransactionExecutionStatus
     finality_status: TransactionFinalityStatus
     execution_resources: ExecutionResources
-    type: TransactionType
+    actual_fee: FeePayment
 
     events: List[Event] = field(default_factory=list)
     messages_sent: List[L2toL1Message] = field(default_factory=list)
 
+    type: Optional[TransactionType] = None
     contract_address: Optional[int] = None
 
     block_number: Optional[int] = None
     block_hash: Optional[int] = None
-    actual_fee: int = 0
 
     message_hash: Optional[int] = None  # L1_HANDLER_TXN_RECEIPT-only
 
@@ -405,7 +494,8 @@ class EstimatedFee:
 
     overall_fee: int
     gas_price: int
-    gas_usage: int
+    gas_consumed: int
+    unit: PriceUnit
 
 
 @dataclass
@@ -689,6 +779,7 @@ class FunctionInvocation:
     calls: List["FunctionInvocation"]
     events: List[OrderedEvent]
     messages: List[OrderedMessage]
+    execution_resources: ExecutionResources
 
 
 @dataclass

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -81,6 +81,10 @@ class ResourceBounds:
     max_amount: int
     max_price_per_unit: int
 
+    @staticmethod
+    def init_with_zeros():
+        return ResourceBounds(max_amount=0, max_price_per_unit=0)
+
 
 @dataclass
 class ResourceBoundsMapping:
@@ -90,6 +94,13 @@ class ResourceBoundsMapping:
 
     l1_gas: ResourceBounds
     l2_gas: ResourceBounds
+
+    @staticmethod
+    def init_with_zeros():
+        return ResourceBoundsMapping(
+            l1_gas=ResourceBounds.init_with_zeros(),
+            l2_gas=ResourceBounds.init_with_zeros(),
+        )
 
 
 class PriceUnit(Enum):

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -340,11 +340,11 @@ class TransactionReceipt:
     finality_status: TransactionFinalityStatus
     execution_resources: ExecutionResources
     actual_fee: FeePayment
+    type: TransactionType
 
     events: List[Event] = field(default_factory=list)
     messages_sent: List[L2toL1Message] = field(default_factory=list)
 
-    type: Optional[TransactionType] = None
     contract_address: Optional[int] = None
 
     block_number: Optional[int] = None

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -226,6 +226,7 @@ class DeclareTransactionV3(TransactionV3):
     compiled_class_hash: int
     nonce: int
     sender_address: int
+    account_deployment_data: List[int]
 
 
 @dataclass

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -161,6 +161,19 @@ class Transaction(ABC):
 
 
 @dataclass
+class DeprecatedTransaction(Transaction):
+    """
+    Dataclass representing common attributes of transactions v1 and v2.
+    """
+
+    max_fee: int
+
+    def __post_init__(self):
+        if self.__class__ == DeprecatedTransaction:
+            raise TypeError("Cannot instantiate abstract DeprecatedTransaction class.")
+
+
+@dataclass
 class TransactionV3(Transaction):
     """
     Dataclass representing common attributes of all transactions v3.
@@ -178,12 +191,11 @@ class TransactionV3(Transaction):
 
 
 @dataclass
-class InvokeTransaction(Transaction):
+class InvokeTransaction(DeprecatedTransaction):
     """
     Dataclass representing invoke transaction.
     """
 
-    max_fee: int
     sender_address: int
     calldata: List[int]
     # This field is always None for transactions with version = 1
@@ -204,12 +216,11 @@ class InvokeTransactionV3(TransactionV3):
 
 
 @dataclass
-class DeclareTransaction(Transaction):
+class DeclareTransaction(DeprecatedTransaction):
     """
     Dataclass representing declare transaction.
     """
 
-    max_fee: int
     class_hash: int  # Responses to getBlock and getTransaction include the class hash
     sender_address: int
     compiled_class_hash: Optional[int] = None  # only in DeclareV2, hence Optional
@@ -241,12 +252,11 @@ class DeployTransaction(Transaction):
 
 
 @dataclass
-class DeployAccountTransaction(Transaction):
+class DeployAccountTransaction(DeprecatedTransaction):
     """
     Dataclass representing deploy account transaction.
     """
 
-    max_fee: int
     contract_address_salt: int
     class_hash: int
     constructor_calldata: List[int]
@@ -271,7 +281,6 @@ class L1HandlerTransaction(Transaction):
     Dataclass representing l1 handler transaction.
     """
 
-    max_fee: int
     contract_address: int
     calldata: List[int]
     entry_point_selector: int

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -69,7 +69,7 @@ class ResourcePrice:
     """
 
     price_in_wei: int
-    price_in_fri: Optional[int]
+    price_in_fri: int
 
 
 @dataclass

--- a/starknet_py/net/client_test.py
+++ b/starknet_py/net/client_test.py
@@ -18,7 +18,7 @@ def test_cannot_instantiate_abstract_transaction_class():
     with pytest.raises(
         TypeError, match="Cannot instantiate abstract Transaction class."
     ):
-        _ = Transaction(hash=0, signature=[0, 0], max_fee=0, version=0)
+        _ = Transaction(hash=0, signature=[0, 0], version=0)
 
 
 def test_handle_rpc_error_server_error():

--- a/starknet_py/net/client_test.py
+++ b/starknet_py/net/client_test.py
@@ -1,10 +1,14 @@
 import pytest
 
 from starknet_py.constants import ADDR_BOUND
-from starknet_py.net.client_models import DAMode, Transaction, TransactionV3
+from starknet_py.net.client_models import (
+    DAMode,
+    ResourceBoundsMapping,
+    Transaction,
+    TransactionV3,
+)
 from starknet_py.net.full_node_client import _to_storage_key
 from starknet_py.net.http_client import RpcHttpClient, ServerError
-from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS_L1
 
 
 @pytest.mark.asyncio
@@ -34,7 +38,7 @@ def test_cannot_instantiate_abstract_transaction_v3_class():
             tip=0,
             nonce_data_availability_mode=DAMode.L1,
             fee_data_availability_mode=DAMode.L1,
-            resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+            resource_bounds=ResourceBoundsMapping.init_with_zeros(),
         )
 
 

--- a/starknet_py/net/client_test.py
+++ b/starknet_py/net/client_test.py
@@ -1,9 +1,10 @@
 import pytest
 
 from starknet_py.constants import ADDR_BOUND
-from starknet_py.net.client_models import Transaction
+from starknet_py.net.client_models import DAMode, Transaction, TransactionV3
 from starknet_py.net.full_node_client import _to_storage_key
 from starknet_py.net.http_client import RpcHttpClient, ServerError
+from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS_L1
 
 
 @pytest.mark.asyncio
@@ -19,6 +20,22 @@ def test_cannot_instantiate_abstract_transaction_class():
         TypeError, match="Cannot instantiate abstract Transaction class."
     ):
         _ = Transaction(hash=0, signature=[0, 0], version=0)
+
+
+def test_cannot_instantiate_abstract_transaction_v3_class():
+    with pytest.raises(
+        TypeError, match="Cannot instantiate abstract TransactionV3 class."
+    ):
+        _ = TransactionV3(
+            hash=0,
+            signature=[0, 0],
+            version=0,
+            paymaster_data=[],
+            tip=0,
+            nonce_data_availability_mode=DAMode.L1,
+            fee_data_availability_mode=DAMode.L1,
+            resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+        )
 
 
 def test_handle_rpc_error_server_error():

--- a/starknet_py/net/client_utils.py
+++ b/starknet_py/net/client_utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import Union
 
 from typing_extensions import get_args
@@ -33,3 +34,46 @@ def encode_l1_message(tx: L1HandlerTransaction) -> bytes:
         + encode_uint(len(tx.calldata))
         + encode_uint_list(tx.calldata)
     )
+
+
+def _to_storage_key(key: int) -> str:
+    """
+    Convert a value to RPC storage key matching a ``^0x0[0-7]{1}[a-fA-F0-9]{0,62}$`` pattern.
+
+    :param key: The key to convert.
+    :return: RPC storage key representation of the key.
+    """
+
+    hashed_key = hex(key)[2:]
+
+    if hashed_key[0] not in ("0", "1", "2", "3", "4", "5", "6", "7"):
+        hashed_key = "0" + hashed_key
+
+    hashed_key = "0x0" + hashed_key
+
+    if not re.match(r"^0x0[0-7]{1}[a-fA-F0-9]{0,62}$", hashed_key):
+        raise ValueError(f"Value {key} cannot be represented as RPC storage key.")
+
+    return hashed_key
+
+
+def _to_rpc_felt(value: Hash) -> str:
+    """
+    Convert the value to RPC felt matching a ``^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$`` pattern.
+
+    :param value: The value to convert.
+    :return: RPC felt representation of the value.
+    """
+    if isinstance(value, str):
+        value = int(value, 16)
+
+    rpc_felt = hex(value)
+    assert re.match(r"^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$", rpc_felt)
+    return rpc_felt
+
+
+def _is_valid_eth_address(address: str) -> bool:
+    """
+    A function checking if an address matches Ethereum address regex. Note that it doesn't validate any checksums etc.
+    """
+    return bool(re.fullmatch("^0x[a-fA-F0-9]{40}$", address))

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -472,7 +472,9 @@ class FullNodeClient(Client):
         )
         return [int(i, 16) for i in res]
 
-    async def send_transaction(self, transaction: Invoke) -> SentTransactionResponse:
+    async def send_transaction(
+        self, transaction: Union[Invoke, InvokeV3]
+    ) -> SentTransactionResponse:
         params = _create_broadcasted_txn(transaction=transaction)
 
         res = await self._client.call(
@@ -485,7 +487,7 @@ class FullNodeClient(Client):
         )
 
     async def deploy_account(
-        self, transaction: DeployAccount
+        self, transaction: Union[DeployAccount, DeployAccountV3]
     ) -> DeployAccountTransactionResponse:
         params = _create_broadcasted_txn(transaction=transaction)
 
@@ -961,8 +963,8 @@ def _create_broadcasted_txn_v3_common_properties(
         "resource_bounds": resource_bonds,
         "tip": _to_rpc_felt(transaction.tip),
         "paymaster_data": [_to_rpc_felt(data) for data in transaction.paymaster_data],
-        "nonce_data_availability_mode": transaction.nonce_data_availability_mode,
-        "fee_data_availability_mode": transaction.fee_data_availability_mode,
+        "nonce_data_availability_mode": transaction.nonce_data_availability_mode.name,
+        "fee_data_availability_mode": transaction.fee_data_availability_mode.name,
     }
 
     return broadcasted_txn_v3_common_properties

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -703,7 +703,9 @@ class FullNodeClient(Client):
         # pylint: disable=too-many-arguments
         """
         Simulates a given sequence of transactions on the requested state, and generates the execution traces.
-        If one of the transactions is reverted, raises CONTRACT_ERROR.
+        Note that some of the transactions may revert, in which case no error is thrown, but revert details can be seen on the returned trace object.
+        Note that some of the transactions may revert, this will be reflected by the revert_error property in the trace.
+        Other types of failures (e.g. unexpected error or failure in the validation phase) will result in TRANSACTION_EXECUTION_ERROR.
 
         :param transactions: Transactions to be traced.
         :param skip_validate: Flag checking whether the validation part of the transaction should be executed.

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -834,7 +834,9 @@ def _create_broadcasted_declare_properties(
     if isinstance(transaction, DeclareV3):
         return _create_broadcasted_declare_v3_properties(transaction)
 
-    contract_class = cast(Dict, DeclareV1Schema().dump(obj=transaction))["contract_class"]
+    contract_class = cast(Dict, DeclareV1Schema().dump(obj=transaction))[
+        "contract_class"
+    ]
     declare_properties = {
         "contract_class": {
             "entry_points_by_type": contract_class["entry_points_by_type"],

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -46,7 +46,7 @@ from starknet_py.net.http_client import RpcHttpClient
 from starknet_py.net.models.transaction import (
     AccountTransaction,
     Declare,
-    DeclareSchema,
+    DeclareV1Schema,
     DeclareV2,
     DeclareV2Schema,
     DeclareV3,
@@ -834,7 +834,7 @@ def _create_broadcasted_declare_properties(
     if isinstance(transaction, DeclareV3):
         return _create_broadcasted_declare_v3_properties(transaction)
 
-    contract_class = cast(Dict, DeclareSchema().dump(obj=transaction))["contract_class"]
+    contract_class = cast(Dict, DeclareV1Schema().dump(obj=transaction))["contract_class"]
     declare_properties = {
         "contract_class": {
             "entry_points_by_type": contract_class["entry_points_by_type"],

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -715,11 +715,13 @@ class FullNodeClient(Client):
         # pylint: disable=too-many-arguments
         """
         Simulates a given sequence of transactions on the requested state, and generates the execution traces.
-        Note that some of the transactions may revert, in which case no error is thrown, but revert details can be seen
-        on the returned trace object.
-        Note that some of the transactions may revert, this will be reflected by the revert_error property in the trace.
-        Other types of failures (e.g. unexpected error or failure in the validation phase) will result
-        in TRANSACTION_EXECUTION_ERROR.
+        Note the following:
+
+        - A transaction may revert. If this occurs, no error is thrown. Instead, revert details are visible
+          in the returned trace object.
+        - If a transaction reverts, this will be reflected by the revert_error property in the trace.
+        - Other types of failures (e.g. unexpected error or failure in the validation phase) will result
+          in TRANSACTION_EXECUTION_ERROR.
 
         :param transactions: Transactions to be traced.
         :param skip_validate: Flag checking whether the validation part of the transaction should be executed.

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -472,9 +472,7 @@ class FullNodeClient(Client):
         )
         return [int(i, 16) for i in res]
 
-    async def send_transaction(
-        self, transaction: Union[Invoke, InvokeV3]
-    ) -> SentTransactionResponse:
+    async def send_transaction(self, transaction: Invoke) -> SentTransactionResponse:
         params = _create_broadcasted_txn(transaction=transaction)
 
         res = await self._client.call(
@@ -487,7 +485,7 @@ class FullNodeClient(Client):
         )
 
     async def deploy_account(
-        self, transaction: Union[DeployAccount, DeployAccountV3]
+        self, transaction: DeployAccount
     ) -> DeployAccountTransactionResponse:
         params = _create_broadcasted_txn(transaction=transaction)
 
@@ -501,9 +499,7 @@ class FullNodeClient(Client):
             DeployAccountTransactionResponseSchema().load(res, unknown=EXCLUDE),
         )
 
-    async def declare(
-        self, transaction: Union[Declare, DeclareV2, DeclareV3]
-    ) -> DeclareTransactionResponse:
+    async def declare(self, transaction: Declare) -> DeclareTransactionResponse:
         params = _create_broadcasted_txn(transaction=transaction)
 
         res = await self._client.call(

--- a/starknet_py/net/models/__init__.py
+++ b/starknet_py/net/models/__init__.py
@@ -2,9 +2,12 @@ from .address import Address, AddressRepresentation, parse_address
 from .chains import StarknetChainId, chain_from_network
 from .transaction import (
     AccountTransaction,
-    Declare,
+    DeclareV1,
     DeclareV2,
-    DeployAccount,
-    Invoke,
+    DeclareV3,
+    DeployAccountV1,
+    DeployAccountV3,
+    InvokeV1,
+    InvokeV3,
     Transaction,
 )

--- a/starknet_py/net/models/transaction.py
+++ b/starknet_py/net/models/transaction.py
@@ -10,7 +10,7 @@ import gzip
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, TypeVar
+from typing import Any, Dict, List, TypeVar, Union
 
 import marshmallow
 import marshmallow_dataclass
@@ -173,7 +173,7 @@ class DeclareV2(AccountTransaction):
 
 
 @dataclass(frozen=True)
-class Declare(AccountTransaction):
+class DeclareV1(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is a declaration of a Starknet contract
     class.
@@ -249,7 +249,7 @@ class DeployAccountV3(_AccountTransactionV3):
 
 
 @dataclass(frozen=True)
-class DeployAccount(AccountTransaction):
+class DeployAccountV1(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is a deployment of a Starknet account
     contract.
@@ -313,7 +313,7 @@ class InvokeV3(_AccountTransactionV3):
 
 
 @dataclass(frozen=True)
-class Invoke(AccountTransaction):
+class InvokeV1(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is an invocation of a Cairo contract
     function.
@@ -343,10 +343,14 @@ class Invoke(AccountTransaction):
         )
 
 
-InvokeSchema = marshmallow_dataclass.class_schema(Invoke)
-DeclareSchema = marshmallow_dataclass.class_schema(Declare)
+Declare = Union[DeclareV1, DeclareV2, DeclareV3]
+DeployAccount = Union[DeployAccountV1, DeployAccountV3]
+Invoke = Union[InvokeV1, InvokeV3]
+
+InvokeSchema = marshmallow_dataclass.class_schema(InvokeV1)
+DeclareSchema = marshmallow_dataclass.class_schema(DeclareV1)
 DeclareV2Schema = marshmallow_dataclass.class_schema(DeclareV2)
-DeployAccountSchema = marshmallow_dataclass.class_schema(DeployAccount)
+DeployAccountSchema = marshmallow_dataclass.class_schema(DeployAccountV1)
 
 
 def compress_program(data: dict, program_name: str = "program") -> dict:

--- a/starknet_py/net/models/transaction.py
+++ b/starknet_py/net/models/transaction.py
@@ -41,6 +41,10 @@ from starknet_py.net.schemas.gateway import (
     SierraContractClassSchema,
 )
 
+# TODO (#1219):
+#  consider unifying these classes with client_models
+#  remove marshmallow logic if not needed
+
 
 @dataclass(frozen=True)
 class Transaction(ABC):
@@ -228,7 +232,7 @@ class DeployAccountV3(AccountTransaction):
             constructor_calldata=self.constructor_calldata,
             contract_address_salt=self.contract_address_salt,
             common_fields=CommonTransactionV3Fields(
-                tx_prefix=TransactionHashPrefix.DECLARE,
+                tx_prefix=TransactionHashPrefix.DEPLOY_ACCOUNT,
                 version=self.version,
                 address=contract_address,
                 tip=self.tip,
@@ -306,7 +310,7 @@ class InvokeV3(AccountTransaction):
             account_deployment_data=self.account_deployment_data,
             calldata=self.calldata,
             common_fields=CommonTransactionV3Fields(
-                tx_prefix=TransactionHashPrefix.DECLARE,
+                tx_prefix=TransactionHashPrefix.INVOKE,
                 version=self.version,
                 address=self.sender_address,
                 tip=self.tip,

--- a/starknet_py/net/models/transaction.py
+++ b/starknet_py/net/models/transaction.py
@@ -17,13 +17,20 @@ from marshmallow import fields
 
 from starknet_py.hash.address import compute_address
 from starknet_py.hash.transaction import (
+    CommonTransactionV3Fields,
+    TransactionHashPrefix,
     compute_declare_transaction_hash,
     compute_declare_v2_transaction_hash,
+    compute_declare_v3_transaction_hash,
     compute_deploy_account_transaction_hash,
+    compute_deploy_account_v3_transaction_hash,
     compute_invoke_transaction_hash,
+    compute_invoke_v3_transaction_hash,
 )
 from starknet_py.net.client_models import (
     ContractClass,
+    DAMode,
+    ResourceBoundsMapping,
     SierraContractClass,
     TransactionType,
 )
@@ -65,7 +72,6 @@ class AccountTransaction(Transaction, ABC):
     account.
     """
 
-    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     signature: List[int] = field(
         metadata={"marshmallow_field": fields.List(fields.String())}
     )
@@ -77,12 +83,53 @@ TypeAccountTransaction = TypeVar("TypeAccountTransaction", bound=AccountTransact
 
 
 @dataclass(frozen=True)
+class DeclareV3(AccountTransaction):
+    """
+    Represents a transaction in the Starknet network that is a version 3 declaration of a Starknet contract
+    class. Supports only sierra compiled contracts.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    sender_address: int
+    compiled_class_hash: int
+    contract_class: SierraContractClass
+    resource_bounds: ResourceBoundsMapping
+    tip: int = 0
+    nonce_data_availability_mode: DAMode = DAMode.L1
+    fee_data_availability_mode: DAMode = DAMode.L1
+    account_deployment_data: List[int] = field(default_factory=list)
+    paymaster_data: List[int] = field(default_factory=list)
+    type: TransactionType = TransactionType.DECLARE
+
+    def calculate_hash(self, chain_id: StarknetChainId) -> int:
+        return compute_declare_v3_transaction_hash(
+            account_deployment_data=self.account_deployment_data,
+            contract_class=self.contract_class,
+            compiled_class_hash=self.compiled_class_hash,
+            common_fields=CommonTransactionV3Fields(
+                tx_prefix=TransactionHashPrefix.DECLARE,
+                version=self.version,
+                address=self.sender_address,
+                tip=self.tip,
+                resource_bounds=self.resource_bounds,
+                paymaster_data=self.paymaster_data,
+                chain_id=chain_id,
+                nonce=self.nonce,
+                nonce_data_availability_mode=self.nonce_data_availability_mode,
+                fee_data_availability_mode=self.fee_data_availability_mode,
+            ),
+        )
+
+
+@dataclass(frozen=True)
 class DeclareV2(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is a version 2 declaration of a Starknet contract
     class. Supports only sierra compiled contracts.
     """
 
+    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     contract_class: SierraContractClass = field(
         metadata={"marshmallow_field": fields.Nested(SierraContractClassSchema())}
     )
@@ -112,6 +159,7 @@ class Declare(AccountTransaction):
     class.
     """
 
+    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     # The class to be declared, included for all methods involving execution (estimateFee, simulateTransactions)
     contract_class: ContractClass = field(
         metadata={"marshmallow_field": fields.Nested(ContractClassSchema())}
@@ -150,18 +198,63 @@ class Declare(AccountTransaction):
 
 
 @dataclass(frozen=True)
+class DeployAccountV3(AccountTransaction):
+    """
+    Represents a transaction in the Starknet network that is a version 3 deployment of a Starknet account
+    contract.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    class_hash: int
+    contract_address_salt: int
+    constructor_calldata: List[int]
+    resource_bounds: ResourceBoundsMapping
+    paymaster_data: List[int] = field(default_factory=list)
+    fee_data_availability_mode: DAMode = DAMode.L1
+    nonce_data_availability_mode: DAMode = DAMode.L1
+    tip: int = 0
+    type: TransactionType = TransactionType.DEPLOY_ACCOUNT
+
+    def calculate_hash(self, chain_id: StarknetChainId) -> int:
+        contract_address = compute_address(
+            salt=self.contract_address_salt,
+            class_hash=self.class_hash,
+            constructor_calldata=self.constructor_calldata,
+            deployer_address=0,
+        )
+        return compute_deploy_account_v3_transaction_hash(
+            class_hash=self.class_hash,
+            constructor_calldata=self.constructor_calldata,
+            contract_address_salt=self.contract_address_salt,
+            common_fields=CommonTransactionV3Fields(
+                tx_prefix=TransactionHashPrefix.DECLARE,
+                version=self.version,
+                address=contract_address,
+                tip=self.tip,
+                resource_bounds=self.resource_bounds,
+                paymaster_data=self.paymaster_data,
+                chain_id=chain_id,
+                nonce=self.nonce,
+                nonce_data_availability_mode=self.nonce_data_availability_mode,
+                fee_data_availability_mode=self.fee_data_availability_mode,
+            ),
+        )
+
+
+@dataclass(frozen=True)
 class DeployAccount(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is a deployment of a Starknet account
     contract.
     """
 
+    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     class_hash: int = field(metadata={"marshmallow_field": Felt()})
     contract_address_salt: int = field(metadata={"marshmallow_field": Felt()})
     constructor_calldata: List[int] = field(
         metadata={"marshmallow_field": fields.List(fields.String())}
     )
-
     type: TransactionType = field(
         metadata={"marshmallow_field": TransactionTypeField()},
         default=TransactionType.DEPLOY_ACCOUNT,
@@ -190,17 +283,55 @@ class DeployAccount(AccountTransaction):
 
 
 @dataclass(frozen=True)
+class InvokeV3(AccountTransaction):
+    """
+    Represents a transaction in the Starknet network that is a version 3 invocation of a Cairo contract
+    function.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    calldata: List[int]
+    resource_bounds: ResourceBoundsMapping
+    sender_address: int
+    account_deployment_data: List[int] = field(default_factory=list)
+    paymaster_data: List[int] = field(default_factory=list)
+    fee_data_availability_mode: DAMode = DAMode.L1
+    nonce_data_availability_mode: DAMode = DAMode.L1
+    tip: int = 0
+    type: TransactionType = TransactionType.INVOKE
+
+    def calculate_hash(self, chain_id: StarknetChainId) -> int:
+        return compute_invoke_v3_transaction_hash(
+            account_deployment_data=self.account_deployment_data,
+            calldata=self.calldata,
+            common_fields=CommonTransactionV3Fields(
+                tx_prefix=TransactionHashPrefix.DECLARE,
+                version=self.version,
+                address=self.sender_address,
+                tip=self.tip,
+                resource_bounds=self.resource_bounds,
+                paymaster_data=self.paymaster_data,
+                chain_id=chain_id,
+                nonce=self.nonce,
+                nonce_data_availability_mode=self.nonce_data_availability_mode,
+                fee_data_availability_mode=self.fee_data_availability_mode,
+            ),
+        )
+
+
+@dataclass(frozen=True)
 class Invoke(AccountTransaction):
     """
     Represents a transaction in the Starknet network that is an invocation of a Cairo contract
     function.
     """
 
+    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     sender_address: int = field(metadata={"marshmallow_field": Felt()})
     calldata: List[int] = field(
         metadata={"marshmallow_field": fields.List(fields.String())}
     )
-
     type: TransactionType = field(
         metadata={"marshmallow_field": TransactionTypeField()},
         default=TransactionType.INVOKE,

--- a/starknet_py/net/models/transaction.py
+++ b/starknet_py/net/models/transaction.py
@@ -88,6 +88,11 @@ TypeAccountTransaction = TypeVar("TypeAccountTransaction", bound=AccountTransact
 
 
 @dataclass(frozen=True)
+class _DeprecatedAccountTransaction(AccountTransaction, ABC):
+    max_fee: int = field(metadata={"marshmallow_field": Felt()})
+
+
+@dataclass(frozen=True)
 class _AccountTransactionV3(AccountTransaction, ABC):
     resource_bounds: ResourceBoundsMapping
     tip: int = field(init=False, default=0)
@@ -143,13 +148,12 @@ class DeclareV3(_AccountTransactionV3):
 
 
 @dataclass(frozen=True)
-class DeclareV2(AccountTransaction):
+class DeclareV2(_DeprecatedAccountTransaction):
     """
     Represents a transaction in the Starknet network that is a version 2 declaration of a Starknet contract
     class. Supports only sierra compiled contracts.
     """
 
-    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     contract_class: SierraContractClass = field(
         metadata={"marshmallow_field": fields.Nested(SierraContractClassSchema())}
     )
@@ -173,13 +177,12 @@ class DeclareV2(AccountTransaction):
 
 
 @dataclass(frozen=True)
-class DeclareV1(AccountTransaction):
+class DeclareV1(_DeprecatedAccountTransaction):
     """
     Represents a transaction in the Starknet network that is a declaration of a Starknet contract
     class.
     """
 
-    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     # The class to be declared, included for all methods involving execution (estimateFee, simulateTransactions)
     contract_class: ContractClass = field(
         metadata={"marshmallow_field": fields.Nested(ContractClassSchema())}
@@ -249,13 +252,12 @@ class DeployAccountV3(_AccountTransactionV3):
 
 
 @dataclass(frozen=True)
-class DeployAccountV1(AccountTransaction):
+class DeployAccountV1(_DeprecatedAccountTransaction):
     """
     Represents a transaction in the Starknet network that is a deployment of a Starknet account
     contract.
     """
 
-    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     class_hash: int = field(metadata={"marshmallow_field": Felt()})
     contract_address_salt: int = field(metadata={"marshmallow_field": Felt()})
     constructor_calldata: List[int] = field(
@@ -313,13 +315,12 @@ class InvokeV3(_AccountTransactionV3):
 
 
 @dataclass(frozen=True)
-class InvokeV1(AccountTransaction):
+class InvokeV1(_DeprecatedAccountTransaction):
     """
     Represents a transaction in the Starknet network that is an invocation of a Cairo contract
     function.
     """
 
-    max_fee: int = field(metadata={"marshmallow_field": Felt()})
     sender_address: int = field(metadata={"marshmallow_field": Felt()})
     calldata: List[int] = field(
         metadata={"marshmallow_field": fields.List(fields.String())}
@@ -347,10 +348,10 @@ Declare = Union[DeclareV1, DeclareV2, DeclareV3]
 DeployAccount = Union[DeployAccountV1, DeployAccountV3]
 Invoke = Union[InvokeV1, InvokeV3]
 
-InvokeSchema = marshmallow_dataclass.class_schema(InvokeV1)
-DeclareSchema = marshmallow_dataclass.class_schema(DeclareV1)
+InvokeV1Schema = marshmallow_dataclass.class_schema(InvokeV1)
+DeclareV1Schema = marshmallow_dataclass.class_schema(DeclareV1)
 DeclareV2Schema = marshmallow_dataclass.class_schema(DeclareV2)
-DeployAccountSchema = marshmallow_dataclass.class_schema(DeployAccountV1)
+DeployAccountV1Schema = marshmallow_dataclass.class_schema(DeployAccountV1)
 
 
 def compress_program(data: dict, program_name: str = "program") -> dict:

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -6,10 +6,10 @@ from starknet_py.common import create_contract_class
 from starknet_py.net.client_models import TransactionType
 from starknet_py.net.models.transaction import (
     Declare,
-    DeclareV1Schema,
     DeclareV1,
-    InvokeV1Schema,
+    DeclareV1Schema,
     InvokeV1,
+    InvokeV1Schema,
 )
 
 

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -6,9 +6,9 @@ from starknet_py.common import create_contract_class
 from starknet_py.net.client_models import TransactionType
 from starknet_py.net.models.transaction import (
     Declare,
-    DeclareSchema,
+    DeclareV1Schema,
     DeclareV1,
-    InvokeSchema,
+    InvokeV1Schema,
     InvokeV1,
 )
 
@@ -24,7 +24,7 @@ def test_declare_compress_program(balance_contract):
         version=1,
     )
 
-    schema = DeclareSchema()
+    schema = DeclareV1Schema()
 
     serialized = typing.cast(dict, schema.dump(declare_transaction))
     # Pattern used in match taken from
@@ -48,8 +48,8 @@ def test_serialize_deserialize_invoke():
         "version": "0x1",
         "type": "INVOKE_FUNCTION",
     }
-    invoke = InvokeSchema().load(data)
-    serialized_invoke = InvokeSchema().dump(invoke)
+    invoke = InvokeV1Schema().load(data)
+    serialized_invoke = InvokeV1Schema().dump(invoke)
 
     assert isinstance(invoke, InvokeV1)
     assert invoke.type == TransactionType.INVOKE

--- a/starknet_py/net/models/transaction_test.py
+++ b/starknet_py/net/models/transaction_test.py
@@ -7,14 +7,15 @@ from starknet_py.net.client_models import TransactionType
 from starknet_py.net.models.transaction import (
     Declare,
     DeclareSchema,
-    Invoke,
+    DeclareV1,
     InvokeSchema,
+    InvokeV1,
 )
 
 
 def test_declare_compress_program(balance_contract):
     contract_class = create_contract_class(balance_contract)
-    declare_transaction = Declare(
+    declare_transaction = DeclareV1(
         contract_class=contract_class,
         sender_address=0x1234,
         max_fee=0x1111,
@@ -50,7 +51,7 @@ def test_serialize_deserialize_invoke():
     invoke = InvokeSchema().load(data)
     serialized_invoke = InvokeSchema().dump(invoke)
 
-    assert isinstance(invoke, Invoke)
+    assert isinstance(invoke, InvokeV1)
     assert invoke.type == TransactionType.INVOKE
     assert isinstance(serialized_invoke, dict)
     assert serialized_invoke["type"] == "INVOKE_FUNCTION"

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -6,6 +6,7 @@ from marshmallow import Schema, ValidationError, fields, post_load
 from starknet_py.net.client_models import (
     BlockStatus,
     CallType,
+    DAMode,
     EntryPointType,
     PriceUnit,
     StorageEntry,
@@ -233,6 +234,25 @@ class PriceUnitField(fields.Field):
             raise ValidationError(f"Invalid value provided for PriceUnit: {value}.")
 
         return PriceUnit(value)
+
+
+class DAModeField(fields.Field):
+    def _serialize(self, value: Any, attr: str, obj: Any, **kwargs):
+        return value.name if value is not None else ""
+
+    def _deserialize(
+        self,
+        value: Any,
+        attr: Optional[str],
+        data: Optional[Mapping[str, Any]],
+        **kwargs,
+    ) -> DAMode:
+        names = [v.name for v in DAMode]
+
+        if value not in names:
+            raise ValidationError(f"Invalid value provided for DAMode: {value}.")
+
+        return DAMode[value]
 
 
 class StorageEntrySchema(Schema):

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -7,6 +7,7 @@ from starknet_py.net.client_models import (
     BlockStatus,
     CallType,
     EntryPointType,
+    PriceUnit,
     StorageEntry,
     TransactionExecutionStatus,
     TransactionFinalityStatus,
@@ -213,6 +214,25 @@ class CallTypeField(fields.Field):
             raise ValidationError(f"Invalid value provided for CallType: {value}.")
 
         return CallType(value)
+
+
+class PriceUnitField(fields.Field):
+    def _serialize(self, value: Any, attr: str, obj: Any, **kwargs):
+        return value.name if value is not None else ""
+
+    def _deserialize(
+        self,
+        value: Any,
+        attr: Optional[str],
+        data: Optional[Mapping[str, Any]],
+        **kwargs,
+    ) -> PriceUnit:
+        values = [v.value for v in PriceUnit]
+
+        if value not in values:
+            raise ValidationError(f"Invalid value provided for PriceUnit: {value}.")
+
+        return PriceUnit(value)
 
 
 class StorageEntrySchema(Schema):

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -290,6 +290,9 @@ class DeclareTransactionV3Schema(TransactionV3Schema):
     compiled_class_hash = Felt(data_key="compiled_class_hash", load_default=None)
     nonce = Felt(data_key="nonce", required=True)
     sender_address = Felt(data_key="sender_address", required=True)
+    account_deployment_data = fields.List(
+        Felt(), data_key="account_deployment_data", load_default=[]
+    )
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> DeclareTransactionV3:

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -158,7 +158,7 @@ class TransactionReceiptSchema(Schema):
     block_number = fields.Integer(data_key="block_number", load_default=None)
     block_hash = Felt(data_key="block_hash", load_default=None)
     actual_fee = fields.Nested(FeePaymentSchema(), data_key="actual_fee", required=True)
-    type = TransactionTypeField(data_key="type", load_default=None)
+    type = TransactionTypeField(data_key="type", required=True)
     contract_address = Felt(data_key="contract_address", load_default=None)
     revert_reason = fields.String(data_key="revert_reason", load_default=None)
     events = fields.List(

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -232,6 +232,10 @@ class TransactionSchema(Schema):
     version = Felt(data_key="version", required=True)
 
 
+class DeprecatedTransactionSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", required=True)
+
+
 class TransactionV3Schema(TransactionSchema):
     tip = Felt(data_key="tip", load_default=0)
     nonce_data_availability_mode = DAModeField(
@@ -246,8 +250,7 @@ class TransactionV3Schema(TransactionSchema):
     )
 
 
-class InvokeTransactionDeprecatedSchema(TransactionSchema):
-    max_fee = Felt(data_key="max_fee", load_default=0)
+class DeprecatedInvokeTransactionSchema(DeprecatedTransactionSchema):
     contract_address = Felt(data_key="contract_address", load_default=None)
     sender_address = Felt(data_key="sender_address", load_default=None)
     entry_point_selector = Felt(data_key="entry_point_selector", load_default=None)
@@ -273,8 +276,7 @@ class InvokeTransactionV3Schema(TransactionV3Schema):
         return InvokeTransactionV3(**data)
 
 
-class DeclareTransactionDeprecatedSchema(TransactionSchema):
-    max_fee = Felt(data_key="max_fee", load_default=0)
+class DeprecatedDeclareTransactionSchema(DeprecatedTransactionSchema):
     class_hash = Felt(data_key="class_hash", required=True)
     sender_address = Felt(data_key="sender_address", required=True)
     nonce = Felt(data_key="nonce", load_default=None)
@@ -311,8 +313,7 @@ class DeployTransactionSchema(TransactionSchema):
         return DeployTransaction(**data)
 
 
-class DeployAccountTransactionDeprecatedSchema(TransactionSchema):
-    max_fee = Felt(data_key="max_fee", load_default=0)
+class DeprecatedDeployAccountTransactionSchema(DeprecatedTransactionSchema):
     contract_address_salt = Felt(data_key="contract_address_salt", required=True)
     constructor_calldata = fields.List(
         Felt(), data_key="constructor_calldata", required=True
@@ -340,9 +341,9 @@ class DeployAccountTransactionV3Schema(TransactionV3Schema):
 
 class DeclareTransactionSchema(OneOfSchema):
     type_schemas = {
-        0: DeclareTransactionDeprecatedSchema,
-        1: DeclareTransactionDeprecatedSchema,
-        2: DeclareTransactionDeprecatedSchema,
+        0: DeprecatedDeclareTransactionSchema,
+        1: DeprecatedDeclareTransactionSchema,
+        2: DeprecatedDeclareTransactionSchema,
         3: DeclareTransactionV3Schema,
     }
 
@@ -352,8 +353,8 @@ class DeclareTransactionSchema(OneOfSchema):
 
 class InvokeTransactionSchema(OneOfSchema):
     type_schemas = {
-        0: InvokeTransactionDeprecatedSchema,
-        1: InvokeTransactionDeprecatedSchema,
+        0: DeprecatedInvokeTransactionSchema,
+        1: DeprecatedInvokeTransactionSchema,
         3: InvokeTransactionV3Schema,
     }
 
@@ -363,7 +364,7 @@ class InvokeTransactionSchema(OneOfSchema):
 
 class DeployAccountTransactionSchema(OneOfSchema):
     type_schemas = {
-        1: DeployAccountTransactionDeprecatedSchema,
+        1: DeprecatedDeployAccountTransactionSchema,
         3: DeployAccountTransactionV3Schema,
     }
 
@@ -372,7 +373,6 @@ class DeployAccountTransactionSchema(OneOfSchema):
 
 
 class L1HandlerTransactionSchema(TransactionSchema):
-    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address = Felt(data_key="contract_address", required=True)
     calldata = fields.List(Felt(), data_key="calldata", required=True)
     entry_point_selector = Felt(data_key="entry_point_selector", required=True)

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -200,7 +200,7 @@ class TransactionStatusResponseSchema(Schema):
 
 
 class ResourcePriceSchema(Schema):
-    price_in_fri = Felt(data_key="price_in_fri", load_default=None)
+    price_in_fri = Felt(data_key="price_in_fri", required=True)
     price_in_wei = Felt(data_key="price_in_wei", required=True)
 
     @post_load

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -297,7 +297,6 @@ class DeclareTransactionV3Schema(TransactionV3Schema):
 
 
 class DeployTransactionSchema(TransactionSchema):
-    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address_salt = Felt(data_key="contract_address_salt", required=True)
     constructor_calldata = fields.List(
         Felt(), data_key="constructor_calldata", required=True

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -8,13 +8,16 @@ from starknet_py.net.client_models import (
     BlockTransactionTrace,
     ContractClass,
     ContractsNonce,
+    DAMode,
     DeclaredContractHash,
     DeclareTransaction,
     DeclareTransactionResponse,
     DeclareTransactionTrace,
+    DeclareTransactionV3,
     DeployAccountTransaction,
     DeployAccountTransactionResponse,
     DeployAccountTransactionTrace,
+    DeployAccountTransactionV3,
     DeployedContract,
     DeployTransaction,
     EntryPoint,
@@ -23,9 +26,11 @@ from starknet_py.net.client_models import (
     Event,
     EventsChunk,
     ExecutionResources,
+    FeePayment,
     FunctionInvocation,
     InvokeTransaction,
     InvokeTransactionTrace,
+    InvokeTransactionV3,
     L1HandlerTransaction,
     L1HandlerTransactionTrace,
     L2toL1Message,
@@ -35,6 +40,8 @@ from starknet_py.net.client_models import (
     PendingStarknetBlock,
     PendingStarknetBlockWithTxHashes,
     ReplacedClass,
+    ResourceBounds,
+    ResourceBoundsMapping,
     ResourcePrice,
     RevertedFunctionInvocation,
     SentTransactionResponse,
@@ -58,11 +65,13 @@ from starknet_py.net.schemas.common import (
     Felt,
     FinalityStatusField,
     NonPrefixedHex,
+    PriceUnitField,
     StatusField,
     StorageEntrySchema,
     TransactionTypeField,
 )
 from starknet_py.net.schemas.utils import (
+    _extract_tx_version,
     _replace_invoke_contract_address_with_sender_address,
 )
 
@@ -105,25 +114,25 @@ class L2toL1MessageSchema(Schema):
 class ExecutionResourcesSchema(Schema):
     steps = Felt(data_key="steps", required=True)
     range_check_builtin_applications = Felt(
-        data_key="range_check_builtin_applications", required=True
+        data_key="range_check_builtin_applications", load_default=None
     )
     pedersen_builtin_applications = Felt(
-        data_key="pedersen_builtin_applications", required=True
+        data_key="pedersen_builtin_applications", load_default=None
     )
     poseidon_builtin_applications = Felt(
-        data_key="poseidon_builtin_applications", required=True
+        data_key="poseidon_builtin_applications", load_default=None
     )
     ec_op_builtin_applications = Felt(
-        data_key="ec_op_builtin_applications", required=True
+        data_key="ec_op_builtin_applications", load_default=None
     )
     ecdsa_builtin_applications = Felt(
-        data_key="ecdsa_builtin_applications", required=True
+        data_key="ecdsa_builtin_applications", load_default=None
     )
     bitwise_builtin_applications = Felt(
-        data_key="bitwise_builtin_applications", required=True
+        data_key="bitwise_builtin_applications", load_default=None
     )
     keccak_builtin_applications = Felt(
-        data_key="keccak_builtin_applications", required=True
+        data_key="keccak_builtin_applications", load_default=None
     )
     memory_holes = Felt(data_key="memory_holes", load_default=None)
 
@@ -132,13 +141,22 @@ class ExecutionResourcesSchema(Schema):
         return ExecutionResources(**data)
 
 
+class FeePaymentSchema(Schema):
+    amount = Felt(data_key="amount", required=True)
+    unit = PriceUnitField(data_key="unit", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> FeePayment:
+        return FeePayment(**data)
+
+
 class TransactionReceiptSchema(Schema):
     transaction_hash = Felt(data_key="transaction_hash", required=True)
     execution_status = ExecutionStatusField(data_key="execution_status", required=True)
     finality_status = FinalityStatusField(data_key="finality_status", required=True)
     block_number = fields.Integer(data_key="block_number", load_default=None)
     block_hash = Felt(data_key="block_hash", load_default=None)
-    actual_fee = Felt(data_key="actual_fee", required=True)
+    actual_fee = fields.Nested(FeePaymentSchema(), data_key="actual_fee", required=True)
     type = TransactionTypeField(data_key="type", load_default=None)
     contract_address = Felt(data_key="contract_address", load_default=None)
     revert_reason = fields.String(data_key="revert_reason", load_default=None)
@@ -162,6 +180,7 @@ class EstimatedFeeSchema(Schema):
     overall_fee = Felt(data_key="overall_fee", required=True)
     gas_price = Felt(data_key="gas_price", required=True)
     gas_usage = Felt(data_key="gas_consumed", required=True)
+    unit = PriceUnitField(data_key="unit", required=True)
 
     @post_load
     def make_dataclass(self, data, **kwargs):
@@ -180,7 +199,7 @@ class TransactionStatusResponseSchema(Schema):
 
 
 class ResourcePriceSchema(Schema):
-    price_in_strk = Felt(data_key="price_in_strk", load_default=None)
+    price_in_fri = Felt(data_key="price_in_fri", load_default=None)
     price_in_wei = Felt(data_key="price_in_wei", required=True)
 
     @post_load
@@ -188,14 +207,46 @@ class ResourcePriceSchema(Schema):
         return ResourcePrice(**data)
 
 
+class ResourceBoundsSchema(Schema):
+    max_amount = Felt(data_key="max_amount", required=True)
+    max_price_per_unit = Felt(data_key="max_price_per_unit", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> ResourceBounds:
+        return ResourceBounds(**data)
+
+
+class ResourceBoundsMappingSchema(Schema):
+    l1_gas = fields.Nested(ResourceBoundsSchema(), data_key="l1_gas", required=True)
+    l2_gas = fields.Nested(ResourceBoundsSchema(), data_key="l2_gas", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> ResourceBoundsMapping:
+        return ResourceBoundsMapping(**data)
+
+
 class TransactionSchema(Schema):
     hash = Felt(data_key="transaction_hash", load_default=None)
     signature = fields.List(Felt(), data_key="signature", load_default=[])
-    max_fee = Felt(data_key="max_fee", load_default=0)
     version = Felt(data_key="version", required=True)
 
 
-class InvokeTransactionSchema(TransactionSchema):
+class TransactionV3Schema(TransactionSchema):
+    tip = Felt(data_key="tip", load_default=0)
+    nonce_data_availability_mode = Felt(
+        data_key="nonce_data_availability_mode", load_default=DAMode.L1
+    )
+    fee_data_availability_mode = Felt(
+        data_key="fee_data_availability_mode", load_default=DAMode.L1
+    )
+    paymaster_data = fields.List(Felt(), data_key="calldata", load_default=[])
+    resource_bounds = fields.Nested(
+        ResourceBoundsMappingSchema(), data_key="resource_bounds", required=True
+    )
+
+
+class InvokeTransactionDeprecatedSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address = Felt(data_key="contract_address", load_default=None)
     sender_address = Felt(data_key="sender_address", load_default=None)
     entry_point_selector = Felt(data_key="entry_point_selector", load_default=None)
@@ -208,7 +259,19 @@ class InvokeTransactionSchema(TransactionSchema):
         return InvokeTransaction(**data)
 
 
-class DeclareTransactionSchema(TransactionSchema):
+class InvokeTransactionV3Schema(TransactionSchema):
+    sender_address = Felt(data_key="sender_address", required=True)
+    calldata = fields.List(Felt(), data_key="calldata", required=True)
+    account_deployment_data = fields.List(Felt(), data_key="calldata", required=True)
+    nonce = Felt(data_key="nonce", required=True)
+
+    @post_load
+    def make_transaction(self, data, **kwargs) -> InvokeTransactionV3:
+        return InvokeTransactionV3(**data)
+
+
+class DeclareTransactionDeprecatedSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", load_default=0)
     class_hash = Felt(data_key="class_hash", required=True)
     sender_address = Felt(data_key="sender_address", required=True)
     nonce = Felt(data_key="nonce", load_default=None)
@@ -219,7 +282,19 @@ class DeclareTransactionSchema(TransactionSchema):
         return DeclareTransaction(**data)
 
 
+class DeclareTransactionV3Schema(TransactionV3Schema):
+    class_hash = Felt(data_key="class_hash", required=True)
+    compiled_class_hash = Felt(data_key="compiled_class_hash", load_default=None)
+    nonce = Felt(data_key="nonce", required=True)
+    sender_address = Felt(data_key="sender_address", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> DeclareTransactionV3:
+        return DeclareTransactionV3(**data)
+
+
 class DeployTransactionSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address_salt = Felt(data_key="contract_address_salt", required=True)
     constructor_calldata = fields.List(
         Felt(), data_key="constructor_calldata", required=True
@@ -231,7 +306,8 @@ class DeployTransactionSchema(TransactionSchema):
         return DeployTransaction(**data)
 
 
-class DeployAccountTransactionSchema(TransactionSchema):
+class DeployAccountTransactionDeprecatedSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address_salt = Felt(data_key="contract_address_salt", required=True)
     constructor_calldata = fields.List(
         Felt(), data_key="constructor_calldata", required=True
@@ -244,7 +320,54 @@ class DeployAccountTransactionSchema(TransactionSchema):
         return DeployAccountTransaction(**data)
 
 
+class DeployAccountTransactionV3Schema(TransactionV3Schema):
+    contract_address_salt = Felt(data_key="contract_address_salt", required=True)
+    constructor_calldata = fields.List(
+        Felt(), data_key="constructor_calldata", required=True
+    )
+    class_hash = Felt(data_key="class_hash", required=True)
+    nonce = Felt(data_key="nonce", load_default=None)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> DeployAccountTransactionV3:
+        return DeployAccountTransactionV3(**data)
+
+
+class DeclareTransactionSchema(OneOfSchema):
+    type_schemas = {
+        0: DeclareTransactionDeprecatedSchema,
+        1: DeclareTransactionDeprecatedSchema,
+        2: DeclareTransactionDeprecatedSchema,
+        3: DeclareTransactionV3Schema,
+    }
+
+    def get_data_type(self, data):
+        return _extract_tx_version(data.get("version"))
+
+
+class InvokeTransactionSchema(OneOfSchema):
+    type_schemas = {
+        0: InvokeTransactionDeprecatedSchema,
+        1: InvokeTransactionDeprecatedSchema,
+        3: InvokeTransactionV3,
+    }
+
+    def get_data_type(self, data):
+        return _extract_tx_version(data.get("version"))
+
+
+class DeployAccountTransactionSchema(OneOfSchema):
+    type_schemas = {
+        1: DeployAccountTransactionDeprecatedSchema,
+        3: DeclareTransactionV3Schema,
+    }
+
+    def get_data_type(self, data):
+        return _extract_tx_version(data.get("version"))
+
+
 class L1HandlerTransactionSchema(TransactionSchema):
+    max_fee = Felt(data_key="max_fee", load_default=0)
     contract_address = Felt(data_key="contract_address", required=True)
     calldata = fields.List(Felt(), data_key="calldata", required=True)
     entry_point_selector = Felt(data_key="entry_point_selector", required=True)
@@ -626,6 +749,9 @@ class FunctionInvocationSchema(Schema):
     )
     messages = fields.List(
         fields.Nested(L2toL1MessageSchema()), data_key="messages", required=True
+    )
+    execution_resources = fields.Nested(
+        ExecutionResourcesSchema(), data_key="execution_resources", required=True
     )
 
     @post_load

--- a/starknet_py/net/schemas/utils.py
+++ b/starknet_py/net/schemas/utils.py
@@ -1,3 +1,8 @@
+from typing import Union
+
+from starknet_py.constants import QUERY_VERSION_BASE
+
+
 def _replace_invoke_contract_address_with_sender_address(data: dict):
     data["sender_address"] = data.get("sender_address") or data.get("contract_address")
 
@@ -7,3 +12,9 @@ def _replace_invoke_contract_address_with_sender_address(data: dict):
         )
 
     del data["contract_address"]
+
+
+def _extract_tx_version(version: Union[int, str]):
+    if isinstance(version, str):
+        version = int(version, 16)
+    return version % QUERY_VERSION_BASE

--- a/starknet_py/net/signer/stark_curve_signer.py
+++ b/starknet_py/net/signer/stark_curve_signer.py
@@ -1,25 +1,10 @@
 from dataclasses import dataclass
-from typing import List, cast
+from typing import List
 
-from starknet_py.constants import DEFAULT_ENTRY_POINT_SELECTOR
-from starknet_py.hash.address import compute_address
-from starknet_py.hash.transaction import (
-    TransactionHashPrefix,
-    compute_declare_transaction_hash,
-    compute_declare_v2_transaction_hash,
-    compute_deploy_account_transaction_hash,
-    compute_transaction_hash,
-)
 from starknet_py.hash.utils import message_signature, private_to_stark_key
 from starknet_py.net.client_models import Hash
 from starknet_py.net.models import AddressRepresentation, StarknetChainId, parse_address
-from starknet_py.net.models.transaction import (
-    AccountTransaction,
-    Declare,
-    DeclareV2,
-    DeployAccount,
-    Invoke,
-)
+from starknet_py.net.models.transaction import AccountTransaction
 from starknet_py.net.signer.base_signer import BaseSigner
 from starknet_py.utils.typed_data import TypedData
 
@@ -76,73 +61,7 @@ class StarkCurveSigner(BaseSigner):
         self,
         transaction: AccountTransaction,
     ) -> List[int]:
-        if isinstance(transaction, Declare):
-            return self._sign_declare_transaction(transaction)
-        if isinstance(transaction, DeclareV2):
-            return self._sign_declare_v2_transaction(transaction)
-        if isinstance(transaction, DeployAccount):
-            return self._sign_deploy_account_transaction(transaction)
-        return self._sign_transaction(cast(Invoke, transaction))
-
-    def _sign_transaction(self, transaction: Invoke):
-        tx_hash = compute_transaction_hash(
-            tx_hash_prefix=TransactionHashPrefix.INVOKE,
-            version=transaction.version,
-            contract_address=self.address,
-            entry_point_selector=DEFAULT_ENTRY_POINT_SELECTOR,
-            calldata=transaction.calldata,
-            max_fee=transaction.max_fee,
-            chain_id=self.chain_id,
-            additional_data=[transaction.nonce],
-        )
-        # pylint: disable=invalid-name
-        r, s = message_signature(msg_hash=tx_hash, priv_key=self.private_key)
-        return [r, s]
-
-    def _sign_declare_transaction(self, transaction: Declare) -> List[int]:
-        tx_hash = compute_declare_transaction_hash(
-            contract_class=transaction.contract_class,
-            chain_id=self.chain_id,
-            sender_address=self.address,
-            max_fee=transaction.max_fee,
-            version=transaction.version,
-            nonce=transaction.nonce,
-        )
-        # pylint: disable=invalid-name
-        r, s = message_signature(msg_hash=tx_hash, priv_key=self.private_key)
-        return [r, s]
-
-    def _sign_declare_v2_transaction(self, transaction: DeclareV2) -> List[int]:
-        tx_hash = compute_declare_v2_transaction_hash(
-            contract_class=transaction.contract_class,
-            compiled_class_hash=transaction.compiled_class_hash,
-            chain_id=self.chain_id,
-            sender_address=self.address,
-            max_fee=transaction.max_fee,
-            version=transaction.version,
-            nonce=transaction.nonce,
-        )
-        # pylint: disable=invalid-name
-        r, s = message_signature(msg_hash=tx_hash, priv_key=self.private_key)
-        return [r, s]
-
-    def _sign_deploy_account_transaction(self, transaction: DeployAccount) -> List[int]:
-        contract_address = compute_address(
-            salt=transaction.contract_address_salt,
-            class_hash=transaction.class_hash,
-            constructor_calldata=transaction.constructor_calldata,
-            deployer_address=0,
-        )
-        tx_hash = compute_deploy_account_transaction_hash(
-            contract_address=contract_address,
-            class_hash=transaction.class_hash,
-            constructor_calldata=transaction.constructor_calldata,
-            salt=transaction.contract_address_salt,
-            max_fee=transaction.max_fee,
-            version=transaction.version,
-            chain_id=self.chain_id,
-            nonce=transaction.nonce,
-        )
+        tx_hash = transaction.calculate_hash(self.chain_id)
         # pylint: disable=invalid-name
         r, s = message_signature(msg_hash=tx_hash, priv_key=self.private_key)
         return [r, s]

--- a/starknet_py/net/signer/test_stark_curve_signer.py
+++ b/starknet_py/net/signer/test_stark_curve_signer.py
@@ -2,7 +2,7 @@ import pytest
 
 from starknet_py.common import create_compiled_contract
 from starknet_py.net.models import StarknetChainId
-from starknet_py.net.models.transaction import Declare, DeployAccount, Invoke
+from starknet_py.net.models.transaction import DeclareV1, DeployAccountV1, InvokeV1
 from starknet_py.net.signer.stark_curve_signer import KeyPair, StarkCurveSigner
 from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_COMPILED_V0_DIR
 from starknet_py.tests.e2e.fixtures.misc import read_contract
@@ -15,7 +15,7 @@ compiled_contract = read_contract(
 @pytest.mark.parametrize(
     "transaction",
     [
-        Invoke(
+        InvokeV1(
             sender_address=0x1,
             calldata=[1, 2, 3],
             max_fee=10000,
@@ -23,7 +23,7 @@ compiled_contract = read_contract(
             nonce=23,
             version=1,
         ),
-        DeployAccount(
+        DeployAccountV1(
             class_hash=0x1,
             contract_address_salt=0x2,
             constructor_calldata=[1, 2, 3, 4],
@@ -32,7 +32,7 @@ compiled_contract = read_contract(
             nonce=23,
             version=1,
         ),
-        Declare(
+        DeclareV1(
             contract_class=create_compiled_contract(
                 compiled_contract=compiled_contract
             ),

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -79,7 +79,7 @@ async def test_estimated_fee_greater_than_zero(account, erc20_contract):
 
 @pytest.mark.asyncio
 async def test_estimate_fee_for_declare_transaction(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 
@@ -171,8 +171,8 @@ async def test_get_nonce(account, map_contract):
 @pytest.mark.parametrize(
     "calls", [[Call(10, 20, [30])], [Call(10, 20, [30]), Call(40, 50, [60])]]
 )
-async def test_sign_invoke_transaction(account, calls):
-    signed_tx = await account.sign_invoke_transaction(calls, max_fee=MAX_FEE)
+async def test_sign_invoke_v1_transaction(account, calls):
+    signed_tx = await account.sign_invoke_v1_transaction(calls, max_fee=MAX_FEE)
 
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) > 0
@@ -180,8 +180,8 @@ async def test_sign_invoke_transaction(account, calls):
 
 
 @pytest.mark.asyncio
-async def test_sign_invoke_transaction_auto_estimate(account, map_contract):
-    signed_tx = await account.sign_invoke_transaction(
+async def test_sign_invoke_v1_transaction_auto_estimate(account, map_contract):
+    signed_tx = await account.sign_invoke_v1_transaction(
         Call(map_contract.address, get_selector_from_name("put"), [3, 4]),
         auto_estimate=True,
     )
@@ -228,7 +228,7 @@ async def test_sign_invoke_v3_transaction_auto_estimate(account, map_contract):
 
 @pytest.mark.asyncio
 async def test_sign_declare_transaction(account, map_compiled_contract):
-    signed_tx = await account.sign_declare_transaction(
+    signed_tx = await account.sign_declare_v1_transaction(
         map_compiled_contract, max_fee=MAX_FEE
     )
 
@@ -241,7 +241,7 @@ async def test_sign_declare_transaction(account, map_compiled_contract):
 
 @pytest.mark.asyncio
 async def test_sign_declare_transaction_auto_estimate(account, map_compiled_contract):
-    signed_tx = await account.sign_declare_transaction(
+    signed_tx = await account.sign_declare_v1_transaction(
         map_compiled_contract, auto_estimate=True
     )
 
@@ -352,7 +352,7 @@ async def test_declare_contract_raises_on_sierra_contract_without_compiled_class
         ValueError,
         match="Signing sierra contracts requires using `sign_declare_v2_transaction` method.",
     ):
-        await account.sign_declare_transaction(compiled_contract=compiled_contract)
+        await account.sign_declare_v1_transaction(compiled_contract=compiled_contract)
 
 
 @pytest.mark.asyncio
@@ -360,7 +360,7 @@ async def test_sign_deploy_account_transaction(account):
     class_hash = 0x1234
     salt = 0x123
     calldata = [1, 2, 3]
-    signed_tx = await account.sign_deploy_account_transaction(
+    signed_tx = await account.sign_deploy_account_v1_transaction(
         class_hash, salt, calldata, max_fee=MAX_FEE
     )
 
@@ -379,7 +379,7 @@ async def test_sign_deploy_account_transaction_auto_estimate(
     class_hash = account_with_validate_deploy_class_hash
     salt = 0x1234
     calldata = [account.signer.public_key]
-    signed_tx = await account.sign_deploy_account_transaction(
+    signed_tx = await account.sign_deploy_account_v1_transaction(
         class_hash, salt, calldata, auto_estimate=True
     )
 
@@ -598,7 +598,7 @@ async def test_sign_deploy_account_tx_for_fee_estimation(
         chain=StarknetChainId.TESTNET,
     )
 
-    transaction = await account.sign_deploy_account_transaction(
+    transaction = await account.sign_deploy_account_v1_transaction(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],
@@ -623,10 +623,12 @@ async def test_sign_deploy_account_tx_for_fee_estimation(
 @pytest.mark.asyncio
 async def test_sign_transaction_custom_nonce(account, cairo1_hello_starknet_class_hash):
     deployment = Deployer().create_contract_deployment(cairo1_hello_starknet_class_hash)
-    deploy_tx = await account.sign_invoke_transaction(deployment.call, max_fee=MAX_FEE)
+    deploy_tx = await account.sign_invoke_v1_transaction(
+        deployment.call, max_fee=MAX_FEE
+    )
 
     new_balance = 30
-    invoke_tx = await account.sign_invoke_transaction(
+    invoke_tx = await account.sign_invoke_v1_transaction(
         Call(
             deployment.address,
             get_selector_from_name("increase_balance"),

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -32,7 +32,11 @@ from starknet_py.net.models.transaction import (
 )
 from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.net.udc_deployer.deployer import Deployer
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUNDS_L1
+from starknet_py.tests.e2e.fixtures.constants import (
+    MAX_FEE,
+    MAX_RESOURCE_BOUNDS,
+    MAX_RESOURCE_BOUNDS_L1,
+)
 
 
 @pytest.mark.run_on_devnet
@@ -197,13 +201,13 @@ async def test_sign_invoke_v1_transaction_auto_estimate(account, map_contract):
 )
 async def test_sign_invoke_v3_transaction(account, calls):
     signed_tx = await account.sign_invoke_v3_transaction(
-        calls, resource_bounds=MAX_RESOURCE_BOUNDS_L1
+        calls, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
     )
 
     assert isinstance(signed_tx, InvokeV3)
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) == 2
-    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS_L1
+    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS
     assert signed_tx.version == 3
 
 
@@ -306,7 +310,9 @@ async def test_sign_declare_v3_transaction(
     ) = sierra_minimal_compiled_contract_and_class_hash
 
     signed_tx = await account.sign_declare_v3_transaction(
-        compiled_contract, compiled_class_hash, resource_bounds=MAX_RESOURCE_BOUNDS_L1
+        compiled_contract,
+        compiled_class_hash,
+        l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
     )
 
     assert isinstance(signed_tx, DeclareV3)
@@ -314,7 +320,7 @@ async def test_sign_declare_v3_transaction(
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) == 2
     assert signed_tx.nonce is not None
-    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS_L1
+    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS
     assert signed_tx.version == 3
 
 
@@ -399,7 +405,7 @@ async def test_sign_deploy_account_v3_transaction(account):
     signed_tx = await account.sign_deploy_account_v3_transaction(
         class_hash,
         salt,
-        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+        l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
         constructor_calldata=calldata,
     )
 
@@ -409,7 +415,7 @@ async def test_sign_deploy_account_v3_transaction(account):
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) == 2
 
-    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS_L1
+    assert signed_tx.resource_bounds == MAX_RESOURCE_BOUNDS
     assert signed_tx.class_hash == class_hash
     assert signed_tx.contract_address_salt == salt
     assert signed_tx.constructor_calldata == calldata
@@ -747,7 +753,7 @@ async def test_account_execute_v3(account, deployed_balance_contract):
     (initial_balance,) = await account.client.call_contract(call=get_balance_call)
 
     execute_increase_balance = await account.execute_v3(
-        calls=increase_balance_call, resource_bounds=MAX_RESOURCE_BOUNDS_L1
+        calls=increase_balance_call, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
     )
     receipt = await account.client.wait_for_tx(
         tx_hash=execute_increase_balance.transaction_hash

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -24,7 +24,7 @@ from starknet_py.net.client_models import (
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.models import StarknetChainId
 from starknet_py.net.models.transaction import (
-    Declare,
+    DeclareV1,
     DeclareV2,
     DeclareV3,
     DeployAccountV3,
@@ -232,7 +232,7 @@ async def test_sign_declare_transaction(account, map_compiled_contract):
         map_compiled_contract, max_fee=MAX_FEE
     )
 
-    assert isinstance(signed_tx, Declare)
+    assert isinstance(signed_tx, DeclareV1)
     assert signed_tx.version == 1
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) > 0
@@ -245,7 +245,7 @@ async def test_sign_declare_transaction_auto_estimate(account, map_compiled_cont
         map_compiled_contract, auto_estimate=True
     )
 
-    assert isinstance(signed_tx, Declare)
+    assert isinstance(signed_tx, DeclareV1)
     assert signed_tx.version == 1
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) > 0

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -22,6 +22,7 @@ from starknet_py.net.client_models import (
     L1HandlerTransaction,
     PendingBlockStateUpdate,
     PriceUnit,
+    ResourceBounds,
     SierraContractClass,
     SierraEntryPointsByType,
     TransactionExecutionStatus,
@@ -35,11 +36,7 @@ from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.http_client import RpcHttpClient
 from starknet_py.net.models.transaction import DeclareV2
 from starknet_py.net.udc_deployer.deployer import Deployer
-from starknet_py.tests.e2e.fixtures.constants import (
-    CONTRACTS_COMPILED_V0_DIR,
-    MAX_FEE,
-    MAX_RESOURCE_BOUNDS_L1,
-)
+from starknet_py.tests.e2e.fixtures.constants import CONTRACTS_COMPILED_V0_DIR, MAX_FEE
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 from starknet_py.transaction_errors import (
     TransactionNotReceivedError,
@@ -166,7 +163,7 @@ async def test_estimate_fee_invoke_v3(account, contract_address):
             selector=get_selector_from_name("increase_balance"),
             calldata=[123],
         ),
-        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+        l1_resource_bounds=ResourceBounds.init_with_zeros(),
     )
     invoke_tx = await account.sign_for_fee_estimate(invoke_tx)
     estimate_fee = await account.client.estimate_fee(tx=invoke_tx)

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -169,7 +169,7 @@ async def test_estimate_fee_invoke_v3(account, contract_address):
         resource_bounds=MAX_RESOURCE_BOUNDS_L1,
     )
     invoke_tx = await account.sign_for_fee_estimate(invoke_tx)
-    estimate_fee = await account.client.estimate_fee(tx=invoke_tx, skip_validate=True)
+    estimate_fee = await account.client.estimate_fee(tx=invoke_tx)
 
     assert isinstance(estimate_fee, EstimatedFee)
     assert estimate_fee.unit == PriceUnit.FRI

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -140,7 +140,7 @@ async def test_get_transaction_receipt(
 
 @pytest.mark.asyncio
 async def test_estimate_fee_invoke(account, contract_address):
-    invoke_tx = await account.sign_invoke_transaction(
+    invoke_tx = await account.sign_invoke_v1_transaction(
         calls=Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -180,7 +180,7 @@ async def test_estimate_fee_invoke_v3(account, contract_address):
 
 @pytest.mark.asyncio
 async def test_estimate_fee_declare(account):
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=read_contract(
             "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
         ),
@@ -211,7 +211,7 @@ async def test_estimate_fee_deploy_account(client, deploy_account_transaction):
 async def test_estimate_fee_for_multiple_transactions(
     client, deploy_account_transaction, contract_address, account
 ):
-    invoke_tx = await account.sign_invoke_transaction(
+    invoke_tx = await account.sign_invoke_v1_transaction(
         calls=Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -221,7 +221,7 @@ async def test_estimate_fee_for_multiple_transactions(
     )
     invoke_tx = await account.sign_for_fee_estimate(invoke_tx)
 
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=read_contract(
             "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
         ),
@@ -260,7 +260,7 @@ async def test_call_contract(client, contract_address):
 @pytest.mark.asyncio
 async def test_add_transaction(map_contract, client, account):
     prepared_function_call = map_contract.functions["put"].prepare(key=73, value=12)
-    signed_invoke = await account.sign_invoke_transaction(
+    signed_invoke = await account.sign_invoke_v1_transaction(
         calls=prepared_function_call, max_fee=MAX_FEE
     )
 
@@ -373,7 +373,7 @@ async def test_wait_for_tx_unknown_error(
 
 @pytest.mark.asyncio
 async def test_declare_contract(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 
@@ -501,7 +501,7 @@ async def test_state_update_deployed_contracts(
     # setup
     deployer = Deployer()
     contract_deployment = deployer.create_contract_deployment(class_hash=class_hash)
-    deploy_invoke_tx = await account.sign_invoke_transaction(
+    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
         contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -23,7 +23,7 @@ from starknet_py.tests.e2e.utils import (
 @pytest_asyncio.fixture(scope="package")
 async def deploy_account_transaction(
     account_with_validate_deploy_class_hash: int,
-    fee_contract: Contract,
+    eth_fee_contract: Contract,
     strk_fee_contract: Contract,
     network: str,
 ) -> DeployAccount:
@@ -32,7 +32,7 @@ async def deploy_account_transaction(
     """
     address, key_pair, salt, class_hash = await get_deploy_account_details(
         class_hash=account_with_validate_deploy_class_hash,
-        fee_contract=fee_contract,
+        eth_fee_contract=eth_fee_contract,
         strk_fee_contract=strk_fee_contract,
     )
     return await get_deploy_account_transaction(

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -7,7 +7,7 @@ import pytest_asyncio
 from starknet_py.contract import Contract
 from starknet_py.net.account.account import Account
 from starknet_py.net.full_node_client import FullNodeClient
-from starknet_py.net.models.transaction import DeployAccount
+from starknet_py.net.models.transaction import DeployAccountV1
 from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.tests.e2e.client.fixtures.prepare_net_for_gateway_test import (
     PreparedNetworkData,
@@ -26,7 +26,7 @@ async def deploy_account_transaction(
     eth_fee_contract: Contract,
     strk_fee_contract: Contract,
     network: str,
-) -> DeployAccount:
+) -> DeployAccountV1:
     """
     Returns a DeployAccount transaction
     """

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -74,7 +74,7 @@ async def hello_starknet_deploy_transaction_address(
     contract_deployment = deployer.create_contract_deployment_raw(
         class_hash=cairo1_hello_starknet_class_hash
     )
-    deploy_invoke_transaction = await account.sign_invoke_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
         calls=contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -22,13 +22,18 @@ from starknet_py.tests.e2e.utils import (
 
 @pytest_asyncio.fixture(scope="package")
 async def deploy_account_transaction(
-    account_with_validate_deploy_class_hash: int, fee_contract: Contract, network: str
+    account_with_validate_deploy_class_hash: int,
+    fee_contract: Contract,
+    strk_fee_contract: Contract,
+    network: str,
 ) -> DeployAccount:
     """
     Returns a DeployAccount transaction
     """
     address, key_pair, salt, class_hash = await get_deploy_account_details(
-        class_hash=account_with_validate_deploy_class_hash, fee_contract=fee_contract
+        class_hash=account_with_validate_deploy_class_hash,
+        fee_contract=fee_contract,
+        strk_fee_contract=strk_fee_contract,
     )
     return await get_deploy_account_transaction(
         address=address,

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -408,7 +408,7 @@ async def test_simulate_transactions_skip_validate(account, deployed_balance_con
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
     invoke_tx = dataclasses.replace(invoke_tx, signature=[])
 
     simulated_txs = await account.client.simulate_transactions(
@@ -432,7 +432,7 @@ async def test_simulate_transactions_skip_fee_charge(
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
 
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], skip_fee_charge=True, block_number="latest"
@@ -448,7 +448,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], block_number="latest"
     )
@@ -457,7 +457,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(simulated_txs[0].transaction_trace, InvokeTransactionTrace)
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
 
-    invoke_tx = await account.sign_invoke_transaction(
+    invoke_tx = await account.sign_invoke_v1_transaction(
         calls=[call, call], auto_estimate=True
     )
     simulated_txs = await account.client.simulate_transactions(
@@ -474,7 +474,7 @@ async def test_simulate_transactions_declare(account):
     compiled_contract = read_contract(
         "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
     )
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract, max_fee=int(1e16)
     )
 
@@ -495,7 +495,7 @@ async def test_simulate_transactions_two_txs(account, deployed_balance_contract)
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
 
     compiled_v2_contract = read_contract(
         "test_contract_declare_compiled.json", directory=CONTRACTS_COMPILED_V1_DIR
@@ -545,7 +545,7 @@ async def test_simulate_transactions_deploy_account(
         key_pair=key_pair,
         chain=StarknetChainId.TESTNET,
     )
-    deploy_account_tx = await account.sign_deploy_account_transaction(
+    deploy_account_tx = await account.sign_deploy_account_v1_transaction(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -26,7 +26,7 @@ async def test_declare_v3_tx(account, abi_types_compiled_contract_and_class_hash
     declare_tx = await account.sign_declare_v3_transaction(
         compiled_contract=abi_types_compiled_contract_and_class_hash[0],
         compiled_class_hash=abi_types_compiled_contract_and_class_hash[1],
-        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+        l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
     )
     assert isinstance(declare_tx, DeclareV3)
 

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -7,7 +7,7 @@ from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUND
 
 @pytest.mark.asyncio
 async def test_declare_tx(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
     result = await account.client.declare(declare_tx)

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -1,6 +1,8 @@
 import pytest
 
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
+from starknet_py.net.client_models import TransactionExecutionStatus
+from starknet_py.net.models.transaction import DeclareV3
+from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUNDS_L1
 
 
 @pytest.mark.asyncio
@@ -17,3 +19,18 @@ async def test_declare_tx(account, map_compiled_contract):
 async def test_declare_v2_tx(cairo1_minimal_contract_class_hash: int):
     assert isinstance(cairo1_minimal_contract_class_hash, int)
     assert cairo1_minimal_contract_class_hash != 0
+
+
+@pytest.mark.asyncio
+async def test_declare_v3_tx(account, abi_types_compiled_contract_and_class_hash):
+    declare_tx = await account.sign_declare_v3_transaction(
+        compiled_contract=abi_types_compiled_contract_and_class_hash[0],
+        compiled_class_hash=abi_types_compiled_contract_and_class_hash[1],
+        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+    )
+    assert isinstance(declare_tx, DeclareV3)
+
+    result = await account.client.declare(declare_tx)
+    tx_receipt = await account.client.wait_for_tx(tx_hash=result.transaction_hash)
+
+    assert tx_receipt.execution_status == TransactionExecutionStatus.SUCCEEDED

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -14,7 +14,7 @@ async def test_default_deploy_with_class_hash(account, map_class_hash):
 
     contract_deployment = deployer.create_contract_deployment(class_hash=map_class_hash)
 
-    deploy_invoke_tx = await account.sign_invoke_transaction(
+    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
         contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)
@@ -74,7 +74,7 @@ async def test_constructor_arguments_contract_deploy(
         calldata=calldata,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)
@@ -113,7 +113,7 @@ async def test_address_computation(salt, pass_account_address, account, map_clas
         salt=salt,
     )
 
-    deploy_invoke_tx = await account.sign_invoke_transaction(
+    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)
@@ -158,7 +158,7 @@ async def test_create_deployment_call_raw(
         raw_calldata=raw_calldata,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)
@@ -202,7 +202,7 @@ async def test_create_deployment_call_raw_supports_seed_0(
         salt=0,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)

--- a/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
+++ b/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
@@ -43,7 +43,7 @@ async def test_deploy_account_v3(client, deploy_account_details_factory):
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],
-        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+        l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
     )
 
     assert isinstance(deploy_account_tx, DeployAccountV3)

--- a/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
+++ b/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
@@ -17,7 +17,7 @@ async def test_general_flow(client, deploy_account_details_factory):
         chain=StarknetChainId.TESTNET,
     )
 
-    deploy_account_tx = await account.sign_deploy_account_transaction(
+    deploy_account_tx = await account.sign_deploy_account_v1_transaction(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],

--- a/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
+++ b/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
@@ -2,7 +2,8 @@ import pytest
 
 from starknet_py.net.account.account import Account
 from starknet_py.net.models import StarknetChainId
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
+from starknet_py.net.models.transaction import DeployAccountV3
+from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUNDS_L1
 
 
 @pytest.mark.asyncio
@@ -22,6 +23,31 @@ async def test_general_flow(client, deploy_account_details_factory):
         constructor_calldata=[key_pair.public_key],
         max_fee=MAX_FEE,
     )
+    resp = await account.client.deploy_account(transaction=deploy_account_tx)
+
+    assert resp.address == address
+
+
+@pytest.mark.asyncio
+async def test_deploy_account_v3(client, deploy_account_details_factory):
+    address, key_pair, salt, class_hash = await deploy_account_details_factory.get()
+
+    account = Account(
+        address=address,
+        client=client,
+        key_pair=key_pair,
+        chain=StarknetChainId.TESTNET,
+    )
+
+    deploy_account_tx = await account.sign_deploy_account_v3_transaction(
+        class_hash=class_hash,
+        contract_address_salt=salt,
+        constructor_calldata=[key_pair.public_key],
+        resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+    )
+
+    assert isinstance(deploy_account_tx, DeployAccountV3)
+
     resp = await account.client.deploy_account(transaction=deploy_account_tx)
 
     assert resp.address == address

--- a/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
+++ b/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
@@ -11,7 +11,7 @@ from starknet_py.tests.e2e.utils import _get_random_private_key_unsafe
 async def test_deploy_prefunded_account(
     account_with_validate_deploy_class_hash: int,
     network: str,
-    fee_contract: Contract,
+    eth_fee_contract: Contract,
     client: Client,
 ):
     # pylint: disable=import-outside-toplevel, too-many-locals
@@ -43,7 +43,7 @@ async def test_deploy_prefunded_account(
     # Prefund the address (using the token bridge or by sending fee tokens to the computed address)
     # Make sure the tx has been accepted on L2 before proceeding
     # docs: end
-    res = await fee_contract.functions["transfer"].invoke(
+    res = await eth_fee_contract.functions["transfer"].invoke(
         recipient=address, amount=int(1e16), max_fee=MAX_FEE
     )
     await res.wait_for_acceptance()

--- a/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
@@ -233,7 +233,7 @@ async def test_simulate_transactions(
         selector=get_selector_from_name("method_name"),
         calldata=[0xCA11DA7A],
     )
-    first_transaction = await account.sign_invoke_transaction(
+    first_transaction = await account.sign_invoke_v1_transaction(
         calls=call, max_fee=int(1e16)
     )
     # docs-end: simulate_transactions
@@ -243,7 +243,7 @@ async def test_simulate_transactions(
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    first_transaction = await account.sign_invoke_transaction(
+    first_transaction = await account.sign_invoke_v1_transaction(
         calls=call, auto_estimate=True
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
@@ -18,15 +18,15 @@ async def test_account_sign_without_execute(account, map_compiled_contract):
 
     # Create a signed Invoke transaction
     call = Call(to_addr=address, selector=selector, calldata=calldata)
-    invoke_transaction = await account.sign_invoke_transaction(call, max_fee=max_fee)
+    invoke_transaction = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
 
     # Create a signed Declare transaction
-    declare_transaction = await account.sign_declare_transaction(
+    declare_transaction = await account.sign_declare_v1_transaction(
         compiled_contract=compiled_contract, max_fee=max_fee
     )
 
     # Create a signed DeployAccount transaction
-    deploy_account_transaction = await account.sign_deploy_account_transaction(
+    deploy_account_transaction = await account.sign_deploy_account_v1_transaction(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=calldata,

--- a/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
@@ -1,7 +1,7 @@
 import pytest
 
 from starknet_py.net.account.account import Account
-from starknet_py.net.models.transaction import Declare, DeployAccount, Invoke
+from starknet_py.net.models.transaction import DeclareV1, DeployAccountV1, InvokeV1
 
 
 @pytest.mark.asyncio
@@ -34,6 +34,6 @@ async def test_account_sign_without_execute(account, map_compiled_contract):
     )
     # docs: end
 
-    assert isinstance(invoke_transaction, Invoke)
-    assert isinstance(declare_transaction, Declare)
-    assert isinstance(deploy_account_transaction, DeployAccount)
+    assert isinstance(invoke_transaction, InvokeV1)
+    assert isinstance(declare_transaction, DeclareV1)
+    assert isinstance(deploy_account_transaction, DeployAccountV1)

--- a/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
+++ b/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
@@ -38,7 +38,7 @@ async def test_cairo1_contract(
 
     # docs: start
 
-    # Create Declare v2 transaction
+    # Create Declare v2 transaction (to create Declare v3 transaction use `sign_declare_v3_transaction` method)
     declare_v2_transaction = await account.sign_declare_v2_transaction(
         # compiled_contract is a string containing the content of the starknet-compile (.json file)
         compiled_contract=compiled_contract,
@@ -46,7 +46,7 @@ async def test_cairo1_contract(
         max_fee=MAX_FEE,
     )
 
-    # Send Declare v2 transaction
+    # Send transaction
     resp = await account.client.declare(transaction=declare_v2_transaction)
     await account.client.wait_for_tx(resp.transaction_hash)
 

--- a/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starknet_py.net.models import Invoke
+from starknet_py.net.models import InvokeV1
 
 
 @pytest.mark.asyncio
@@ -20,4 +20,4 @@ async def test_create_invoke_from_contract(map_contract, account):
     invoke_transaction = await account.sign_invoke_transaction(call, max_fee=max_fee)
     # docs: end
 
-    assert isinstance(invoke_transaction, Invoke)
+    assert isinstance(invoke_transaction, InvokeV1)

--- a/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
@@ -17,7 +17,7 @@ async def test_create_invoke_from_contract(map_contract, account):
     assert issubclass(type(call), Call)
 
     # Crate an Invoke transaction from call
-    invoke_transaction = await account.sign_invoke_transaction(call, max_fee=max_fee)
+    invoke_transaction = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
     # docs: end
 
     assert isinstance(invoke_transaction, InvokeV1)

--- a/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
+++ b/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
@@ -61,5 +61,7 @@ async def test_custom_nonce(account):
     # docs: end
 
     assert account.nonce_counter == 0
-    await account.sign_invoke_transaction(calls=Call(0x1, 0x1, []), max_fee=10000000000)
+    await account.sign_invoke_v1_transaction(
+        calls=Call(0x1, 0x1, []), max_fee=10000000000
+    )
     assert account.nonce_counter == 1

--- a/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
@@ -6,9 +6,9 @@ async def test_declaring_contracts(account, map_compiled_contract):
     contract_compiled = map_compiled_contract
 
     # docs: start
-    # Account.sign_declare_transaction takes contract source code or compiled contract
+    # Account.sign_declare_v1_transaction takes contract source code or compiled contract
     # and returns Declare transaction
-    declare_transaction = await account.sign_declare_transaction(
+    declare_transaction = await account.sign_declare_v1_transaction(
         compiled_contract=contract_compiled, max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
@@ -30,7 +30,7 @@ async def test_deploying_in_multicall(account, map_class_hash, map_compiled_cont
 
     # After that multicall transaction can be sent
     # Note that `deploy_call` and `put_call` are two regular calls!
-    invoke_tx = await account.sign_invoke_transaction(
+    invoke_tx = await account.sign_invoke_v1_transaction(
         calls=[deploy_call, put_call], max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -80,7 +80,7 @@ async def test_deploying_with_udc(
     )
     # docs: start
     # Or signed and send with an account
-    invoke_tx = await account.sign_invoke_transaction(deploy_call, max_fee=int(1e16))
+    invoke_tx = await account.sign_invoke_v1_transaction(deploy_call, max_fee=int(1e16))
     resp = await account.client.send_transaction(invoke_tx)
 
     # Wait for transaction

--- a/starknet_py/tests/e2e/docs/guide/test_sign_for_fee_estimate.py
+++ b/starknet_py/tests/e2e/docs/guide/test_sign_for_fee_estimate.py
@@ -6,7 +6,7 @@ async def test_signing_fee_estimate(account, map_contract):
     # docs: start
     # Create a transaction
     call = map_contract.functions["put"].prepare(key=10, value=20)
-    transaction = await account.sign_invoke_transaction(calls=call, max_fee=0)
+    transaction = await account.sign_invoke_v1_transaction(calls=call, max_fee=0)
 
     # Re-sign a transaction for fee estimation
     estimate_transaction = await account.sign_for_fee_estimate(transaction)
@@ -20,7 +20,7 @@ async def test_signing_fee_estimate(account, map_contract):
     assert estimate.overall_fee > 0
 
     # Use a new fee in original transaction
-    transaction = await account.sign_invoke_transaction(
+    transaction = await account.sign_invoke_v1_transaction(
         calls=call, max_fee=estimate.overall_fee
     )
 

--- a/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
+++ b/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
@@ -27,12 +27,12 @@ async def test_account_comparison(gateway_account, map_contract):
     # docs-2: start
     # Sending transactions
 
-    tx = await account_client.sign_invoke_transaction(call, max_fee)
+    tx = await account_client.sign_invoke_v1_transaction(call, max_fee)
     await account_client.send_transaction(tx)
 
     # becomes
 
-    tx = await account.sign_invoke_transaction(call, max_fee=max_fee)
+    tx = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
     # Note that max_fee is now keyword-only argument
     await account.client.send_transaction(tx)
     # docs-2: end

--- a/starknet_py/tests/e2e/fixtures/accounts.py
+++ b/starknet_py/tests/e2e/fixtures/accounts.py
@@ -134,7 +134,7 @@ def full_node_account(
 @dataclass
 class AccountToBeDeployedDetailsFactory:
     class_hash: int
-    fee_contract: Contract
+    eth_fee_contract: Contract
     strk_fee_contract: Contract
 
     async def get(
@@ -142,7 +142,7 @@ class AccountToBeDeployedDetailsFactory:
     ) -> AccountToBeDeployedDetails:
         return await get_deploy_account_details(
             class_hash=class_hash if class_hash is not None else self.class_hash,
-            fee_contract=self.fee_contract,
+            eth_fee_contract=self.eth_fee_contract,
             strk_fee_contract=self.strk_fee_contract,
             argent_calldata=argent_calldata,
         )
@@ -151,7 +151,7 @@ class AccountToBeDeployedDetailsFactory:
 @pytest_asyncio.fixture(scope="package")
 async def deploy_account_details_factory(
     account_with_validate_deploy_class_hash: int,
-    fee_contract: Contract,
+    eth_fee_contract: Contract,
     strk_fee_contract: Contract,
 ) -> AccountToBeDeployedDetailsFactory:
     """
@@ -163,7 +163,7 @@ async def deploy_account_details_factory(
     """
     return AccountToBeDeployedDetailsFactory(
         class_hash=account_with_validate_deploy_class_hash,
-        fee_contract=fee_contract,
+        eth_fee_contract=eth_fee_contract,
         strk_fee_contract=strk_fee_contract,
     )
 

--- a/starknet_py/tests/e2e/fixtures/constants.py
+++ b/starknet_py/tests/e2e/fixtures/constants.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from starknet_py.net.client_models import ResourceBounds, ResourceBoundsMapping
+
 load_dotenv(dotenv_path=Path(os.path.dirname(__file__)) / "../test-variables.env")
 
 
@@ -56,7 +58,16 @@ DEVNET_PRE_DEPLOYED_ACCOUNT_ADDRESS = (
 )
 DEVNET_PRE_DEPLOYED_ACCOUNT_PRIVATE_KEY = "0xc10662b7b247c7cecf7e8a30726cff12"
 
+STRK_FEE_CONTRACT_ADDRESS = (
+    "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+)
+
 MAX_FEE = int(1e16)
+
+MAX_RESOURCE_BOUNDS_L1 = ResourceBoundsMapping(
+    l1_gas=ResourceBounds(max_amount=5000, max_price_per_unit=int(2e12)),
+    l2_gas=ResourceBounds(max_amount=0, max_price_per_unit=0),
+)
 
 MOCK_DIR = Path(os.path.dirname(__file__)) / "../mock"
 TYPED_DATA_DIR = MOCK_DIR / "typed_data"

--- a/starknet_py/tests/e2e/fixtures/constants.py
+++ b/starknet_py/tests/e2e/fixtures/constants.py
@@ -64,9 +64,9 @@ STRK_FEE_CONTRACT_ADDRESS = (
 
 MAX_FEE = int(1e16)
 
-MAX_RESOURCE_BOUNDS_L1 = ResourceBoundsMapping(
-    l1_gas=ResourceBounds(max_amount=5000, max_price_per_unit=int(2e12)),
-    l2_gas=ResourceBounds(max_amount=0, max_price_per_unit=0),
+MAX_RESOURCE_BOUNDS_L1 = ResourceBounds(max_amount=5000, max_price_per_unit=int(2e12))
+MAX_RESOURCE_BOUNDS = ResourceBoundsMapping(
+    l1_gas=MAX_RESOURCE_BOUNDS_L1, l2_gas=ResourceBounds.init_with_zeros()
 )
 
 MOCK_DIR = Path(os.path.dirname(__file__)) / "../mock"

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -20,6 +20,7 @@ from starknet_py.tests.e2e.fixtures.constants import (
     CONTRACTS_COMPILED_V2_DIR,
     CONTRACTS_DIR,
     MAX_FEE,
+    STRK_FEE_CONTRACT_ADDRESS,
 )
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 
@@ -47,6 +48,24 @@ def sierra_minimal_compiled_contract_and_class_hash() -> Tuple[str, int]:
     """
     compiled_contract = read_contract("minimal_contract_compiled.json")
     compiled_contract_casm = read_contract("minimal_contract_compiled.casm")
+
+    return (
+        compiled_contract,
+        compute_casm_class_hash(create_casm_class(compiled_contract_casm)),
+    )
+
+
+@pytest.fixture(scope="package")
+def abi_types_compiled_contract_and_class_hash() -> Tuple[str, int]:
+    """
+    Returns abi_types contract compiled to sierra and its compiled class hash.
+    """
+    compiled_contract = read_contract(
+        "abi_types_compiled.json", directory=CONTRACTS_COMPILED_V2_DIR
+    )
+    compiled_contract_casm = read_contract(
+        "abi_types_compiled.casm", directory=CONTRACTS_COMPILED_V2_DIR
+    )
 
     return (
         compiled_contract,
@@ -215,11 +234,34 @@ async def deploy_erc20_contract(
 
 
 @pytest.fixture(scope="package")
-def fee_contract(account: BaseAccount) -> Contract:
+def fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
     """
-    Returns an instance of the fee contract. It is used to transfer tokens.
+    Returns an instance of the ETH fee contract. It is used to transfer tokens.
     """
-    abi = [
+
+    return Contract(
+        address=FEE_CONTRACT_ADDRESS,
+        abi=fee_contract_abi,
+        provider=account,
+    )
+
+
+@pytest.fixture(scope="package")
+def strk_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
+    """
+    Returns an instance of the STRK fee contract. It is used to transfer tokens.
+    """
+
+    return Contract(
+        address=STRK_FEE_CONTRACT_ADDRESS,
+        abi=fee_contract_abi,
+        provider=account,
+    )
+
+
+@pytest.fixture(scope="package")
+def fee_contract_abi():
+    return [
         {
             "inputs": [
                 {"name": "recipient", "type": "felt"},
@@ -239,12 +281,6 @@ def fee_contract(account: BaseAccount) -> Contract:
             "type": "struct",
         },
     ]
-
-    return Contract(
-        address=FEE_CONTRACT_ADDRESS,
-        abi=abi,
-        provider=account,
-    )
 
 
 @pytest.fixture(name="balance_contract")

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -296,7 +296,7 @@ async def declare_account(account: BaseAccount, compiled_account_contract: str) 
     Declares a specified account.
     """
 
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=compiled_account_contract,
         max_fee=MAX_FEE,
     )
@@ -362,7 +362,7 @@ async def map_class_hash(account: BaseAccount, map_compiled_contract: str) -> in
     """
     Returns class_hash of the map.cairo.
     """
-    declare = await account.sign_declare_transaction(
+    declare = await account.sign_declare_v1_transaction(
         compiled_contract=map_compiled_contract,
         max_fee=int(1e16),
     )
@@ -378,7 +378,7 @@ async def simple_storage_with_event_class_hash(
     """
     Returns class_hash of the simple_storage_with_event.cairo
     """
-    declare = await account.sign_declare_transaction(
+    declare = await account.sign_declare_v1_transaction(
         compiled_contract=simple_storage_with_event_compiled_contract,
         max_fee=int(1e16),
     )
@@ -392,7 +392,7 @@ async def erc20_class_hash(account: BaseAccount, erc20_compiled_contract: str) -
     """
     Returns class_hash of the erc20.cairo.
     """
-    declare = await account.sign_declare_transaction(
+    declare = await account.sign_declare_v1_transaction(
         compiled_contract=erc20_compiled_contract,
         max_fee=int(1e16),
     )
@@ -438,7 +438,7 @@ async def constructor_with_arguments_class_hash(
     """
     Returns a class_hash of the constructor_with_arguments.cairo.
     """
-    declare = await account.sign_declare_transaction(
+    declare = await account.sign_declare_v1_transaction(
         compiled_contract=constructor_with_arguments_compiled,
         max_fee=int(1e16),
     )

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -234,7 +234,7 @@ async def deploy_erc20_contract(
 
 
 @pytest.fixture(scope="package")
-def fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
+def eth_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
     """
     Returns an instance of the ETH fee contract. It is used to transfer tokens.
     """

--- a/starknet_py/tests/e2e/fixtures/devnet.py
+++ b/starknet_py/tests/e2e/fixtures/devnet.py
@@ -33,6 +33,8 @@ def get_start_devnet_command(devnet_port: int) -> List[str]:
         str(1),
         "--seed",  # generates same accounts each time
         str(1),
+        "--state-archive-capacity",
+        "full",
     ]
 
 

--- a/starknet_py/tests/e2e/fixtures/proxy.py
+++ b/starknet_py/tests/e2e/fixtures/proxy.py
@@ -110,7 +110,7 @@ async def deploy_proxy_to_contract(
         compiled_contract_name, directory=CONTRACTS_COMPILED_V0_DIR
     )
 
-    declare_tx = await account.sign_declare_transaction(
+    declare_tx = await account.sign_declare_v1_transaction(
         compiled_contract=compiled_contract, max_fee=MAX_FEE
     )
     declare_result = await account.client.declare(declare_tx)

--- a/starknet_py/tests/e2e/tests_on_networks/account_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/account_test.py
@@ -22,7 +22,7 @@ async def test_sign_invoke_tx_for_fee_estimation(full_node_account_integration):
     )
 
     call = map_contract.functions["put"].prepare(key=40, value=50)
-    transaction = await account.sign_invoke_transaction(calls=call, max_fee=MAX_FEE)
+    transaction = await account.sign_invoke_v1_transaction(calls=call, max_fee=MAX_FEE)
 
     estimate_fee_transaction = await account.sign_for_fee_estimate(transaction)
 
@@ -44,7 +44,7 @@ async def test_sign_declare_tx_for_fee_estimation(
 ):
     account = full_node_account_integration
 
-    transaction = await account.sign_declare_transaction(
+    transaction = await account.sign_declare_v1_transaction(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -54,7 +54,9 @@ async def test_wait_for_tx_reverted(full_node_account_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[0x1, 0x2, 0x3, 0x4, 0x5],
     )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
+    sign_invoke = await account.sign_invoke_v1_transaction(
+        calls=call, max_fee=int(1e16)
+    )
     invoke = await account.client.send_transaction(sign_invoke)
 
     with pytest.raises(TransactionRevertedError, match="Input too long for arguments"):
@@ -69,7 +71,9 @@ async def test_wait_for_tx_accepted(full_node_account_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
+    sign_invoke = await account.sign_invoke_v1_transaction(
+        calls=call, max_fee=int(1e16)
+    )
     invoke = await account.client.send_transaction(sign_invoke)
 
     result = await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
@@ -86,7 +90,9 @@ async def test_transaction_not_received_max_fee_too_small(full_node_account_test
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e10))
+    sign_invoke = await account.sign_invoke_v1_transaction(
+        calls=call, max_fee=int(1e10)
+    )
 
     with pytest.raises(ClientError, match=r".*Max fee.*"):
         await account.client.send_transaction(sign_invoke)
@@ -100,7 +106,9 @@ async def test_transaction_not_received_max_fee_too_big(full_node_account_testne
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=sys.maxsize)
+    sign_invoke = await account.sign_invoke_v1_transaction(
+        calls=call, max_fee=sys.maxsize
+    )
 
     with pytest.raises(ClientError, match=r".*max_fee.*"):
         await account.client.send_transaction(sign_invoke)
@@ -114,7 +122,7 @@ async def test_transaction_not_received_invalid_nonce(full_node_account_testnet)
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_transaction(
+    sign_invoke = await account.sign_invoke_v1_transaction(
         calls=call, max_fee=int(1e16), nonce=0
     )
 
@@ -132,7 +140,9 @@ async def test_transaction_not_received_invalid_signature(full_node_account_test
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_transaction(calls=call, max_fee=int(1e16))
+    sign_invoke = await account.sign_invoke_v1_transaction(
+        calls=call, max_fee=int(1e16)
+    )
     sign_invoke = dataclasses.replace(sign_invoke, signature=[0x21, 0x37])
 
     with pytest.raises(ClientError, match=r"(.*Signature.*)|(.*An unexpected error.*)"):

--- a/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
@@ -105,7 +105,7 @@ async def test_simulate_transactions_declare_on_network(full_node_account_testne
     compiled_contract = read_contract(
         "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
     )
-    declare_tx = await full_node_account_testnet.sign_declare_transaction(
+    declare_tx = await full_node_account_testnet.sign_declare_v1_transaction(
         compiled_contract, max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -8,7 +8,7 @@ from starknet_py.net.account.account import Account
 from starknet_py.net.client import Client
 from starknet_py.net.http_client import HttpClient, HttpMethod
 from starknet_py.net.models import StarknetChainId
-from starknet_py.net.models.transaction import DeployAccount
+from starknet_py.net.models.transaction import DeployAccountV1
 from starknet_py.net.signer.stark_curve_signer import KeyPair
 from starknet_py.net.udc_deployer.deployer import _get_random_salt
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
@@ -62,7 +62,7 @@ async def get_deploy_account_details(
 
 async def get_deploy_account_transaction(
     *, address: int, key_pair: KeyPair, salt: int, class_hash: int, client: Client
-) -> DeployAccount:
+) -> DeployAccountV1:
     """
     Get a signed DeployAccount transaction from provided details
     """

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -17,7 +17,11 @@ AccountToBeDeployedDetails = Tuple[int, KeyPair, int, int]
 
 
 async def get_deploy_account_details(
-    *, class_hash: int, fee_contract: Contract, argent_calldata: bool = False
+    *,
+    class_hash: int,
+    fee_contract: Contract,
+    strk_fee_contract: Contract,
+    argent_calldata: bool = False,
 ) -> AccountToBeDeployedDetails:
     """
     Returns address, key_pair, salt and class_hash of the account with validate deploy.
@@ -42,10 +46,15 @@ async def get_deploy_account_details(
         deployer_address=0,
     )
 
-    res = await fee_contract.functions["transfer"].invoke(
+    transfer_wei_res = await fee_contract.functions["transfer"].invoke(
         recipient=address, amount=int(1e19), max_fee=MAX_FEE
     )
-    await res.wait_for_acceptance()
+    await transfer_wei_res.wait_for_acceptance()
+
+    transfer_fri_res = await strk_fee_contract.functions["transfer"].invoke(
+        recipient=address, amount=int(1e19), max_fee=MAX_FEE
+    )
+    await transfer_fri_res.wait_for_acceptance()
 
     return address, key_pair, salt, class_hash
 

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -19,7 +19,7 @@ AccountToBeDeployedDetails = Tuple[int, KeyPair, int, int]
 async def get_deploy_account_details(
     *,
     class_hash: int,
-    fee_contract: Contract,
+    eth_fee_contract: Contract,
     strk_fee_contract: Contract,
     argent_calldata: bool = False,
 ) -> AccountToBeDeployedDetails:
@@ -27,7 +27,8 @@ async def get_deploy_account_details(
     Returns address, key_pair, salt and class_hash of the account with validate deploy.
 
     :param class_hash: Class hash of account to be deployed.
-    :param fee_contract: Contract for prefunding deployments.
+    :param eth_fee_contract: Contract for prefunding deployments in ETH.
+    :param strk_fee_contract: Contract for prefunding deployments in STRK.
     :param argent_calldata: Flag deciding whether calldata should be in Argent-account format.
     """
     priv_key = _get_random_private_key_unsafe()
@@ -46,7 +47,7 @@ async def get_deploy_account_details(
         deployer_address=0,
     )
 
-    transfer_wei_res = await fee_contract.functions["transfer"].invoke(
+    transfer_wei_res = await eth_fee_contract.functions["transfer"].invoke(
         recipient=address, amount=int(1e19), max_fee=MAX_FEE
     )
     await transfer_wei_res.wait_for_acceptance()

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -73,7 +73,7 @@ async def get_deploy_account_transaction(
         key_pair=key_pair,
         chain=StarknetChainId.TESTNET,
     )
-    return await account.sign_deploy_account_transaction(
+    return await account.sign_deploy_account_v1_transaction(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1235 

## Introduced changes
<!-- A brief description of the changes -->

- Classes for V3 transactions, currently we are using separate classes for input and output to the RPC provider. The modifications in this PR follow this approach to avoid extensive changes unrelated to RPC v0.6.0. However, this aspect should be addressed during the next refactoring
- Classes added to `client_models` to mirror the new structs added to the RPC spec
    - `ResourceBoundsMapping`, `PriceUnit`, `FeePayment`, `DAMode`
    - Abstract class `TransactionV3` with common V3 fields
- Schemas for new transaction in `rpc.py` that uses `OneOfSchema`, this approach aligns more closely with RPC spec structures, as opposed to the earlier use of `Optional` fields
- Methods for calculating V3 transactions hashes and helper class `CommonTransactionV3Fields`
- `Account`
    -  Methods for signing v3 transactions and `execute_v3` method
- `StarkCurveSigner`
    - In `sign_transaction` remove specific logic for hash calculation for every transaction type, use abstract method `calculate_hash` from `AccountTransaction`
- `FullNodeClient`
    - `estimate_fee` method now includes `skip_validate`
    - `send_transaction`, `deploy_account` and `declare` have been adapted to alight with V3 transactions
    - Helper methods for creating broadcasted transactions V3 <- Note: Since only the declare transaction has a specific broadcasted structure, it suggests potential for simplifying these methods
    - Some utility methods have been moved to `client_utils.py`


##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->
