### PR TITLE
issue 1249: split deprecated schemas to their respective classes based on versions

### DIFF
--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -191,16 +191,25 @@ class TransactionV3(Transaction):
 
 
 @dataclass
-class InvokeTransaction(DeprecatedTransaction):
+class InvokeTransactionV0(DeprecatedTransaction):
     """
-    Dataclass representing invoke transaction.
+    Dataclass representing invoke transaction v0.
     """
 
-    sender_address: int
     calldata: List[int]
-    # This field is always None for transactions with version = 1
-    entry_point_selector: Optional[int] = None
-    nonce: Optional[int] = None
+    contract_address: int
+    entry_point_selector: int
+
+
+@dataclass
+class InvokeTransactionV1(DeprecatedTransaction):
+    """
+    Dataclass representing invoke transaction v1.
+    """
+
+    calldata: List[int]
+    sender_address: int
+    nonce: int
 
 
 @dataclass
@@ -209,22 +218,43 @@ class InvokeTransactionV3(TransactionV3):
     Dataclass representing invoke transaction v3.
     """
 
-    sender_address: int
     calldata: List[int]
+    sender_address: int
+    nonce: int
     account_deployment_data: List[int]
+
+
+@dataclass
+class DeclareTransactionV0(DeprecatedTransaction):
+    """
+    Dataclass representing declare transaction v0.
+    """
+
+    sender_address: int
+    class_hash: int
+
+
+@dataclass
+class DeclareTransactionV1(DeprecatedTransaction):
+    """
+    Dataclass representing declare transaction v1.
+    """
+
+    sender_address: int
+    class_hash: int
     nonce: int
 
 
 @dataclass
-class DeclareTransaction(DeprecatedTransaction):
+class DeclareTransactionV2(DeprecatedTransaction):
     """
-    Dataclass representing declare transaction.
+    Dataclass representing declare transaction v2.
     """
 
-    class_hash: int  # Responses to getBlock and getTransaction include the class hash
     sender_address: int
-    compiled_class_hash: Optional[int] = None  # only in DeclareV2, hence Optional
-    nonce: Optional[int] = None
+    class_hash: int
+    compiled_class_hash: int
+    nonce: int
 
 
 @dataclass
@@ -233,10 +263,10 @@ class DeclareTransactionV3(TransactionV3):
     Dataclass representing declare transaction v3.
     """
 
+    sender_address: int
     class_hash: int
     compiled_class_hash: int
     nonce: int
-    sender_address: int
     account_deployment_data: List[int]
 
 
@@ -252,15 +282,15 @@ class DeployTransaction(Transaction):
 
 
 @dataclass
-class DeployAccountTransaction(DeprecatedTransaction):
+class DeployAccountTransactionV1(DeprecatedTransaction):
     """
-    Dataclass representing deploy account transaction.
+    Dataclass representing deploy account transaction v1.
     """
 
-    contract_address_salt: int
-    class_hash: int
-    constructor_calldata: List[int]
     nonce: int
+    contract_address_salt: int
+    constructor_calldata: List[int]
+    class_hash: int
 
 
 @dataclass
