### PR TITLE
Add `Account.deploy_account_v3` static method

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -241,7 +241,7 @@ class DeclareResult(SentTransaction):
             calldata=constructor_args,
             cairo_version=self._cairo_version,
         )
-        res = await self._account.execute(
+        res = await self._account.execute_v1(
             calls=deploy_call, nonce=nonce, max_fee=max_fee, auto_estimate=auto_estimate
         )
 
@@ -728,7 +728,7 @@ class Contract:
             calldata=constructor_args,
             cairo_version=cairo_version,
         )
-        res = await account.execute(
+        res = await account.execute_v1(
             calls=deploy_call, nonce=nonce, max_fee=max_fee, auto_estimate=auto_estimate
         )
 

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -804,19 +804,19 @@ def _add_resource_bounds_to_transaction(
 
 def _parse_calls(cairo_version: int, calls: Calls) -> List[int]:
     if cairo_version == 1:
-        parsed_calls = _parse_calls_v2(ensure_iterable(calls))
-        wrapped_calldata = _execute_payload_serializer_v2.serialize(
+        parsed_calls = _parse_calls_cairo_v1(ensure_iterable(calls))
+        wrapped_calldata = _execute_payload_serializer_v1.serialize(
             {"calls": parsed_calls}
         )
     else:
         call_descriptions, calldata = _merge_calls(ensure_iterable(calls))
-        wrapped_calldata = _execute_payload_serializer.serialize(
+        wrapped_calldata = _execute_payload_serializer_v0.serialize(
             {"call_array": call_descriptions, "calldata": calldata}
         )
     return wrapped_calldata
 
 
-def _parse_call(call: Call, entire_calldata: List) -> Tuple[Dict, List]:
+def _parse_call_cairo_v0(call: Call, entire_calldata: List) -> Tuple[Dict, List]:
     _data = {
         "to": call.to_addr,
         "selector": call.selector,
@@ -832,13 +832,13 @@ def _merge_calls(calls: Iterable[Call]) -> Tuple[List[Dict], List[int]]:
     call_descriptions = []
     entire_calldata = []
     for call in calls:
-        data, entire_calldata = _parse_call(call, entire_calldata)
+        data, entire_calldata = _parse_call_cairo_v0(call, entire_calldata)
         call_descriptions.append(data)
 
     return call_descriptions, entire_calldata
 
 
-def _parse_calls_v2(calls: Iterable[Call]) -> List[Dict]:
+def _parse_calls_cairo_v1(calls: Iterable[Call]) -> List[Dict]:
     calls_parsed = []
     for call in calls:
         _data = {
@@ -852,7 +852,7 @@ def _parse_calls_v2(calls: Iterable[Call]) -> List[Dict]:
 
 
 _felt_serializer = FeltSerializer()
-_call_description = StructSerializer(
+_call_description_cairo_v0 = StructSerializer(
     OrderedDict(
         to=_felt_serializer,
         selector=_felt_serializer,
@@ -860,7 +860,7 @@ _call_description = StructSerializer(
         data_len=_felt_serializer,
     )
 )
-_call_description_v2 = StructSerializer(
+_call_description_cairo_v1 = StructSerializer(
     OrderedDict(
         to=_felt_serializer,
         selector=_felt_serializer,
@@ -868,14 +868,14 @@ _call_description_v2 = StructSerializer(
     )
 )
 
-_execute_payload_serializer = PayloadSerializer(
+_execute_payload_serializer_v0 = PayloadSerializer(
     OrderedDict(
-        call_array=ArraySerializer(_call_description),
+        call_array=ArraySerializer(_call_description_cairo_v0),
         calldata=ArraySerializer(_felt_serializer),
     )
 )
-_execute_payload_serializer_v2 = PayloadSerializer(
+_execute_payload_serializer_v1 = PayloadSerializer(
     OrderedDict(
-        calls=ArraySerializer(_call_description_v2),
+        calls=ArraySerializer(_call_description_cairo_v1),
     )
 )

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -651,12 +651,7 @@ class Account(BaseAccount):
             auto_estimate=auto_estimate,
         )
 
-        if chain in (
-            StarknetChainId.SEPOLIA_TESTNET,
-            StarknetChainId.SEPOLIA_INTEGRATION,
-            StarknetChainId.GOERLI,
-            StarknetChainId.MAINNET,
-        ):
+        if chain in StarknetChainId:
             balance = await account.get_balance()
             if balance < deploy_account_tx.max_fee:
                 raise ValueError(

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -592,7 +592,7 @@ class Account(BaseAccount):
         return verify_message_signature(message_hash, signature, self.signer.public_key)
 
     @staticmethod
-    async def deploy_account(
+    async def deploy_account_v1(
         *,
         address: AddressRepresentation,
         class_hash: int,

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -550,7 +550,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(deploy_account_tx)
         return _add_signature_to_transaction(deploy_account_tx, signature)
 
-    async def execute(
+    async def execute_v1(
         self,
         calls: Calls,
         *,

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -611,8 +611,8 @@ class Account(BaseAccount):
 
         Provided address must be first prefunded with enough tokens, otherwise the method will fail.
 
-        If using Client for GOERLI, SEPOLIA or MAINNET, this method will verify if the address balance
-        is high enough to cover deployment costs.
+        If using Client for MAINNET, GOERLI, SEPOLIA or SEPOLIA_INTEGRATION, this method will verify
+        if the address balance is high enough to cover deployment costs.
 
         :param address: Calculated and prefunded address of the new account.
         :param class_hash: Class hash of the account contract to be deployed.
@@ -693,7 +693,7 @@ class Account(BaseAccount):
         :param constructor_calldata: Optional calldata to account contract constructor. If ``None`` is passed,
             ``[key_pair.public_key]`` will be used as calldata.
         :param nonce: Nonce of the transaction.
-        :param l1_resource_bounds: Max amount and max price per unit of L1 gas (in Wei) used when executing
+        :param l1_resource_bounds: Max amount and max price per unit of L1 gas (in Fri) used when executing
             this transaction.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         """

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -611,19 +611,19 @@ class Account(BaseAccount):
 
         Provided address must be first prefunded with enough tokens, otherwise the method will fail.
 
-        If using Client for either TESTNET or MAINNET, this method will verify if the address balance
+        If using Client for GOERLI, SEPOLIA or MAINNET, this method will verify if the address balance
         is high enough to cover deployment costs.
 
-        :param address: calculated and prefunded address of the new account.
-        :param class_hash: class_hash of the account contract to be deployed.
-        :param salt: salt used to calculate the address.
+        :param address: Calculated and prefunded address of the new account.
+        :param class_hash: Class hash of the account contract to be deployed.
+        :param salt: Salt used to calculate the address.
         :param key_pair: KeyPair used to calculate address and sign deploy account transaction.
-        :param client: a Client instance used for deployment.
-        :param chain: id of the Starknet chain used.
-        :param constructor_calldata: optional calldata to account contract constructor. If ``None`` is passed,
+        :param client: Client instance used for deployment.
+        :param chain: Id of the Starknet chain used.
+        :param constructor_calldata: Optional calldata to account contract constructor. If ``None`` is passed,
             ``[key_pair.public_key]`` will be used as calldata.
         :param nonce: Nonce of the transaction.
-        :param max_fee: max fee to be paid for deployment, must be less or equal to the amount of tokens prefunded.
+        :param max_fee: Max fee to be paid for deployment, must be less or equal to the amount of tokens prefunded.
         :param auto_estimate: Use automatic fee estimation, not recommend as it may lead to high costs.
         """
         calldata = (
@@ -684,16 +684,13 @@ class Account(BaseAccount):
 
         Provided address must be first prefunded with enough tokens, otherwise the method will fail.
 
-        If using Client for either TESTNET or MAINNET, this method will verify if the address balance
-        is high enough to cover deployment costs.
-
-        :param address: calculated and prefunded address of the new account.
-        :param class_hash: class_hash of the account contract to be deployed.
-        :param salt: salt used to calculate the address.
+        :param address: Calculated and prefunded address of the new account.
+        :param class_hash: Class hash of the account contract to be deployed.
+        :param salt: Salt used to calculate the address.
         :param key_pair: KeyPair used to calculate address and sign deploy account transaction.
-        :param client: a Client instance used for deployment.
-        :param chain: id of the Starknet chain used.
-        :param constructor_calldata: optional calldata to account contract constructor. If ``None`` is passed,
+        :param client: Client instance used for deployment.
+        :param chain: Id of the Starknet chain used.
+        :param constructor_calldata: Optional calldata to account contract constructor. If ``None`` is passed,
             ``[key_pair.public_key]`` will be used as calldata.
         :param nonce: Nonce of the transaction.
         :param l1_resource_bounds: Max amount and max price per unit of L1 gas (in Wei) used when executing

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -264,7 +264,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def execute(
+    async def execute_v1(
         self,
         calls: Calls,
         *,

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -448,7 +448,7 @@ async def test_sign_deploy_account_v3_transaction_auto_estimate(
 async def test_deploy_account(client, deploy_account_details_factory, map_contract):
     address, key_pair, salt, class_hash = await deploy_account_details_factory.get()
 
-    deploy_result = await Account.deploy_account(
+    deploy_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,
@@ -487,7 +487,7 @@ async def test_deploy_account_raises_on_incorrect_address(
         ValueError,
         match=f"Provided address {hex(0x111)} is different than computed address {hex(address)}",
     ):
-        await Account.deploy_account(
+        await Account.deploy_account_v1(
             address=0x111,
             class_hash=class_hash,
             salt=salt,
@@ -513,7 +513,7 @@ async def test_deploy_account_raises_on_no_enough_funds(
             ValueError,
             match="Not enough tokens at the specified address to cover deployment costs",
         ):
-            await Account.deploy_account(
+            await Account.deploy_account_v1(
                 address=address,
                 class_hash=class_hash,
                 salt=salt,
@@ -540,7 +540,7 @@ async def test_deploy_account_passes_on_enough_funds(
             transaction_hash=0x1
         )
 
-        await Account.deploy_account(
+        await Account.deploy_account_v1(
             address=address,
             class_hash=class_hash,
             salt=salt,
@@ -573,7 +573,7 @@ async def test_deploy_account_uses_custom_calldata(
     )
     await res.wait_for_acceptance()
 
-    deploy_result = await Account.deploy_account(
+    deploy_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,
@@ -668,7 +668,7 @@ async def test_argent_cairo1_account_deploy(
         class_hash=argent_cairo1_account_class_hash, argent_calldata=True
     )
 
-    deploy_result = await Account.deploy_account(
+    deploy_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -106,7 +106,7 @@ async def test_sending_multicall(account, map_contract, key, val):
         map_contract.functions["put"].prepare(key=key, value=val),
     ]
 
-    res = await account.execute(calls=calls, max_fee=int(1e20))
+    res = await account.execute_v1(calls=calls, max_fee=int(1e20))
     await account.client.wait_for_tx(res.transaction_hash)
 
     (value,) = await map_contract.functions["get"].call(key=key)
@@ -152,7 +152,7 @@ async def test_get_nonce(account, map_contract):
     address = map_contract.address
     block = await account.client.get_block(block_number="latest")
 
-    tx = await account.execute(
+    tx = await account.execute_v1(
         Call(
             to_addr=address, selector=get_selector_from_name("put"), calldata=[10, 20]
         ),
@@ -469,7 +469,7 @@ async def test_deploy_account_v1(client, deploy_account_details_factory, map_con
     assert isinstance(transaction, DeployAccountTransaction)
     assert transaction.constructor_calldata == [key_pair.public_key]
 
-    res = await account.execute(
+    res = await account.execute_v1(
         calls=Call(
             to_addr=map_contract.address,
             selector=get_selector_from_name("put"),
@@ -744,7 +744,7 @@ async def test_argent_cairo1_account_execute(
         selector=get_selector_from_name("increase_balance"),
         calldata=[value],
     )
-    execute = await argent_cairo1_account.execute(
+    execute = await argent_cairo1_account.execute_v1(
         calls=increase_balance_by_20_call, max_fee=int(1e16)
     )
     await argent_cairo1_account.client.wait_for_tx(tx_hash=execute.transaction_hash)

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -118,7 +118,7 @@ async def test_get_transaction_receipt_deploy_account(
     client, deploy_account_details_factory
 ):
     address, key_pair, salt, class_hash = await deploy_account_details_factory.get()
-    deploy_result = await Account.deploy_account(
+    deploy_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,

--- a/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
+++ b/starknet_py/tests/e2e/docs/account_creation/test_deploy_prefunded_account.py
@@ -58,8 +58,8 @@ async def test_deploy_prefunded_account(
     chain = chain_from_network(net=network, chain=StarknetChainId.GOERLI)
     # docs: start
 
-    # Use `Account.deploy_account` static method to deploy an account
-    account_deployment_result = await Account.deploy_account(
+    # Use `Account.deploy_account_v1` static method to deploy an account
+    account_deployment_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,

--- a/starknet_py/tests/e2e/docs/code_examples/test_account.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_account.py
@@ -27,7 +27,7 @@ def test_init():
 @pytest.mark.asyncio
 async def test_execute(account, contract_address):
     # docs-start: execute
-    resp = await account.execute(
+    resp = await account.execute_v1(
         Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -43,7 +43,7 @@ async def test_execute(account, contract_address):
         calldata=[123],
     )
     # docs-start: execute
-    resp = await account.execute(calls=[call1, call2], auto_estimate=True)
+    resp = await account.execute_v1(calls=[call1, call2], auto_estimate=True)
     # docs-end: execute
 
 

--- a/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
+++ b/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
@@ -74,7 +74,7 @@ async def test_cairo1_contract(
         salt=salt,
     )
 
-    res = await account.execute(calls=contract_deployment.call, max_fee=MAX_FEE)
+    res = await account.execute_v1(calls=contract_deployment.call, max_fee=MAX_FEE)
     await account.client.wait_for_tx(res.transaction_hash)
 
     # The contract has been deployed and can be found at contract_deployment.address

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -65,7 +65,7 @@ async def test_deploying_with_udc(
     )
 
     # Once call is prepared, it can be executed with an account (preferred way)
-    resp = await account.execute(deploy_call, max_fee=int(1e16))
+    resp = await account.execute_v1(deploy_call, max_fee=int(1e16))
 
     # docs: end
     deploy_call, _ = deployer.create_contract_deployment(

--- a/starknet_py/tests/e2e/docs/guide/test_executing_transactions.py
+++ b/starknet_py/tests/e2e/docs/guide/test_executing_transactions.py
@@ -13,7 +13,7 @@ async def test_executing_transactions(account, map_contract):
         to_addr=address, selector=get_selector_from_name("put"), calldata=[20, 20]
     )
 
-    resp = await account.execute(calls=call, max_fee=int(1e16))
+    resp = await account.execute_v1(calls=call, max_fee=int(1e16))
 
     await account.client.wait_for_tx(resp.transaction_hash)
     # docs: end

--- a/starknet_py/tests/e2e/docs/guide/test_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_multicall.py
@@ -18,7 +18,7 @@ async def test_multicall(account, deployed_balance_contract):
     calls = [increase_balance_by_20_call, increase_balance_by_20_call]
 
     # Execute one transaction with multiple calls
-    resp = await account.execute(calls=calls, max_fee=int(1e16))
+    resp = await account.execute_v1(calls=calls, max_fee=int(1e16))
     await account.client.wait_for_tx(resp.transaction_hash)
     # docs: end
 

--- a/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
+++ b/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
@@ -40,9 +40,9 @@ async def test_account_comparison(gateway_account, map_contract):
     # docs-3: start
     # Using execute method
 
-    await account_client.execute(call, max_fee)
+    await account_client.execute_v1(call, max_fee)
 
     # becomes
 
-    await account.execute(call, max_fee=max_fee)
+    await account.execute_v1(call, max_fee=max_fee)
     # docs-3: end

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
@@ -45,7 +45,7 @@ async def test_using_account(account, map_compiled_contract):
     ]
 
     # Executes only one transaction with prepared calls
-    transaction_response = await account.execute(calls=calls, max_fee=int(1e16))
+    transaction_response = await account.execute_v1(calls=calls, max_fee=int(1e16))
     await account.client.wait_for_tx(transaction_response.transaction_hash)
     # docs: end
 

--- a/starknet_py/tests/e2e/fixtures/accounts.py
+++ b/starknet_py/tests/e2e/fixtures/accounts.py
@@ -213,7 +213,7 @@ async def argent_cairo1_account(
         class_hash=argent_cairo1_account_class_hash,
         argent_calldata=True,
     )
-    deploy_result = await Account.deploy_account(
+    deploy_result = await Account.deploy_account_v1(
         address=address,
         class_hash=class_hash,
         salt=salt,

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -151,7 +151,7 @@ async def deploy_v1_contract(
         calldata=calldata,
         cairo_version=1,
     )
-    res = await account.execute(calls=deploy_call, max_fee=MAX_FEE)
+    res = await account.execute_v1(calls=deploy_call, max_fee=MAX_FEE)
     await account.client.wait_for_tx(res.transaction_hash)
 
     return Contract(address, abi, provider=account, cairo_version=1)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to #1235 and #1262 


## Introduced changes
<!-- A brief description of the changes -->

- Add static method `Account.deploy_account_v3()`
- Rename:
  - `deploy_account` -> `deploy_account_v1` 
  - `execute` -> `execute_v1`
  - helper methods for parsing calls, previous names with v1 and v2 postfixes were confusing

Please note that documentation update will be done in a separate PR.

##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


