### PR TITLE
Remove `wait_for_accept` parameter

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -58,6 +58,7 @@ Changes in the :class:`~starknet_py.net.full_node_client.FullNodeClient`:
 9. :class:`FunctionInvocation` has a new required field ``execution_resources``.
 10. :class:`ResourcePrice` field ``price_in_strk`` has been renamed to ``price_in_fri`` and has now become required.
 11. :class:`ResourceLimits` class has been renamed to :class:`ResourceBounds`.
+12. ``wait_for_accept`` parameter in :meth:`Client.wait_for_tx` and :meth:`SentTransaction.wait_for_acceptance` has been removed.
 
 0.19.0 Minor changes
 --------------------

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import json
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property
@@ -117,7 +116,6 @@ class SentTransaction:
 
     async def wait_for_acceptance(
         self: TypeSentTransaction,
-        wait_for_accept: Optional[bool] = None,
         check_interval: float = 2,
         retries: int = 500,
     ) -> TypeSentTransaction:
@@ -125,11 +123,6 @@ class SentTransaction:
         Waits for transaction to be accepted on chain till ``ACCEPTED`` status.
         Returns a new SentTransaction instance, **does not mutate original instance**.
         """
-        if wait_for_accept is not None:
-            warnings.warn(
-                "Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING"
-                " block have status ACCEPTED_ON_L2."
-            )
 
         tx_receipt = await self._client.wait_for_tx(
             self.hash,

--- a/starknet_py/net/client.py
+++ b/starknet_py/net/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional, Union
 
@@ -137,7 +136,6 @@ class Client(ABC):
     async def wait_for_tx(
         self,
         tx_hash: Hash,
-        wait_for_accept: Optional[bool] = None,  # pylint: disable=unused-argument
         check_interval: float = 2,
         retries: int = 500,
     ) -> TransactionReceipt:
@@ -146,10 +144,6 @@ class Client(ABC):
         Awaits for transaction to get accepted or at least pending by polling its status.
 
         :param tx_hash: Transaction's hash.
-        :param wait_for_accept:
-            .. deprecated:: 0.17.0
-                Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING
-                block have status ACCEPTED_ON_L2.
         :param check_interval: Defines interval between checks.
         :param retries: Defines how many times the transaction is checked until an error is thrown.
         :return: Transaction receipt.
@@ -158,11 +152,6 @@ class Client(ABC):
             raise ValueError("Argument check_interval has to be greater than 0.")
         if retries <= 0:
             raise ValueError("Argument retries has to be greater than 0.")
-        if wait_for_accept is not None:
-            warnings.warn(
-                "Parameter `wait_for_accept` has been deprecated - since Starknet 0.12.0, transactions in a PENDING"
-                " block have status ACCEPTED_ON_L2."
-            )
 
         transaction_received = False
         while True:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1268 


## Introduced changes
<!-- A brief description of the changes -->

- Remove deprecated `wait_for_accept` parameter from `Client.wait_for_tx()` and `SentTransaction.wait_for_acceptance()`

##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