@@ -269,10 +299,10 @@ class DeployAccountTransactionV3(TransactionV3):
     Dataclass representing deploy account transaction v3.
     """
 
-    contract_address_salt: int
-    class_hash: int
-    constructor_calldata: List[int]
     nonce: int
+    contract_address_salt: int
+    constructor_calldata: List[int]
+    class_hash: int
 
 
 @dataclass

--- a/starknet_py/net/schemas/utils.py
+++ b/starknet_py/net/schemas/utils.py
@@ -3,17 +3,6 @@ from typing import Union
 from starknet_py.constants import QUERY_VERSION_BASE
 
 
-def _replace_invoke_contract_address_with_sender_address(data: dict):
-    data["sender_address"] = data.get("sender_address") or data.get("contract_address")
-
-    if data["sender_address"] is None:
-        raise ValueError(
-            "Missing field `contract_address` or `sender_address` for InvokeTransactionSchema."
-        )
-
-    del data["contract_address"]
-
-
 def _extract_tx_version(version: Union[int, str]):
     if isinstance(version, str):
         version = int(version, 16)

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -11,8 +11,8 @@ from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client_errors import ClientError
 from starknet_py.net.client_models import (
     Call,
-    DeployAccountTransaction,
     DeployAccountTransactionResponse,
+    DeployAccountTransactionV1,
     DeployAccountTransactionV3,
     EstimatedFee,
     InvokeTransactionV3,
@@ -466,7 +466,7 @@ async def test_deploy_account_v1(client, deploy_account_details_factory, map_con
     assert account.address == address
 
     transaction = await client.get_transaction(tx_hash=deploy_result.hash)
-    assert isinstance(transaction, DeployAccountTransaction)
+    assert isinstance(transaction, DeployAccountTransactionV1)
     assert transaction.constructor_calldata == [key_pair.public_key]
 
     res = await account.execute_v1(
@@ -615,7 +615,7 @@ async def test_deploy_account_uses_custom_calldata(
     )
 
     tx = await client.get_transaction(deploy_result.hash)
-    assert isinstance(tx, DeployAccountTransaction)
+    assert isinstance(tx, DeployAccountTransactionV1)
     assert tx.constructor_calldata == calldata
 
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -13,12 +13,13 @@ from starknet_py.net.client_models import (
     Call,
     ContractClass,
     DeclaredContractHash,
-    DeclareTransaction,
-    DeployAccountTransaction,
+    DeclareTransactionV1,
+    DeclareTransactionV2,
+    DeployAccountTransactionV1,
     EstimatedFee,
     ExecutionResources,
     FeePayment,
-    InvokeTransaction,
+    InvokeTransactionV1,
     L1HandlerTransaction,
     PendingBlockStateUpdate,
     PriceUnit,
@@ -51,7 +52,7 @@ async def test_get_declare_transaction(
 ):
     transaction = await client.get_transaction(declare_transaction_hash)
 
-    assert isinstance(transaction, DeclareTransaction)
+    assert isinstance(transaction, DeclareTransactionV1)
     assert transaction.class_hash == class_hash
     assert transaction.hash == declare_transaction_hash
     assert transaction.sender_address == account.address
@@ -64,7 +65,7 @@ async def test_get_invoke_transaction(
 ):
     transaction = await client.get_transaction(invoke_transaction_hash)
 
-    assert isinstance(transaction, InvokeTransaction)
+    assert isinstance(transaction, InvokeTransactionV1)
     assert any(data == 1234 for data in transaction.calldata)
     assert transaction.hash == invoke_transaction_hash
 
@@ -73,7 +74,7 @@ async def test_get_invoke_transaction(
 async def test_get_deploy_account_transaction(client, deploy_account_transaction_hash):
     transaction = await client.get_transaction(deploy_account_transaction_hash)
 
-    assert isinstance(transaction, DeployAccountTransaction)
+    assert isinstance(transaction, DeployAccountTransactionV1)
     assert transaction.hash == deploy_account_transaction_hash
     assert len(transaction.signature) > 0
     assert transaction.nonce == 0
@@ -536,8 +537,8 @@ async def test_get_declare_v2_transaction(
 
     transaction = await client.get_transaction(tx_hash=tx_hash)
 
-    assert isinstance(transaction, DeclareTransaction)
-    assert transaction == DeclareTransaction(
+    assert isinstance(transaction, DeclareTransactionV2)
+    assert transaction == DeclareTransactionV2(
         class_hash=class_hash,
         compiled_class_hash=declare_v2_hello_starknet.compiled_class_hash,
         sender_address=declare_v2_hello_starknet.sender_address,
@@ -561,7 +562,7 @@ async def test_get_block_with_declare_v2(
     block = await client.get_block(block_number=block_with_declare_v2_number)
 
     assert (
-        DeclareTransaction(
+        DeclareTransactionV2(
             class_hash=class_hash,
             compiled_class_hash=declare_v2_hello_starknet.compiled_class_hash,
             sender_address=declare_v2_hello_starknet.sender_address,

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -15,8 +15,8 @@ from starknet_py.net.client_models import (
     BlockHashAndNumber,
     Call,
     ContractClass,
-    DeclareTransaction,
     DeclareTransactionTrace,
+    DeclareTransactionV1,
     DeployAccountTransactionTrace,
     InvokeTransactionTrace,
     SierraContractClass,
@@ -53,7 +53,7 @@ async def test_node_get_declare_transaction_by_block_number_and_index(
         block_number=block_with_declare_number, index=0
     )
 
-    assert isinstance(tx, DeclareTransaction)
+    assert isinstance(tx, DeclareTransactionV1)
     assert tx.hash == declare_transaction_hash
     assert tx.class_hash == class_hash
     assert tx.version == 1

--- a/starknet_py/tests/e2e/contract_interaction/deploy_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/deploy_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from starknet_py.common import create_sierra_compiled_contract
 from starknet_py.contract import Contract, DeclareResult
-from starknet_py.net.client_models import InvokeTransaction, InvokeTransactionV3
+from starknet_py.net.client_models import InvokeTransactionV1, InvokeTransactionV3
 from starknet_py.net.models import DeclareV2
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUNDS_L1
 from starknet_py.tests.e2e.fixtures.misc import read_contract
@@ -114,7 +114,7 @@ async def test_deploy_contract_v1(account, cairo1_hello_starknet_class_hash: int
     assert len(contract.functions) != 0
 
     transaction = await account.client.get_transaction(tx_hash=deploy_result.hash)
-    assert isinstance(transaction, InvokeTransaction)
+    assert isinstance(transaction, InvokeTransactionV1)
 
     class_hash = await account.client.get_class_hash_at(
         contract_address=contract.address

--- a/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
@@ -1,12 +1,13 @@
 import pytest
 
 from starknet_py.net.client_models import (
-    DeclareTransaction,
     DeclareTransactionTrace,
-    DeployAccountTransaction,
+    DeclareTransactionV2,
     DeployAccountTransactionTrace,
-    InvokeTransaction,
+    DeployAccountTransactionV1,
     InvokeTransactionTrace,
+    InvokeTransactionV0,
+    InvokeTransactionV1,
     L1HandlerTransaction,
     L1HandlerTransactionTrace,
     RevertedFunctionInvocation,
@@ -22,9 +23,10 @@ from starknet_py.tests.e2e.fixtures.misc import read_contract
 @pytest.mark.asyncio
 async def test_trace_transaction(client_goerli_testnet):
     tx_to_trace: dict[type[Transaction], type[TransactionTrace]] = {
-        InvokeTransaction: InvokeTransactionTrace,
-        DeclareTransaction: DeclareTransactionTrace,
-        DeployAccountTransaction: DeployAccountTransactionTrace,
+        InvokeTransactionV0: InvokeTransactionTrace,
+        InvokeTransactionV1: InvokeTransactionTrace,
+        DeclareTransactionV2: DeclareTransactionTrace,
+        DeployAccountTransactionV1: DeployAccountTransactionTrace,
         L1HandlerTransaction: L1HandlerTransactionTrace,
     }
     block = await client_goerli_testnet.get_block(block_number=600000)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1249 


## Introduced changes

- Split deprecated rpc schemas to their respective classes based on version.

##

- [ ] This PR contains breaking changes


