### PR TITLE
Support V3 transactions in the `Contract` class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -543,7 +543,7 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=6
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -338,7 +338,6 @@ class PreparedFunctionCall(Call):
         result = await self.call_raw(block_hash=block_hash, block_number=block_number)
         return self._payload_transformer.deserialize(result)
 
-    # TODO (#1182): add `cairo_version` parameter
     async def invoke(
         self,
         max_fee: Optional[int] = None,

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -163,7 +163,7 @@ class Account(BaseAccount):
     ) -> ResourceBoundsMapping:
         if auto_estimate and l1_resource_bounds is not None:
             raise ValueError(
-                "Arguments auto_estimate and l1_resource_bounds are mutually exclusive."
+                "Arguments l1_resource_bounds and auto_estimate are mutually exclusive."
             )
 
         if auto_estimate:

--- a/starknet_py/net/account/account_test.py
+++ b/starknet_py/net/account/account_test.py
@@ -42,7 +42,9 @@ async def test_account_get_balance(account, map_contract):
     balance = await account.get_balance()
     block = await account.client.get_block(block_number="latest")
 
-    await map_contract.functions["put"].invoke(key=10, value=10, max_fee=MAX_FEE)
+    await map_contract.functions["put"].invoke(
+        key=10, value=10, tx_version=1, max_fee=MAX_FEE
+    )
 
     new_balance = await account.get_balance()
     old_balance = await account.get_balance(block_number=block.block_number)

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -70,7 +70,7 @@ async def test_estimated_fee_greater_than_zero(account, erc20_contract):
 
     estimated_fee = (
         await erc20_contract.functions["balanceOf"]
-        .prepare("1234", max_fee=0)
+        .prepare("1234", tx_version=1, max_fee=0)
         .estimate_fee(block_hash="latest")
     )
 
@@ -118,7 +118,9 @@ async def test_rejection_reason_in_transaction_receipt(map_contract):
     with pytest.raises(
         ClientError, match="Max fee is smaller than the minimal transaction cost"
     ):
-        await map_contract.functions["put"].invoke(key=10, value=20, max_fee=1)
+        await map_contract.functions["put"].invoke(
+            key=10, value=20, tx_version=1, max_fee=1
+        )
 
 
 def test_sign_and_verify_offchain_message_fail(account, typed_data):
@@ -569,7 +571,7 @@ async def test_deploy_account_uses_custom_calldata(
     )
 
     res = await fee_contract.functions["transfer"].invoke(
-        recipient=address, amount=int(1e16), max_fee=MAX_FEE
+        recipient=address, amount=int(1e16), tx_version=1, max_fee=MAX_FEE
     )
     await res.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/cairo1v2_test.py
