### PR TITLE
Add `Uint64` and `Uint128` classes

### DIFF
--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -68,7 +68,6 @@ from starknet_py.net.schemas.rpc import (
     PendingBlockStateUpdateSchema,
     PendingStarknetBlockSchema,
     PendingStarknetBlockWithTxHashesSchema,
-    ResourceBoundsMappingSchema,
     SentTransactionSchema,
     SierraContractClassSchema,
     SimulatedTransactionSchema,
@@ -78,6 +77,7 @@ from starknet_py.net.schemas.rpc import (
     TransactionReceiptSchema,
     TransactionStatusResponseSchema,
     TransactionTraceSchema,
+    TransactionV3Schema,
     TypesOfTransactionsSchema,
 )
 from starknet_py.net.schemas.utils import _extract_tx_version
@@ -955,16 +955,7 @@ def _create_broadcasted_txn_common_properties(transaction: AccountTransaction) -
 def _create_broadcasted_txn_v3_common_properties(
     transaction: Union[DeclareV3, InvokeV3, DeployAccountV3]
 ) -> dict:
-    resource_bonds = cast(
-        Dict, ResourceBoundsMappingSchema().dump(obj=transaction.resource_bounds)
+    return cast(
+        Dict,
+        TransactionV3Schema(exclude=["version", "signature"]).dump(obj=transaction),
     )
-
-    broadcasted_txn_v3_common_properties = {
-        "resource_bounds": resource_bonds,
-        "tip": _to_rpc_felt(transaction.tip),
-        "paymaster_data": [_to_rpc_felt(data) for data in transaction.paymaster_data],
-        "nonce_data_availability_mode": transaction.nonce_data_availability_mode.name,
-        "fee_data_availability_mode": transaction.fee_data_availability_mode.name,
-    }
-
-    return broadcasted_txn_v3_common_properties

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -30,8 +30,15 @@ class Felt(fields.Field):
     Field that serializes int to felt (hex encoded string)
     """
 
+    REGEX_PATTERN = r"^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})"
+
     def _serialize(self, value: Any, attr: str, obj: Any, **kwargs):
-        return hex(value)
+        if isinstance(value, int):
+            serialized = hex(value)
+            if re.fullmatch(self.REGEX_PATTERN, serialized) is not None:
+                return serialized
+
+        raise ValidationError(f"Invalid value provided for Felt: {value}.")
 
     def _deserialize(
         self,
@@ -44,12 +51,12 @@ class Felt(fields.Field):
             return value
 
         if not isinstance(value, str) or not value.startswith("0x"):
-            raise ValidationError(f"Invalid value provided for felt: {value}.")
+            raise ValidationError(f"Invalid value provided for Felt: {value}.")
 
         try:
             return int(value, 16)
         except ValueError as error:
-            raise ValidationError("Invalid felt.") from error
+            raise ValidationError("Invalid Felt.") from error
 
 
 class Uint64(fields.Field):

--- a/starknet_py/net/schemas/common_test.py
+++ b/starknet_py/net/schemas/common_test.py
@@ -65,7 +65,7 @@ def test_deserialize_felt_throws_on_invalid_data():
         SchemaWithFelt().load(data)
 
     data = {"value": "0xwww"}
-    with pytest.raises(ValidationError, match="Invalid Felt."):
+    with pytest.raises(ValidationError, match="Invalid value provided for Felt"):
         SchemaWithFelt().load(data)
 
 

--- a/starknet_py/net/schemas/common_test.py
+++ b/starknet_py/net/schemas/common_test.py
@@ -16,47 +16,45 @@ class SchemaWithUint128(Schema):
     value = Uint128(data_key="value")
 
 
-def test_serialize_felt():
-    class SchemaWithFelt(Schema):
-        value1 = Felt(data_key="value1")
+class SchemaWithFelt(Schema):
+    value = Felt(data_key="value")
 
-    data = {"value1": 2137}
+
+def test_serialize_felt():
+    data = {"value": 2137}
 
     serialized = SchemaWithFelt().dumps(data)
-    assert '"value1": "0x859"' in serialized
+    assert '"value": "0x859"' in serialized
 
 
-def test_serialize_felt_throws_on_none():
-    class SchemaWithFelt(Schema):
-        value1 = Felt(data_key="value1")
-
-    data = {"value1": None}
-    with pytest.raises(TypeError):
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"value": None},
+        {"value": 2**252},
+    ],
+)
+def test_serialize_felt_throws_on_invalid_data(data):
+    with pytest.raises(ValidationError, match="Invalid value provided for Felt"):
         SchemaWithFelt().dumps(data)
 
 
 def test_deserialize_felt():
-    class SchemaWithFelt(Schema):
-        value1 = Felt(data_key="value1")
-
-    data = {"value1": "0x859"}
+    data = {"value": "0x859"}
 
     deserialized = SchemaWithFelt().load(data)
     assert isinstance(deserialized, dict)
-    assert deserialized["value1"] == 2137
+    assert deserialized["value"] == 2137
 
 
 def test_deserialize_felt_throws_on_invalid_data():
-    class SchemaWithFelt(Schema):
-        value1 = Felt(data_key="value1")
+    data = {"value": "2137"}
 
-    data = {"value1": "2137"}
-
-    with pytest.raises(ValidationError, match="Invalid value provided for felt"):
+    with pytest.raises(ValidationError, match="Invalid value provided for Felt"):
         SchemaWithFelt().load(data)
 
-    data = {"value1": "0xwww"}
-    with pytest.raises(ValidationError, match="Invalid felt."):
+    data = {"value": "0xwww"}
+    with pytest.raises(ValidationError, match="Invalid Felt."):
         SchemaWithFelt().load(data)
 
 

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -70,6 +70,8 @@ from starknet_py.net.schemas.common import (
     StatusField,
     StorageEntrySchema,
     TransactionTypeField,
+    Uint64,
+    Uint128,
 )
 from starknet_py.net.schemas.utils import (
     _extract_tx_version,
@@ -209,8 +211,8 @@ class ResourcePriceSchema(Schema):
 
 
 class ResourceBoundsSchema(Schema):
-    max_amount = Felt(data_key="max_amount", required=True)
-    max_price_per_unit = Felt(data_key="max_price_per_unit", required=True)
+    max_amount = Uint64(data_key="max_amount", required=True)
+    max_price_per_unit = Uint128(data_key="max_price_per_unit", required=True)
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> ResourceBounds:
@@ -237,7 +239,7 @@ class DeprecatedTransactionSchema(TransactionSchema):
 
 
 class TransactionV3Schema(TransactionSchema):
-    tip = Felt(data_key="tip", load_default=0)
+    tip = Uint64(data_key="tip", load_default=0)
     nonce_data_availability_mode = DAModeField(
         data_key="nonce_data_availability_mode", load_default=DAMode.L1
     )

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -66,6 +66,7 @@ from starknet_py.net.schemas.common import (
     Felt,
     FinalityStatusField,
     NonPrefixedHex,
+    NumberAsHex,
     PriceUnitField,
     StatusField,
     StorageEntrySchema,
@@ -169,7 +170,7 @@ class TransactionReceiptSchema(Schema):
     messages_sent = fields.List(
         fields.Nested(L2toL1MessageSchema()), data_key="messages_sent", load_default=[]
     )
-    message_hash = Felt(data_key="message_hash", load_default=None)
+    message_hash = NumberAsHex(data_key="message_hash", load_default=None)
     execution_resources = fields.Nested(
         ExecutionResourcesSchema(), data_key="execution_resources", required=True
     )
@@ -378,7 +379,7 @@ class L1HandlerTransactionSchema(TransactionSchema):
     contract_address = Felt(data_key="contract_address", required=True)
     calldata = fields.List(Felt(), data_key="calldata", required=True)
     entry_point_selector = Felt(data_key="entry_point_selector", required=True)
-    nonce = Felt(data_key="nonce", required=True)
+    nonce = NumberAsHex(data_key="nonce", required=True)
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> L1HandlerTransaction:
@@ -617,7 +618,7 @@ class SierraEntryPointSchema(Schema):
 
 
 class EntryPointSchema(Schema):
-    offset = Felt(data_key="offset", required=True)
+    offset = NumberAsHex(data_key="offset", required=True)
     selector = Felt(data_key="selector", required=True)
 
     @post_load


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to #1235  and #1243 


## Introduced changes
<!-- A brief description of the changes -->

- Introduce classes `Uint64` and `Uint128` used for correct serialization/deserialization of RPC `u64` and `u128` types
- Add `NumberAsHex` class, from which the `Felt`, `Uint64` and `Uint128` classes can inherit. As a result, regex pattern checking has now been added to the `Felt` type
- Use `TransactionV3Schema` to create `dict` of common fields for broadcasted transaction v3, ideally we should implement similar approach for all transactions


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


