### PR TITLE
Add `data` info to RPC error message

### DIFF
--- a/starknet_py/net/client_errors.py
+++ b/starknet_py/net/client_errors.py
@@ -9,9 +9,16 @@ class ClientError(Exception):
     Base class for all errors raised while attempting to communicate with Starknet through Client.
     """
 
-    def __init__(self, message: str, code: Optional[str] = None):
+    def __init__(
+        self, message: str, code: Optional[str] = None, data: Optional[str] = None
+    ):
         self.code = code
-        self.message = f"Client failed{f' with code {code}' if code is not None else ''}: {message}."
+        self.data = data
+        self.message = (
+            f"Client failed{f' with code {code}' if code is not None else ''}. "
+            f"Message: {message}.{f' Data: {data}' if data is not None else ''}"
+        )
+
         super().__init__(self.message)
 
 

--- a/starknet_py/net/http_client.py
+++ b/starknet_py/net/http_client.py
@@ -80,7 +80,9 @@ class RpcHttpClient(HttpClient):
         if "error" not in result:
             raise ServerError(body=result)
         raise ClientError(
-            code=result["error"]["code"], message=result["error"]["message"]
+            code=result["error"]["code"],
+            message=result["error"]["message"],
+            data=result["error"].get("data"),
         )
 
     async def handle_request_error(self, request: ClientResponse):

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -86,7 +86,7 @@ async def test_get_class_at(
 @pytest.mark.asyncio
 async def test_get_class_at_throws_on_wrong_address(client):
     with pytest.raises(
-        ClientError, match="Client failed with code 20: Contract not found."
+        ClientError, match="Client failed with code 20. Message: Contract not found."
     ):
         await client.get_class_at(contract_address=0, block_hash="latest")
 

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -130,8 +130,6 @@ async def test_transaction_not_received_invalid_nonce(full_node_account_testnet)
         await account.client.send_transaction(sign_invoke)
 
 
-# TODO (#1219): fix this error once ClientError returns data field
-@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_transaction_not_received_invalid_signature(full_node_account_testnet):
     account = full_node_account_testnet
@@ -145,8 +143,11 @@ async def test_transaction_not_received_invalid_signature(full_node_account_test
     )
     sign_invoke = dataclasses.replace(sign_invoke, signature=[0x21, 0x37])
 
-    with pytest.raises(ClientError, match=r"(.*Signature.*)|(.*An unexpected error.*)"):
+    with pytest.raises(ClientError, match=r"Signature.*is invalid") as exc:
         await account.client.send_transaction(sign_invoke)
+
+    assert exc.value.data is not None
+    assert "Data:" in exc.value.message
 
 
 # ------------------------------------ FULL_NODE_CLIENT TESTS ------------------------------------


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Requested in #1234 


## Introduced changes
<!-- A brief description of the changes -->

- Slightly change the error message structure in `ClientError`
- Add `data` info returned by RPC client to the error message


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