+++ b/starknet_py/tests/e2e/cairo1v2_test.py
@@ -51,12 +51,12 @@ async def test_deploy_cairo2(contract):
 @pytest.mark.asyncio
 async def test_cairo2_interaction(contract):
     invoke_res = await contract.functions["increase_balance"].invoke(
-        amount=100, auto_estimate=True
+        amount=100, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
     invoke_res = await contract.functions["increase_balance"].invoke(
-        amount=100, auto_estimate=True
+        amount=100, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
@@ -67,7 +67,7 @@ async def test_cairo2_interaction(contract):
 @pytest.mark.asyncio
 async def test_cairo2_interaction2(contract):
     invoke_res = await contract.functions["increase_balance_u8"].invoke(
-        255, auto_estimate=True
+        255, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
@@ -96,7 +96,7 @@ async def test_cairo2_u256(contract):
 @pytest.mark.asyncio
 async def test_cairo2_contract_address(contract):
     invoke_res = await contract.functions["set_ca"].invoke(
-        address=contract.account.address, auto_estimate=True
+        address=contract.account.address, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
@@ -107,7 +107,7 @@ async def test_cairo2_contract_address(contract):
 @pytest.mark.asyncio
 async def test_cairo2_interaction3(contract):
     invoke_res = await contract.functions["increase_balance"].invoke(
-        100, auto_estimate=True
+        100, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
     (balance,) = await contract.functions["get_balance"].call()
@@ -116,7 +116,7 @@ async def test_cairo2_interaction3(contract):
     assert storage == balance
 
     invoke_res = await contract.functions["set_ca"].invoke(
-        contract.account.address, auto_estimate=True
+        contract.account.address, tx_version=1, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
     (ca,) = await contract.functions["get_ca"].call()  # pylint: disable=invalid-name
@@ -124,7 +124,9 @@ async def test_cairo2_interaction3(contract):
     storage = await contract.client.get_storage_at(contract.address, key)
     assert storage == ca
 
-    invoke_res = await contract.functions["set_status"].invoke(True, auto_estimate=True)
+    invoke_res = await contract.functions["set_status"].invoke(
+        True, tx_version=1, auto_estimate=True
+    )
     await invoke_res.wait_for_acceptance()
     (status,) = await contract.functions["get_status"].call()
     key = get_storage_var_address("status")
@@ -136,6 +138,7 @@ async def test_cairo2_interaction3(contract):
             "address": contract.account.address,
             "is_claimed": True,
         },
+        tx_version=1,
         auto_estimate=True,
     )
     await invoke_res.wait_for_acceptance()
@@ -169,7 +172,9 @@ async def test_cairo2_echo_struct(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_echo_complex_struct(contract):
-    invoke_result = await contract.functions["set_bet"].invoke(auto_estimate=True)
+    invoke_result = await contract.functions["set_bet"].invoke(
+        tx_version=1, auto_estimate=True
+    )
     await invoke_result.wait_for_acceptance()
 
     (bet,) = await contract.functions["get_bet"].call(1)

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -395,7 +395,7 @@ async def test_custom_session_client(map_contract, network):
     tx_hash = (
         await (
             await map_contract.functions["put"].invoke(
-                key=10, value=20, max_fee=MAX_FEE
+                key=10, value=20, tx_version=1, max_fee=MAX_FEE
             )
         ).wait_for_acceptance()
     ).hash
@@ -480,7 +480,9 @@ async def test_state_update_storage_diffs(
     client,
     map_contract,
 ):
-    resp = await map_contract.functions["put"].invoke(key=10, value=20, max_fee=MAX_FEE)
+    resp = await map_contract.functions["put"].invoke(
+        key=10, value=20, tx_version=1, max_fee=MAX_FEE
+    )
     await resp.wait_for_acceptance()
 
     state_update = await client.get_state_update()

--- a/starknet_py/tests/e2e/client/fixtures/prepare_net_for_gateway_test.py
+++ b/starknet_py/tests/e2e/client/fixtures/prepare_net_for_gateway_test.py
@@ -44,7 +44,7 @@ async def prepare_net_for_tests(
     contract = deploy_result.deployed_contract
 
     invoke_res = await contract.functions["increase_balance"].invoke(
-        amount=1234, max_fee=int(1e20)
+        amount=1234, tx_version=1, max_fee=int(1e20)
     )
     await invoke_res.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -153,7 +153,7 @@ async def test_get_events_without_following_continuation_token(
 ):
     for i in range(4):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-            i, i, auto_estimate=True
+            i, i, tx_version=1, auto_estimate=True
         )
 
     chunk_size = 3
@@ -179,7 +179,7 @@ async def test_get_events_follow_continuation_token(
     total_invokes = 2
     for i in range(total_invokes):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-            i, i + 1, auto_estimate=True
+            i, i + 1, tx_version=1, auto_estimate=True
         )
 
     events_response = await client.get_events(
@@ -202,7 +202,7 @@ async def test_get_events_nonexistent_event_name(
     simple_storage_with_event_contract: Contract,
 ):
     await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-        1, 1, auto_estimate=True
+        1, 1, tx_version=1, auto_estimate=True
     )
 
     events_response = await client.get_events(
@@ -228,11 +228,11 @@ async def test_get_events_with_two_events(
     invokes_of_two = 2
     invokes_of_all = invokes_of_one + invokes_of_two
     await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-        1, 2, auto_estimate=True
+        1, 2, tx_version=1, auto_estimate=True
     )
     for i in range(invokes_of_two):
         await simple_storage_with_event_contract.functions[FUNCTION_TWO_NAME].invoke(
-            i, i + 1, auto_estimate=True
+            i, i + 1, tx_version=1, auto_estimate=True
         )
 
     event_one_events_response = await client.get_events(
@@ -275,7 +275,7 @@ async def test_get_events_start_from_continuation_token(
 ):
     for i in range(5):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-            i, i + 1, auto_estimate=True
+            i, i + 1, tx_version=1, auto_estimate=True
         )
 
     chunk_size = 2
@@ -303,10 +303,10 @@ async def test_get_events_no_params(
     default_chunk_size = 1
     for i in range(3):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke(
-            i, i + 1, auto_estimate=True
+            i, i + 1, tx_version=1, auto_estimate=True
         )
         await simple_storage_with_event_contract.functions[FUNCTION_TWO_NAME].invoke(
-            i, i + 1, auto_estimate=True
+            i, i + 1, tx_version=1, auto_estimate=True
         )
     events_response = await client.get_events()
 

--- a/starknet_py/tests/e2e/contract_interaction/declare_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/declare_test.py
@@ -1,14 +1,24 @@
 import pytest
 
 from starknet_py.contract import Contract
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
+from starknet_py.net.models import DeclareV2, DeclareV3
+from starknet_py.tests.e2e.fixtures.constants import (
+    CONTRACTS_COMPILED_V1_DIR,
+    CONTRACTS_COMPILED_V2_DIR,
+    MAX_FEE,
+    MAX_RESOURCE_BOUNDS_L1,
+)
 from starknet_py.tests.e2e.fixtures.misc import read_contract
 
 
 @pytest.mark.asyncio
-async def test_contract_declare(account):
-    compiled_contract = read_contract("test_contract_compiled.json")
-    compiled_contract_casm = read_contract("test_contract_compiled.casm")
+async def test_contract_declare_v2(account):
+    compiled_contract = read_contract(
+        "test_contract_compiled.json", directory=CONTRACTS_COMPILED_V1_DIR
+    )
+    compiled_contract_casm = read_contract(
+        "test_contract_compiled.casm", directory=CONTRACTS_COMPILED_V1_DIR
+    )
 
     declare_result = await Contract.declare(
         account,
@@ -18,6 +28,31 @@ async def test_contract_declare(account):
     )
     await declare_result.wait_for_acceptance()
 
+    assert isinstance(declare_result.declare_transaction, DeclareV2)
+    assert isinstance(declare_result.hash, int)
+    assert isinstance(declare_result.class_hash, int)
+    assert declare_result.compiled_contract == compiled_contract
+
+
+@pytest.mark.asyncio
+async def test_contract_declare_v3(account):
+    compiled_contract = read_contract(
+        "test_contract_compiled.json", directory=CONTRACTS_COMPILED_V2_DIR
+    )
+    compiled_contract_casm = read_contract(
+        "test_contract_compiled.casm", directory=CONTRACTS_COMPILED_V2_DIR
+    )
+
+    declare_result = await Contract.declare(
+        account,
+        compiled_contract=compiled_contract,
+        compiled_contract_casm=compiled_contract_casm,
+        tx_version=3,
+        l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+    )
+    await declare_result.wait_for_acceptance()
+
+    assert isinstance(declare_result.declare_transaction, DeclareV3)
     assert isinstance(declare_result.hash, int)
     assert isinstance(declare_result.class_hash, int)
     assert declare_result.compiled_contract == compiled_contract
@@ -35,4 +70,22 @@ async def test_throws_when_cairo1_without_compiled_contract_casm_and_casm_class_
     ):
         await Contract.declare(
             account, compiled_contract=compiled_contract, max_fee=MAX_FEE
+        )
+
+
+@pytest.mark.asyncio
+async def test_throws_when_max_fee_and_resource_bounds(
+    account,
+):
+    compiled_contract = read_contract("erc20_compiled.json")
+
+    with pytest.raises(
+        ValueError,
+        match="Arguments 'max_fee' and 'l1_resource_bounds' are mutually exclusive.",
+    ):
+        await Contract.declare(
+            account,
+            compiled_contract=compiled_contract,
+            max_fee=MAX_FEE,
+            l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
         )

--- a/starknet_py/tests/e2e/contract_interaction/deploy_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/deploy_test.py
@@ -75,7 +75,7 @@ async def test_throws_on_wrong_abi(account, cairo1_minimal_contract_class_hash: 
         class_hash=cairo1_minimal_contract_class_hash,
         compiled_contract=compiled_contract,
         hash=0,
-        declare_transaction=Mock(spec=DeclareV2)
+        declare_transaction=Mock(spec=DeclareV2),
     )
 
     compiled_contract = compiled_contract.replace('"abi": [', '"abi": ')

--- a/starknet_py/tests/e2e/contract_interaction/deploy_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/deploy_test.py
@@ -80,3 +80,20 @@ async def test_deploy_contract_flow(account, cairo1_hello_starknet_class_hash: i
 
     assert isinstance(contract.address, int)
     assert len(contract.functions) != 0
+
+
+@pytest.mark.asyncio
+async def test_general_simplified_deployment_flow(account, map_compiled_contract):
+    declare_result = await Contract.declare(
+        account=account,
+        compiled_contract=map_compiled_contract,
+        max_fee=MAX_FEE,
+    )
+    await declare_result.wait_for_acceptance()
+    deployment = await declare_result.deploy(max_fee=MAX_FEE)
+    await deployment.wait_for_acceptance()
+
+    contract = deployment.deployed_contract
+
+    assert isinstance(contract.address, int)
+    assert len(contract.functions) != 0

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -3,114 +3,262 @@ import pytest
 from starknet_py.contract import Contract
 from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.net.client_errors import ClientError
-from starknet_py.net.client_models import Call
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
+from starknet_py.net.client_models import Call, ResourceBounds, ResourceBoundsMapping
+from starknet_py.net.models import InvokeV1, InvokeV3
+from starknet_py.tests.e2e.fixtures.constants import (
+    MAX_FEE,
+    MAX_RESOURCE_BOUNDS,
+    MAX_RESOURCE_BOUNDS_L1,
+)
+
+key, value = 1, 2
 
 
 @pytest.mark.asyncio
-async def test_max_fee_is_set_in_sent_invoke(map_contract):
-    key = 2
-    value = 3
-
-    prepared_call = map_contract.functions["put"].prepare(key, value, max_fee=MAX_FEE)
+async def test_prepare_and_invoke_v1(map_contract):
+    prepared_call = map_contract.functions["put"].prepare(
+        key, value, tx_version=1, max_fee=MAX_FEE
+    )
+    assert prepared_call.l1_resource_bounds is None
     assert prepared_call.max_fee == MAX_FEE
+    assert prepared_call.tx_version == 1
 
     invocation = await prepared_call.invoke()
+    assert isinstance(invocation.invoke_transaction, InvokeV1)
     assert invocation.invoke_transaction.max_fee == MAX_FEE
-
-    invocation = await map_contract.functions["put"].invoke(
-        key, value, max_fee=MAX_FEE + 100
-    )
-    assert invocation.invoke_transaction.max_fee == MAX_FEE + 100
-
-    prepared_call = map_contract.functions["put"].prepare(
-        key, value, max_fee=MAX_FEE + 200
-    )
-    assert prepared_call.max_fee == MAX_FEE + 200
-
-    invocation = await prepared_call.invoke(max_fee=MAX_FEE + 300)
-    assert invocation.invoke_transaction.max_fee == MAX_FEE + 300
 
 
 @pytest.mark.asyncio
-async def test_auto_fee_estimation(map_contract):
-    key = 2
-    value = 3
+async def test_prepare_and_invoke_v3(map_contract):
+    prepared_call = map_contract.functions["put"].prepare(
+        key, value, tx_version=3, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
+    )
+    assert prepared_call.max_fee is None
+    assert prepared_call.l1_resource_bounds == MAX_RESOURCE_BOUNDS_L1
+    assert prepared_call.tx_version == 3
 
-    prepared_call = map_contract.functions["put"].prepare(key, value)
+    invocation = await prepared_call.invoke()
+    assert isinstance(invocation.invoke_transaction, InvokeV3)
+    assert invocation.invoke_transaction.resource_bounds == MAX_RESOURCE_BOUNDS
+
+
+@pytest.mark.asyncio
+async def test_invoke_v1(map_contract):
+    invocation = await map_contract.functions["put"].invoke(
+        key, value, tx_version=1, max_fee=MAX_FEE
+    )
+    assert isinstance(invocation.invoke_transaction, InvokeV1)
+    assert invocation.invoke_transaction.max_fee == MAX_FEE
+
+
+@pytest.mark.asyncio
+async def test_invoke_v3(map_contract):
+    invocation = await map_contract.functions["put"].invoke(
+        key, value, tx_version=3, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
+    )
+    assert isinstance(invocation.invoke_transaction, InvokeV3)
+    assert invocation.invoke_transaction.resource_bounds == MAX_RESOURCE_BOUNDS
+
+
+@pytest.mark.asyncio
+async def test_auto_fee_estimation_v1(map_contract):
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=1)
+    assert prepared_call.tx_version == 1
+
     invocation = await prepared_call.invoke(auto_estimate=True)
 
+    assert isinstance(invocation.invoke_transaction, InvokeV1)
     assert invocation.invoke_transaction.max_fee is not None
 
 
 @pytest.mark.asyncio
-async def test_throws_invoke_without_max_fee(map_contract):
-    error_message = "Argument max_fee must be specified when invoking a transaction."
+async def test_auto_fee_estimation_v3(map_contract):
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=3)
+    assert prepared_call.tx_version == 3
 
-    with pytest.raises(ValueError, match=error_message):
-        await map_contract.functions["put"].invoke(2, 3)
+    invocation = await prepared_call.invoke(auto_estimate=True)
+
+    assert isinstance(invocation.invoke_transaction, InvokeV3)
+    assert invocation.invoke_transaction.resource_bounds is not None
 
 
 @pytest.mark.asyncio
-async def test_throws_prepared_call_invoke_without_max_fee(map_contract):
+async def test_throws_invoke_v1_without_max_fee(map_contract):
     error_message = "Argument max_fee must be specified when invoking a transaction."
 
-    prepared_call = map_contract.functions["put"].prepare(2, 3)
+    with pytest.raises(ValueError, match=error_message):
+        await map_contract.functions["put"].invoke(key, value, tx_version=1)
+
+
+@pytest.mark.asyncio
+async def test_throws_invoke_v3_without_resource_bounds(map_contract):
+    error_message = (
+        "One of arguments: "
+        "l1_resource_bounds or auto_estimate must be specified when invoking a transaction."
+    )
+
+    with pytest.raises(ValueError, match=error_message):
+        await map_contract.functions["put"].invoke(key, value, tx_version=3)
+
+
+@pytest.mark.asyncio
+async def test_throws_prepared_call_invoke_v1_without_max_fee(map_contract):
+    error_message = "Argument max_fee must be specified when invoking a transaction."
+
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=1)
     with pytest.raises(ValueError, match=error_message):
         await prepared_call.invoke()
 
 
 @pytest.mark.asyncio
-async def test_throws_prepared_call_with_max_fee_invoke_with_auto_estimate(
+async def test_throws_prepared_call_invoke_v3_without_resource_bounds(map_contract):
+    error_message = (
+        "One of arguments: "
+        "l1_resource_bounds or auto_estimate must be specified when invoking a transaction."
+    )
+
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=3)
+    with pytest.raises(ValueError, match=error_message):
+        await prepared_call.invoke()
+
+
+@pytest.mark.asyncio
+async def test_throws_prepared_call_with_max_fee_invoke_v1_with_auto_estimate(
     map_contract,
 ):
     error_message = "Arguments max_fee and auto_estimate are mutually exclusive."
 
-    invocation = map_contract.functions["put"].prepare(2, 3, max_fee=2000)
+    invocation = map_contract.functions["put"].prepare(
+        key, value, tx_version=1, max_fee=2000
+    )
     with pytest.raises(ValueError, match=error_message):
         await invocation.invoke(auto_estimate=True)
 
 
 @pytest.mark.asyncio
-async def test_throws_on_call_without_max_fee(map_contract):
+async def test_throws_prepared_call_with_resource_bounds_invoke_v3_with_auto_estimate(
+    map_contract,
+):
+    error_message = (
+        "Arguments l1_resource_bounds and auto_estimate are mutually exclusive."
+    )
+
+    invocation = map_contract.functions["put"].prepare(
+        key, value, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1, tx_version=3
+    )
+    with pytest.raises(ValueError, match=error_message):
+        await invocation.invoke(auto_estimate=True)
+
+
+@pytest.mark.asyncio
+async def test_throws_invoke_v1_with_max_fee_and_auto_estimate(map_contract):
     error_message = "Arguments max_fee and auto_estimate are mutually exclusive."
 
-    prepared_call = map_contract.functions["put"].prepare(2, 3)
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=1)
     with pytest.raises(ValueError, match=error_message):
         await prepared_call.invoke(max_fee=10, auto_estimate=True)
 
 
 @pytest.mark.asyncio
-async def test_latest_max_fee_takes_precedence(map_contract):
-    key = 2
-    value = 3
+async def test_throws_invoke_v3_with_resource_bounds_and_auto_estimate(map_contract):
+    error_message = (
+        "Arguments l1_resource_bounds and auto_estimate are mutually exclusive."
+    )
 
+    with pytest.raises(ValueError, match=error_message):
+        await map_contract.functions["put"].invoke(
+            key,
+            value,
+            tx_version=3,
+            l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
+            auto_estimate=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_throws_invalid_invoke_version(map_contract):
+    error_message = "The allowed versions for Invoke transaction are 1 or 3."
+
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=2)
+    with pytest.raises(ValueError, match=error_message):
+        await prepared_call.invoke(auto_estimate=True)
+
+
+@pytest.mark.asyncio
+async def test_throws_when_max_fee_and_resource_bounds(map_contract):
+    error_message = (
+        "Arguments 'max_fee' and 'l1_resource_bounds' are mutually exclusive."
+    )
+
+    prepared_call = map_contract.functions["put"].prepare(key, value)
+    with pytest.raises(ValueError, match=error_message):
+        await prepared_call.invoke(
+            max_fee=MAX_FEE, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
+        )
+
+
+@pytest.mark.asyncio
+async def test_throws_no_tx_version(map_contract):
+    error_message = (
+        "The transaction version is not specified. "
+        "Please ensure that the 'tx_version' is set to either 1 or 3."
+    )
+
+    prepared_call = map_contract.functions["put"].prepare(key, value)
+    with pytest.raises(ValueError, match=error_message):
+        await prepared_call.invoke(max_fee=MAX_FEE)
+
+
+@pytest.mark.asyncio
+async def test_latest_max_fee_takes_precedence(map_contract):
     prepared_function = map_contract.functions["put"].prepare(
-        key, value, max_fee=MAX_FEE
+        key, value, tx_version=1, max_fee=MAX_FEE
     )
     invocation = await prepared_function.invoke(max_fee=MAX_FEE + 30)
 
+    assert isinstance(invocation.invoke_transaction, InvokeV1)
     assert invocation.invoke_transaction.max_fee == MAX_FEE + 30
 
 
 @pytest.mark.asyncio
-async def test_prepare_without_max_fee(map_contract):
-    key = 2
-    value = 3
+async def test_latest_resource_bounds_take_precedence(map_contract):
+    prepared_function = map_contract.functions["put"].prepare(
+        key, value, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1, tx_version=3
+    )
 
-    prepared_call = map_contract.functions["put"].prepare(key, value)
+    updated_resource_bounds = ResourceBounds(
+        max_amount=MAX_RESOURCE_BOUNDS_L1.max_amount + 100,
+        max_price_per_unit=MAX_RESOURCE_BOUNDS_L1.max_price_per_unit + 10,
+    )
+    invocation = await prepared_function.invoke(
+        l1_resource_bounds=updated_resource_bounds
+    )
+
+    assert isinstance(invocation.invoke_transaction, InvokeV3)
+    assert invocation.invoke_transaction.resource_bounds == ResourceBoundsMapping(
+        l1_gas=updated_resource_bounds, l2_gas=ResourceBounds.init_with_zeros()
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_without_max_fee(map_contract):
+    prepared_call = map_contract.functions["put"].prepare(key, value, tx_version=1)
 
     assert prepared_call.max_fee is None
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("key, value", ((2, 13), (412312, 32134), (12345, 3567)))
-async def test_invoke_and_call(key, value, map_contract):
-    invocation = await map_contract.functions["put"].invoke(key, value, max_fee=MAX_FEE)
+@pytest.mark.parametrize("k, v", ((2, 13), (412312, 32134), (12345, 3567)))
+async def test_invoke_and_call(k, v, map_contract):
+    invocation = await map_contract.functions["put"].invoke(
+        k, v, tx_version=1, max_fee=MAX_FEE
+    )
     await invocation.wait_for_acceptance()
-    (response,) = await map_contract.functions["get"].call(key)
 
-    assert response == value
+    assert isinstance(invocation.invoke_transaction, InvokeV1)
+    (response,) = await map_contract.functions["get"].call(k)
+
+    assert response == v
 
 
 @pytest.mark.asyncio
@@ -129,7 +277,7 @@ async def test_call_uninitialized_contract(client):
 @pytest.mark.asyncio
 async def test_wait_for_tx(client, map_contract):
     transaction = await map_contract.functions["put"].invoke(
-        key=10, value=20, max_fee=MAX_FEE
+        key=10, value=20, tx_version=1, max_fee=MAX_FEE
     )
     await client.wait_for_tx(transaction.hash)
 
@@ -142,7 +290,7 @@ async def test_error_when_invoking_without_account(client, map_contract):
         ValueError,
         match="Contract instance was created without providing an Account.",
     ):
-        await contract.functions["put"].prepare(key=10, value=10).invoke(
+        await contract.functions["put"].prepare(key=10, value=10, tx_version=1).invoke(
             max_fee=MAX_FEE
         )
 
@@ -155,4 +303,6 @@ async def test_error_when_estimating_fee_while_not_using_account(client, map_con
         ValueError,
         match="Contract instance was created without providing an Account.",
     ):
-        await contract.functions["put"].prepare(key=10, value=10).estimate_fee()
+        await contract.functions["put"].prepare(
+            key=10, value=10, tx_version=1
+        ).estimate_fee()

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -1,6 +1,5 @@
 import pytest
 
-from starknet_py.common import create_compiled_contract
 from starknet_py.contract import Contract
 from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.net.client_errors import ClientError
@@ -157,35 +156,3 @@ async def test_error_when_estimating_fee_while_not_using_account(client, map_con
         match="Contract instance was created without providing an Account.",
     ):
         await contract.functions["put"].prepare(key=10, value=10).estimate_fee()
-
-
-@pytest.mark.asyncio
-async def test_general_simplified_deployment_flow(account, map_compiled_contract):
-    declare_result = await Contract.declare(
-        account=account,
-        compiled_contract=map_compiled_contract,
-        max_fee=MAX_FEE,
-    )
-    await declare_result.wait_for_acceptance()
-    deployment = await declare_result.deploy(max_fee=MAX_FEE)
-    await deployment.wait_for_acceptance()
-
-    contract = deployment.deployed_contract
-
-    assert isinstance(contract.address, int)
-    assert len(contract.functions) != 0
-
-
-@pytest.mark.asyncio
-async def test_deploy_contract_flow(account, map_compiled_contract, map_class_hash):
-    abi = create_compiled_contract(compiled_contract=map_compiled_contract).abi
-
-    deploy_result = await Contract.deploy_contract(
-        class_hash=map_class_hash, account=account, abi=abi, max_fee=MAX_FEE
-    )
-    await deploy_result.wait_for_acceptance()
-
-    contract = deploy_result.deployed_contract
-
-    assert isinstance(contract.address, int)
-    assert len(contract.functions) != 0

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -41,7 +41,7 @@ async def test_general_v1_interaction(account, cairo1_erc20_class_hash: int):
     transfer_amount = 10
     await (
         await erc20.functions["transfer"].invoke(
-            recipient=0x11, amount=transfer_amount, max_fee=MAX_FEE
+            recipient=0x11, amount=transfer_amount, tx_version=1, max_fee=MAX_FEE
         )
     ).wait_for_acceptance()
 
@@ -71,7 +71,7 @@ async def test_serializing_struct(account, cairo1_token_bridge_class_hash: int):
 
     await (
         await bridge.functions["set_l1_bridge"].invoke(
-            l1_bridge_address={"address": 0x11}, max_fee=MAX_FEE
+            l1_bridge_address={"address": 0x11}, tx_version=1, max_fee=MAX_FEE
         )
     ).wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
+++ b/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
@@ -44,7 +44,7 @@ async def test_deploy_prefunded_account(
     # Make sure the tx has been accepted on L2 before proceeding
     # docs: end
     res = await eth_fee_contract.functions["transfer"].invoke(
-        recipient=address, amount=int(1e16), max_fee=MAX_FEE
+        recipient=address, amount=int(1e16), tx_version=1, max_fee=MAX_FEE
     )
     await res.wait_for_acceptance()
     # docs: start

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract_function.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract_function.py
@@ -6,7 +6,9 @@ from starknet_py.contract import Contract, ContractFunction
 
 def test_prepare(map_contract: Contract):
     # docs-start: prepare
-    prepared_function_call = map_contract.functions["put"].prepare(key=10, value=20)
+    prepared_function_call = map_contract.functions["put"].prepare(
+        key=10, value=20, tx_version=1
+    )
     # docs-end: prepare
 
 
@@ -22,7 +24,7 @@ async def test_call(map_contract: Contract):
 def test_invoke(map_contract: Contract):
     # docs-start: invoke
     invoke_result = map_contract.functions["put"].invoke(
-        key=10, value=20, max_fee=int(1e15)
+        key=10, value=20, tx_version=1, max_fee=int(1e15)
     )
     # docs-end: invoke
 

--- a/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_call.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_call.py
@@ -26,7 +26,9 @@ async def test_call(map_contract: Contract):
 
 @pytest.mark.asyncio
 async def test_invoke(map_contract: Contract):
-    prepared_function_call = map_contract.functions["put"].prepare(key=10, value=20)
+    prepared_function_call = map_contract.functions["put"].prepare(
+        key=10, value=20, tx_version=1
+    )
     # docs-start: invoke
     invoke_result = await prepared_function_call.invoke(max_fee=int(1e15))
     # docs-end: invoke

--- a/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
@@ -8,7 +8,7 @@ async def test_create_call_from_contract(map_contract, account):
 
     client = account.client
     res = await map_contract.functions["put"].invoke(
-        key=1234, value=9999, auto_estimate=True
+        key=1234, value=9999, tx_version=1, auto_estimate=True
     )
     await res.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/docs/guide/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/guide/test_full_node_client.py
@@ -13,7 +13,7 @@ async def test_full_node_client(client, map_contract):
     # docs: end
 
     await map_contract.functions["put"].prepare(key=10, value=10).invoke(
-        max_fee=int(1e20)
+        tx_version=1, max_fee=int(1e20)
     )
 
     client = full_node_client_fixture

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -46,7 +46,7 @@ async def test_using_existing_contracts(account, erc20_contract):
 
     # Using only positional arguments
     invocation = await contract.functions["transferFrom"].invoke(
-        sender, recipient, 10000, max_fee=int(1e16)
+        sender, recipient, 10000, tx_version=1, max_fee=int(1e16)
     )
     # docs: end
     await invocation.wait_for_acceptance()
@@ -54,7 +54,11 @@ async def test_using_existing_contracts(account, erc20_contract):
 
     # Using only keyword arguments
     invocation = await contract.functions["transferFrom"].invoke(
-        sender=sender, recipient=recipient, amount=10000, max_fee=int(1e16)
+        sender=sender,
+        recipient=recipient,
+        amount=10000,
+        tx_version=1,
+        max_fee=int(1e16),
     )
     # docs: end
     await invocation.wait_for_acceptance()
@@ -62,7 +66,7 @@ async def test_using_existing_contracts(account, erc20_contract):
 
     # Mixing positional with keyword arguments
     invocation = await contract.functions["transferFrom"].invoke(
-        sender, recipient, amount=10000, max_fee=int(1e16)
+        sender, recipient, amount=10000, tx_version=1, max_fee=int(1e16)
     )
     # docs: end
     await invocation.wait_for_acceptance()
@@ -71,7 +75,7 @@ async def test_using_existing_contracts(account, erc20_contract):
     # Creating a PreparedFunctionCall - creates a function call with arguments - useful for signing transactions and
     # specifying additional options
     transfer = contract.functions["transferFrom"].prepare(
-        sender, recipient, amount=10000, max_fee=int(1e16)
+        sender, recipient, amount=10000, tx_version=1, max_fee=int(1e16)
     )
     invocation = await transfer.invoke()
 

--- a/starknet_py/tests/e2e/docs/quickstart/test_synchronous_api.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_synchronous_api.py
@@ -17,7 +17,9 @@ def test_synchronous_api(account, map_contract):
     key = 1234
     contract = Contract.from_address_sync(address=contract_address, provider=account)
 
-    invocation = contract.functions["put"].invoke_sync(key, 7, max_fee=int(1e16))
+    invocation = contract.functions["put"].invoke_sync(
+        key, 7, tx_version=1, max_fee=int(1e16)
+    )
     invocation.wait_for_acceptance_sync()
 
     (saved,) = contract.functions["get"].call_sync(key)  # 7

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
@@ -30,7 +30,9 @@ async def test_using_account(account, map_compiled_contract):
     # Adds a transaction to mutate the state of k-v store. The call goes through account proxy, because we've used
     # Account to create the contract object
     await (
-        await map_contract.functions["put"].invoke(k, v, max_fee=int(1e16))
+        await map_contract.functions["put"].invoke(
+            k, v, tx_version=1, max_fee=int(1e16)
+        )
     ).wait_for_acceptance()
 
     # Retrieves the value, which is equal to 4324 in this case

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -38,7 +38,9 @@ async def test_using_contract(account, map_contract):
 
     # All exposed functions are available at contract.functions.
     # Here we invoke a function, creating a new transaction.
-    invocation = await contract.functions["put"].invoke(key, 7, max_fee=int(1e16))
+    invocation = await contract.functions["put"].invoke(
+        key, 7, tx_version=1, max_fee=int(1e16)
+    )
 
     # Invocation returns InvokeResult object. It exposes a helper for waiting until transaction is accepted.
     await invocation.wait_for_acceptance()

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_full_node_client.py
@@ -17,7 +17,7 @@ async def test_using_full_node_client(client, map_contract):
     # docs: end
 
     await map_contract.functions["put"].prepare(key=10, value=10).invoke(
-        max_fee=int(1e20)
+        tx_version=1, max_fee=int(1e20)
     )
 
     client = full_node_client_fixture

--- a/starknet_py/tests/e2e/proxy/proxy_test.py
+++ b/starknet_py/tests/e2e/proxy/proxy_test.py
@@ -15,7 +15,9 @@ from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 async def is_map_working_properly(map_contract: Contract, key: int, val: int) -> bool:
     """Put (key, val) into map_contract's storage and check if value under the key is val"""
     await (
-        await map_contract.functions["put"].invoke(key, val, max_fee=int(1e16))
+        await map_contract.functions["put"].invoke(
+            key, val, tx_version=1, max_fee=int(1e16)
+        )
     ).wait_for_acceptance()
     (result,) = await map_contract.functions["get"].call(key=key)
     return result == val

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -48,12 +48,12 @@ async def get_deploy_account_details(
     )
 
     transfer_wei_res = await eth_fee_contract.functions["transfer"].invoke(
-        recipient=address, amount=int(1e19), max_fee=MAX_FEE
+        recipient=address, amount=int(1e19), tx_version=1, max_fee=MAX_FEE
     )
     await transfer_wei_res.wait_for_acceptance()
 
     transfer_fri_res = await strk_fee_contract.functions["transfer"].invoke(
-        recipient=address, amount=int(1e19), max_fee=MAX_FEE
+        recipient=address, amount=int(1e19), tx_version=1, max_fee=MAX_FEE
     )
     await transfer_fri_res.wait_for_acceptance()
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to #1235 


## Introduced changes
<!-- A brief description of the changes -->

- Add parameters `tx_version` and `l1_resource_bounds` to:
  - `ContractFunction.invoke()`, `ContractFunction.prepare()`
  - `PreparedFunctionCall`, `PreparedFunctionCall.invoke()`, `PreparedFunctionCall.estimate_fee()` (only `tx_version`)
  - `Contract.declare()`, `Contract.deploy_contract()`
  - `DeclareResult.deploy()`
- Add optional parameters `salt` and `unique` to static method `Contract.deploy_contract()` and use this function in `DeclareResult.deploy()`
- Add `declare_transaction` field to `DeclareResult`
- Increase Pylint `max-args` from 5 to 6 to avoid writing `pylint: disable=too-many-arguments` in certain functions. It is likely that we will need to further increase this value when we update Pylint. It seems that newer versions of the tool report errors in some areas that are currently overlooked


##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


