### PR TITLE
Drop 'transaction' word from sign methods in `Account` class

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -17,8 +17,8 @@ Changes in the :class:`~starknet_py.net.account.account.Account`:
 .. currentmodule:: starknet_py.net.account.account
 
 - :meth:`~Account.execute_v3` has been added.
-- :meth:`~Account.sign_declare_v3_transaction`, :meth:`~Account.sign_deploy_account_v3_transaction` and :meth:`~Account.sign_invoke_v3_transaction` have been added.
-- :meth:`~Account.sign_declare_transaction`, :meth:`~Account.sign_deploy_account_transaction` and :meth:`~Account.sign_invoke_transaction` have been renamed to :meth:`~Account.sign_declare_v1_transaction`, :meth:`~Account.sign_deploy_account_v1_transaction` and :meth:`~Account.sign_invoke_v1_transaction` respectively.
+- :meth:`~Account.sign_declare_v3`, :meth:`~Account.sign_deploy_account_v3` and :meth:`~Account.sign_invoke_v3` have been added.
+- :meth:`sign_declare_transaction`, :meth:`sign_declare_v2_transaction`, :meth:`sign_deploy_account_transaction` and :meth:`sign_invoke_transaction` have been renamed to :meth:`~Account.sign_declare_v1`, :meth:`~Account.sign_declare_v2`, :meth:`~Account.sign_deploy_account_v1` and :meth:`~Account.sign_invoke_v1` respectively.
 
 All new functions with ``v3`` in their name operate similarly to their ``v1`` and ``v2`` counterparts.
 Unlike their ``v1`` counterparts, ``v3`` transaction fees are paid in Fri (10^-18 STRK). Therefore,  ``max_fee`` parameter, which is typically set in Wei, is not applicable for ``v3`` functions. Instead, ``l1_resource_bounds`` parameter is utilized to limit the Fri amount used.
@@ -351,7 +351,7 @@ Also, four methods were added to its interface:
 
 .. currentmodule:: starknet_py.net.account.account
 
-2. :meth:`Account.sign_invoke_transaction`, :meth:`Account.sign_declare_transaction`, :meth:`Account.sign_declare_v2_transaction`, :meth:`Account.sign_deploy_account_transaction` and :meth:`Account.execute` can now accept custom ``nonce`` parameter.
+2. :meth:`Account.sign_invoke_transaction`, :meth:`Account.sign_declare_transaction`, :meth:`Account.sign_declare_v2`, :meth:`Account.sign_deploy_account_transaction` and :meth:`Account.execute` can now accept custom ``nonce`` parameter.
 3. :meth:`Account.get_nonce` can now be parametrized with ``block_number`` or ``block_hash``.
 4. :meth:`Account.get_balance` can now be parametrized with ``block_number`` or ``block_hash``.
 

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -429,7 +429,7 @@ class PreparedFunctionInvokeV1(PreparedFunctionInvoke):
         :return: InvokeResult.
         """
 
-        transaction = await self.get_account.sign_invoke_v1_transaction(
+        transaction = await self.get_account.sign_invoke_v1(
             calls=self,
             nonce=nonce,
             max_fee=max_fee or self.max_fee,
@@ -445,9 +445,7 @@ class PreparedFunctionInvokeV1(PreparedFunctionInvoke):
         *,
         nonce: Optional[int] = None,
     ) -> EstimatedFee:
-        tx = await self.get_account.sign_invoke_v1_transaction(
-            calls=self, nonce=nonce, max_fee=0
-        )
+        tx = await self.get_account.sign_invoke_v1(calls=self, nonce=nonce, max_fee=0)
         estimate_tx = await self.get_account.sign_for_fee_estimate(transaction=tx)
 
         estimated_fee = await self._client.estimate_fee(
@@ -486,7 +484,7 @@ class PreparedFunctionInvokeV3(PreparedFunctionInvoke):
         :return: InvokeResult.
         """
 
-        transaction = await self.get_account.sign_invoke_v3_transaction(
+        transaction = await self.get_account.sign_invoke_v3(
             calls=self,
             nonce=nonce,
             l1_resource_bounds=l1_resource_bounds or self.l1_resource_bounds,
@@ -502,7 +500,7 @@ class PreparedFunctionInvokeV3(PreparedFunctionInvoke):
         *,
         nonce: Optional[int] = None,
     ) -> EstimatedFee:
-        tx = await self.get_account.sign_invoke_v3_transaction(
+        tx = await self.get_account.sign_invoke_v3(
             calls=self, nonce=nonce, l1_resource_bounds=ResourceBounds.init_with_zeros()
         )
         estimate_tx = await self.get_account.sign_for_fee_estimate(transaction=tx)
@@ -831,7 +829,7 @@ class Contract:
         :return: DeclareResult instance.
         """
 
-        declare_tx = await account.sign_declare_v1_transaction(
+        declare_tx = await account.sign_declare_v1(
             compiled_contract=compiled_contract,
             nonce=nonce,
             max_fee=max_fee,
@@ -870,7 +868,7 @@ class Contract:
             compiled_contract_casm, compiled_class_hash
         )
 
-        declare_tx = await account.sign_declare_v2_transaction(
+        declare_tx = await account.sign_declare_v2(
             compiled_contract=compiled_contract,
             compiled_class_hash=compiled_class_hash,
             nonce=nonce,
@@ -911,7 +909,7 @@ class Contract:
             compiled_contract_casm, compiled_class_hash
         )
 
-        declare_tx = await account.sign_declare_v3_transaction(
+        declare_tx = await account.sign_declare_v3(
             compiled_contract=compiled_contract,
             compiled_class_hash=compiled_class_hash,
             nonce=nonce,

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -318,7 +318,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(transaction)
         return _add_signature_to_transaction(tx=transaction, signature=signature)
 
-    async def sign_invoke_v1_transaction(
+    async def sign_invoke_v1(
         self,
         calls: Calls,
         *,
@@ -335,7 +335,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(execute_tx)
         return _add_signature_to_transaction(execute_tx, signature)
 
-    async def sign_invoke_v3_transaction(
+    async def sign_invoke_v3(
         self,
         calls: Calls,
         *,
@@ -352,7 +352,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(invoke_tx)
         return _add_signature_to_transaction(invoke_tx, signature)
 
-    async def sign_declare_v1_transaction(
+    async def sign_declare_v1(
         self,
         compiled_contract: str,
         *,
@@ -362,7 +362,7 @@ class Account(BaseAccount):
     ) -> DeclareV1:
         if _is_sierra_contract(json.loads(compiled_contract)):
             raise ValueError(
-                "Signing sierra contracts requires using `sign_declare_v2_transaction` method."
+                "Signing sierra contracts requires using `sign_declare_v2` method."
             )
 
         declare_tx = await self._make_declare_v1_transaction(
@@ -376,7 +376,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(declare_tx)
         return _add_signature_to_transaction(declare_tx, signature)
 
-    async def sign_declare_v2_transaction(
+    async def sign_declare_v2(
         self,
         compiled_contract: str,
         compiled_class_hash: int,
@@ -395,7 +395,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(declare_tx)
         return _add_signature_to_transaction(declare_tx, signature)
 
-    async def sign_declare_v3_transaction(
+    async def sign_declare_v3(
         self,
         compiled_contract: str,
         compiled_class_hash: int,
@@ -485,7 +485,7 @@ class Account(BaseAccount):
         )
         return declare_tx
 
-    async def sign_deploy_account_v1_transaction(
+    async def sign_deploy_account_v1(
         self,
         class_hash: int,
         contract_address_salt: int,
@@ -512,7 +512,7 @@ class Account(BaseAccount):
         signature = self.signer.sign_transaction(deploy_account_tx)
         return _add_signature_to_transaction(deploy_account_tx, signature)
 
-    async def sign_deploy_account_v3_transaction(
+    async def sign_deploy_account_v3(
         self,
         class_hash: int,
         contract_address_salt: int,
@@ -549,7 +549,7 @@ class Account(BaseAccount):
         max_fee: Optional[int] = None,
         auto_estimate: bool = False,
     ) -> SentTransactionResponse:
-        execute_transaction = await self.sign_invoke_v1_transaction(
+        execute_transaction = await self.sign_invoke_v1(
             calls,
             nonce=nonce,
             max_fee=max_fee,
@@ -565,7 +565,7 @@ class Account(BaseAccount):
         nonce: Optional[int] = None,
         auto_estimate: bool = False,
     ) -> SentTransactionResponse:
-        execute_transaction = await self.sign_invoke_v3_transaction(
+        execute_transaction = await self.sign_invoke_v3(
             calls,
             l1_resource_bounds=l1_resource_bounds,
             nonce=nonce,
@@ -633,7 +633,7 @@ class Account(BaseAccount):
             calldata=calldata,
         )
 
-        deploy_account_tx = await account.sign_deploy_account_v1_transaction(
+        deploy_account_tx = await account.sign_deploy_account_v1(
             class_hash=class_hash,
             contract_address_salt=salt,
             constructor_calldata=calldata,
@@ -704,7 +704,7 @@ class Account(BaseAccount):
             calldata=calldata,
         )
 
-        deploy_account_tx = await account.sign_deploy_account_v3_transaction(
+        deploy_account_tx = await account.sign_deploy_account_v3(
             class_hash=class_hash,
             contract_address_salt=salt,
             constructor_calldata=calldata,

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -101,7 +101,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_invoke_v1_transaction(
+    async def sign_invoke_v1(
         self,
         calls: Calls,
         *,
@@ -120,7 +120,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_invoke_v3_transaction(
+    async def sign_invoke_v3(
         self,
         calls: Calls,
         *,
@@ -139,7 +139,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_declare_v1_transaction(
+    async def sign_declare_v1(
         self,
         compiled_contract: str,
         *,
@@ -158,7 +158,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_declare_v2_transaction(
+    async def sign_declare_v2(
         self,
         compiled_contract: str,
         compiled_class_hash: int,
@@ -181,7 +181,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_declare_v3_transaction(
+    async def sign_declare_v3(
         self,
         compiled_contract: str,
         compiled_class_hash: int,
@@ -204,7 +204,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_deploy_account_v1_transaction(
+    async def sign_deploy_account_v1(
         self,
         class_hash: int,
         contract_address_salt: int,
@@ -229,7 +229,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    async def sign_deploy_account_v3_transaction(
+    async def sign_deploy_account_v3(
         self,
         class_hash: int,
         contract_address_salt: int,

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -84,7 +84,7 @@ async def test_estimated_fee_greater_than_zero(account, erc20_contract):
 
 @pytest.mark.asyncio
 async def test_estimate_fee_for_declare_transaction(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 
@@ -176,8 +176,8 @@ async def test_get_nonce(account, map_contract):
 @pytest.mark.parametrize(
     "calls", [[Call(10, 20, [30])], [Call(10, 20, [30]), Call(40, 50, [60])]]
 )
-async def test_sign_invoke_v1_transaction(account, calls):
-    signed_tx = await account.sign_invoke_v1_transaction(calls, max_fee=MAX_FEE)
+async def test_sign_invoke_v1(account, calls):
+    signed_tx = await account.sign_invoke_v1(calls, max_fee=MAX_FEE)
 
     assert isinstance(signed_tx.signature, list)
     assert len(signed_tx.signature) > 0
@@ -185,8 +185,8 @@ async def test_sign_invoke_v1_transaction(account, calls):
 
 
 @pytest.mark.asyncio
-async def test_sign_invoke_v1_transaction_auto_estimate(account, map_contract):
-    signed_tx = await account.sign_invoke_v1_transaction(
+async def test_sign_invoke_v1_auto_estimate(account, map_contract):
+    signed_tx = await account.sign_invoke_v1(
         Call(map_contract.address, get_selector_from_name("put"), [3, 4]),
         auto_estimate=True,
     )
@@ -200,8 +200,8 @@ async def test_sign_invoke_v1_transaction_auto_estimate(account, map_contract):
 @pytest.mark.parametrize(
     "calls", [[Call(10, 20, [30])], [Call(10, 20, [30]), Call(40, 50, [60])]]
 )
-async def test_sign_invoke_v3_transaction(account, calls):
-    signed_tx = await account.sign_invoke_v3_transaction(
+async def test_sign_invoke_v3(account, calls):
+    signed_tx = await account.sign_invoke_v3(
         calls, l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1
     )
 
@@ -213,8 +213,8 @@ async def test_sign_invoke_v3_transaction(account, calls):
 
 
 @pytest.mark.asyncio
-async def test_sign_invoke_v3_transaction_auto_estimate(account, map_contract):
-    signed_tx = await account.sign_invoke_v3_transaction(
+async def test_sign_invoke_v3_auto_estimate(account, map_contract):
+    signed_tx = await account.sign_invoke_v3(
         Call(map_contract.address, get_selector_from_name("put"), [3, 4]),
         auto_estimate=True,
     )
@@ -233,9 +233,7 @@ async def test_sign_invoke_v3_transaction_auto_estimate(account, map_contract):
 
 @pytest.mark.asyncio
 async def test_sign_declare_transaction(account, map_compiled_contract):
-    signed_tx = await account.sign_declare_v1_transaction(
-        map_compiled_contract, max_fee=MAX_FEE
-    )
+    signed_tx = await account.sign_declare_v1(map_compiled_contract, max_fee=MAX_FEE)
 
     assert isinstance(signed_tx, DeclareV1)
     assert signed_tx.version == 1
@@ -246,9 +244,7 @@ async def test_sign_declare_transaction(account, map_compiled_contract):
 
 @pytest.mark.asyncio
 async def test_sign_declare_transaction_auto_estimate(account, map_compiled_contract):
-    signed_tx = await account.sign_declare_v1_transaction(
-        map_compiled_contract, auto_estimate=True
-    )
+    signed_tx = await account.sign_declare_v1(map_compiled_contract, auto_estimate=True)
 
     assert isinstance(signed_tx, DeclareV1)
     assert signed_tx.version == 1
@@ -258,7 +254,7 @@ async def test_sign_declare_transaction_auto_estimate(account, map_compiled_cont
 
 
 @pytest.mark.asyncio
-async def test_sign_declare_v2_transaction(
+async def test_sign_declare_v2(
     account, sierra_minimal_compiled_contract_and_class_hash
 ):
     (
@@ -266,7 +262,7 @@ async def test_sign_declare_v2_transaction(
         compiled_class_hash,
     ) = sierra_minimal_compiled_contract_and_class_hash
 
-    signed_tx = await account.sign_declare_v2_transaction(
+    signed_tx = await account.sign_declare_v2(
         compiled_contract,
         compiled_class_hash=compiled_class_hash,
         max_fee=MAX_FEE,
@@ -280,7 +276,7 @@ async def test_sign_declare_v2_transaction(
 
 
 @pytest.mark.asyncio
-async def test_sign_declare_v2_transaction_auto_estimate(
+async def test_sign_declare_v2_auto_estimate(
     account, sierra_minimal_compiled_contract_and_class_hash
 ):
     (
@@ -288,7 +284,7 @@ async def test_sign_declare_v2_transaction_auto_estimate(
         compiled_class_hash,
     ) = sierra_minimal_compiled_contract_and_class_hash
 
-    signed_tx = await account.sign_declare_v2_transaction(
+    signed_tx = await account.sign_declare_v2(
         compiled_contract,
         compiled_class_hash=compiled_class_hash,
         auto_estimate=True,
@@ -302,7 +298,7 @@ async def test_sign_declare_v2_transaction_auto_estimate(
 
 
 @pytest.mark.asyncio
-async def test_sign_declare_v3_transaction(
+async def test_sign_declare_v3(
     account, sierra_minimal_compiled_contract_and_class_hash
 ):
     (
@@ -310,7 +306,7 @@ async def test_sign_declare_v3_transaction(
         compiled_class_hash,
     ) = sierra_minimal_compiled_contract_and_class_hash
 
-    signed_tx = await account.sign_declare_v3_transaction(
+    signed_tx = await account.sign_declare_v3(
         compiled_contract,
         compiled_class_hash,
         l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
@@ -326,7 +322,7 @@ async def test_sign_declare_v3_transaction(
 
 
 @pytest.mark.asyncio
-async def test_sign_declare_v3_transaction_auto_estimate(
+async def test_sign_declare_v3_auto_estimate(
     account, sierra_minimal_compiled_contract_and_class_hash
 ):
     (
@@ -334,7 +330,7 @@ async def test_sign_declare_v3_transaction_auto_estimate(
         compiled_class_hash,
     ) = sierra_minimal_compiled_contract_and_class_hash
 
-    signed_tx = await account.sign_declare_v3_transaction(
+    signed_tx = await account.sign_declare_v3(
         compiled_contract, compiled_class_hash, auto_estimate=True
     )
 
@@ -357,9 +353,9 @@ async def test_declare_contract_raises_on_sierra_contract_without_compiled_class
     compiled_contract, _ = sierra_minimal_compiled_contract_and_class_hash
     with pytest.raises(
         ValueError,
-        match="Signing sierra contracts requires using `sign_declare_v2_transaction` method.",
+        match="Signing sierra contracts requires using `sign_declare_v2` method.",
     ):
-        await account.sign_declare_v1_transaction(compiled_contract=compiled_contract)
+        await account.sign_declare_v1(compiled_contract=compiled_contract)
 
 
 @pytest.mark.asyncio
@@ -367,7 +363,7 @@ async def test_sign_deploy_account_transaction(account):
     class_hash = 0x1234
     salt = 0x123
     calldata = [1, 2, 3]
-    signed_tx = await account.sign_deploy_account_v1_transaction(
+    signed_tx = await account.sign_deploy_account_v1(
         class_hash, salt, calldata, max_fee=MAX_FEE
     )
 
@@ -386,7 +382,7 @@ async def test_sign_deploy_account_transaction_auto_estimate(
     class_hash = account_with_validate_deploy_class_hash
     salt = 0x1234
     calldata = [account.signer.public_key]
-    signed_tx = await account.sign_deploy_account_v1_transaction(
+    signed_tx = await account.sign_deploy_account_v1(
         class_hash, salt, calldata, auto_estimate=True
     )
 
@@ -399,11 +395,11 @@ async def test_sign_deploy_account_transaction_auto_estimate(
 
 
 @pytest.mark.asyncio
-async def test_sign_deploy_account_v3_transaction(account):
+async def test_sign_deploy_account_v3(account):
     class_hash = 0x1234
     salt = 0x123
     calldata = [1, 2, 3]
-    signed_tx = await account.sign_deploy_account_v3_transaction(
+    signed_tx = await account.sign_deploy_account_v3(
         class_hash,
         salt,
         l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,
@@ -423,13 +419,13 @@ async def test_sign_deploy_account_v3_transaction(account):
 
 
 @pytest.mark.asyncio
-async def test_sign_deploy_account_v3_transaction_auto_estimate(
+async def test_sign_deploy_account_v3_auto_estimate(
     account, account_with_validate_deploy_class_hash
 ):
     class_hash = account_with_validate_deploy_class_hash
     salt = 0x123
     calldata = [account.signer.public_key]
-    signed_tx = await account.sign_deploy_account_v3_transaction(
+    signed_tx = await account.sign_deploy_account_v3(
         class_hash, salt, constructor_calldata=calldata, auto_estimate=True
     )
 
@@ -634,7 +630,7 @@ async def test_sign_deploy_account_tx_for_fee_estimation(
         chain=StarknetChainId.GOERLI,
     )
 
-    transaction = await account.sign_deploy_account_v1_transaction(
+    transaction = await account.sign_deploy_account_v1(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],
@@ -659,12 +655,10 @@ async def test_sign_deploy_account_tx_for_fee_estimation(
 @pytest.mark.asyncio
 async def test_sign_transaction_custom_nonce(account, cairo1_hello_starknet_class_hash):
     deployment = Deployer().create_contract_deployment(cairo1_hello_starknet_class_hash)
-    deploy_tx = await account.sign_invoke_v1_transaction(
-        deployment.call, max_fee=MAX_FEE
-    )
+    deploy_tx = await account.sign_invoke_v1(deployment.call, max_fee=MAX_FEE)
 
     new_balance = 30
-    invoke_tx = await account.sign_invoke_v1_transaction(
+    invoke_tx = await account.sign_invoke_v1(
         Call(
             deployment.address,
             get_selector_from_name("increase_balance"),

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -138,7 +138,7 @@ async def test_get_transaction_receipt(
 
 @pytest.mark.asyncio
 async def test_estimate_fee_invoke(account, contract_address):
-    invoke_tx = await account.sign_invoke_v1_transaction(
+    invoke_tx = await account.sign_invoke_v1(
         calls=Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -158,7 +158,7 @@ async def test_estimate_fee_invoke(account, contract_address):
 
 @pytest.mark.asyncio
 async def test_estimate_fee_invoke_v3(account, contract_address):
-    invoke_tx = await account.sign_invoke_v3_transaction(
+    invoke_tx = await account.sign_invoke_v3(
         calls=Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -178,7 +178,7 @@ async def test_estimate_fee_invoke_v3(account, contract_address):
 
 @pytest.mark.asyncio
 async def test_estimate_fee_declare(account):
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=read_contract(
             "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
         ),
@@ -209,7 +209,7 @@ async def test_estimate_fee_deploy_account(client, deploy_account_transaction):
 async def test_estimate_fee_for_multiple_transactions(
     client, deploy_account_transaction, contract_address, account
 ):
-    invoke_tx = await account.sign_invoke_v1_transaction(
+    invoke_tx = await account.sign_invoke_v1(
         calls=Call(
             to_addr=contract_address,
             selector=get_selector_from_name("increase_balance"),
@@ -219,7 +219,7 @@ async def test_estimate_fee_for_multiple_transactions(
     )
     invoke_tx = await account.sign_for_fee_estimate(invoke_tx)
 
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=read_contract(
             "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
         ),
@@ -260,7 +260,7 @@ async def test_add_transaction(map_contract, client, account):
     prepared_function_call = map_contract.functions["put"].prepare_invoke_v1(
         key=73, value=12
     )
-    signed_invoke = await account.sign_invoke_v1_transaction(
+    signed_invoke = await account.sign_invoke_v1(
         calls=prepared_function_call, max_fee=MAX_FEE
     )
 
@@ -373,7 +373,7 @@ async def test_wait_for_tx_unknown_error(
 
 @pytest.mark.asyncio
 async def test_declare_contract(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 
@@ -503,7 +503,7 @@ async def test_state_update_deployed_contracts(
     # setup
     deployer = Deployer()
     contract_deployment = deployer.create_contract_deployment(class_hash=class_hash)
-    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
+    deploy_invoke_tx = await account.sign_invoke_v1(
         contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -74,7 +74,7 @@ async def hello_starknet_deploy_transaction_address(
     contract_deployment = deployer.create_contract_deployment_raw(
         class_hash=cairo1_hello_starknet_class_hash
     )
-    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1(
         calls=contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -408,7 +408,7 @@ async def test_simulate_transactions_skip_validate(account, deployed_balance_con
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1(calls=call, auto_estimate=True)
     invoke_tx = dataclasses.replace(invoke_tx, signature=[])
 
     simulated_txs = await account.client.simulate_transactions(
@@ -432,7 +432,7 @@ async def test_simulate_transactions_skip_fee_charge(
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1(calls=call, auto_estimate=True)
 
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], skip_fee_charge=True, block_number="latest"
@@ -448,7 +448,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1(calls=call, auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], block_number="latest"
     )
@@ -457,9 +457,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(simulated_txs[0].transaction_trace, InvokeTransactionTrace)
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
 
-    invoke_tx = await account.sign_invoke_v1_transaction(
-        calls=[call, call], auto_estimate=True
-    )
+    invoke_tx = await account.sign_invoke_v1(calls=[call, call], auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], block_number="latest"
     )
@@ -474,9 +472,7 @@ async def test_simulate_transactions_declare(account):
     compiled_contract = read_contract(
         "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
     )
-    declare_tx = await account.sign_declare_v1_transaction(
-        compiled_contract, max_fee=int(1e16)
-    )
+    declare_tx = await account.sign_declare_v1(compiled_contract, max_fee=int(1e16))
 
     simulated_txs = await account.client.simulate_transactions(
         transactions=[declare_tx], block_number="latest"
@@ -495,7 +491,7 @@ async def test_simulate_transactions_two_txs(account, deployed_balance_contract)
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    invoke_tx = await account.sign_invoke_v1_transaction(calls=call, auto_estimate=True)
+    invoke_tx = await account.sign_invoke_v1(calls=call, auto_estimate=True)
 
     compiled_v2_contract = read_contract(
         "test_contract_declare_compiled.json", directory=CONTRACTS_COMPILED_V1_DIR
@@ -506,7 +502,7 @@ async def test_simulate_transactions_two_txs(account, deployed_balance_contract)
     casm_class = create_casm_class(compiled_v2_contract_casm)
     casm_class_hash = compute_casm_class_hash(casm_class)
 
-    declare_v2_tx = await account.sign_declare_v2_transaction(
+    declare_v2_tx = await account.sign_declare_v2(
         compiled_contract=compiled_v2_contract,
         compiled_class_hash=casm_class_hash,
         # because raw calls do not increment nonce, it needs to be done manually
@@ -545,7 +541,7 @@ async def test_simulate_transactions_deploy_account(
         key_pair=key_pair,
         chain=StarknetChainId.GOERLI,
     )
-    deploy_account_tx = await account.sign_deploy_account_v1_transaction(
+    deploy_account_tx = await account.sign_deploy_account_v1(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -7,7 +7,7 @@ from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, MAX_RESOURCE_BOUND
 
 @pytest.mark.asyncio
 async def test_declare_tx(account, map_compiled_contract):
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
     result = await account.client.declare(declare_tx)
@@ -23,7 +23,7 @@ async def test_declare_v2_tx(cairo1_minimal_contract_class_hash: int):
 
 @pytest.mark.asyncio
 async def test_declare_v3_tx(account, abi_types_compiled_contract_and_class_hash):
-    declare_tx = await account.sign_declare_v3_transaction(
+    declare_tx = await account.sign_declare_v3(
         compiled_contract=abi_types_compiled_contract_and_class_hash[0],
         compiled_class_hash=abi_types_compiled_contract_and_class_hash[1],
         l1_resource_bounds=MAX_RESOURCE_BOUNDS_L1,

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -14,7 +14,7 @@ async def test_default_deploy_with_class_hash(account, map_class_hash):
 
     contract_deployment = deployer.create_contract_deployment(class_hash=map_class_hash)
 
-    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
+    deploy_invoke_tx = await account.sign_invoke_v1(
         contract_deployment.call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_tx)
@@ -74,7 +74,7 @@ async def test_constructor_arguments_contract_deploy(
         calldata=calldata,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)
@@ -113,9 +113,7 @@ async def test_address_computation(salt, pass_account_address, account, map_clas
         salt=salt,
     )
 
-    deploy_invoke_tx = await account.sign_invoke_v1_transaction(
-        deploy_call, max_fee=MAX_FEE
-    )
+    deploy_invoke_tx = await account.sign_invoke_v1(deploy_call, max_fee=MAX_FEE)
     resp = await account.client.send_transaction(deploy_invoke_tx)
     await account.client.wait_for_tx(resp.transaction_hash)
 
@@ -158,7 +156,7 @@ async def test_create_deployment_call_raw(
         raw_calldata=raw_calldata,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)
@@ -202,7 +200,7 @@ async def test_create_deployment_call_raw_supports_seed_0(
         salt=0,
     )
 
-    deploy_invoke_transaction = await account.sign_invoke_v1_transaction(
+    deploy_invoke_transaction = await account.sign_invoke_v1(
         deploy_call, max_fee=MAX_FEE
     )
     resp = await account.client.send_transaction(deploy_invoke_transaction)

--- a/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
+++ b/starknet_py/tests/e2e/deploy_account/deploy_account_test.py
@@ -17,7 +17,7 @@ async def test_general_flow(client, deploy_account_details_factory):
         chain=StarknetChainId.GOERLI,
     )
 
-    deploy_account_tx = await account.sign_deploy_account_v1_transaction(
+    deploy_account_tx = await account.sign_deploy_account_v1(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],
@@ -39,7 +39,7 @@ async def test_deploy_account_v3(client, deploy_account_details_factory):
         chain=StarknetChainId.GOERLI,
     )
 
-    deploy_account_tx = await account.sign_deploy_account_v3_transaction(
+    deploy_account_tx = await account.sign_deploy_account_v3(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],

--- a/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
@@ -233,9 +233,7 @@ async def test_simulate_transactions(
         selector=get_selector_from_name("method_name"),
         calldata=[0xCA11DA7A],
     )
-    first_transaction = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e16)
-    )
+    first_transaction = await account.sign_invoke_v1(calls=call, max_fee=int(1e16))
     # docs-end: simulate_transactions
 
     call = Call(
@@ -243,9 +241,7 @@ async def test_simulate_transactions(
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    first_transaction = await account.sign_invoke_v1_transaction(
-        calls=call, auto_estimate=True
-    )
+    first_transaction = await account.sign_invoke_v1(calls=call, auto_estimate=True)
 
     # docs-start: simulate_transactions
     # one transaction

--- a/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
@@ -18,15 +18,15 @@ async def test_account_sign_without_execute(account, map_compiled_contract):
 
     # Create a signed Invoke transaction
     call = Call(to_addr=address, selector=selector, calldata=calldata)
-    invoke_transaction = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
+    invoke_transaction = await account.sign_invoke_v1(call, max_fee=max_fee)
 
     # Create a signed Declare transaction
-    declare_transaction = await account.sign_declare_v1_transaction(
+    declare_transaction = await account.sign_declare_v1(
         compiled_contract=compiled_contract, max_fee=max_fee
     )
 
     # Create a signed DeployAccount transaction
-    deploy_account_transaction = await account.sign_deploy_account_v1_transaction(
+    deploy_account_transaction = await account.sign_deploy_account_v1(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=calldata,

--- a/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
+++ b/starknet_py/tests/e2e/docs/guide/test_cairo1_contract.py
@@ -38,8 +38,8 @@ async def test_cairo1_contract(
 
     # docs: start
 
-    # Create Declare v2 transaction (to create Declare v3 transaction use `sign_declare_v3_transaction` method)
-    declare_v2_transaction = await account.sign_declare_v2_transaction(
+    # Create Declare v2 transaction (to create Declare v3 transaction use `sign_declare_v3` method)
+    declare_v2_transaction = await account.sign_declare_v2(
         # compiled_contract is a string containing the content of the starknet-compile (.json file)
         compiled_contract=compiled_contract,
         compiled_class_hash=casm_class_hash,

--- a/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_account_compatibility.py
@@ -17,7 +17,7 @@ async def test_create_invoke_from_contract(map_contract, account):
     assert issubclass(type(call), Call)
 
     # Crate an Invoke transaction from call
-    invoke_transaction = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
+    invoke_transaction = await account.sign_invoke_v1(call, max_fee=max_fee)
     # docs: end
 
     assert isinstance(invoke_transaction, InvokeV1)

--- a/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
+++ b/starknet_py/tests/e2e/docs/guide/test_custom_nonce.py
@@ -61,7 +61,5 @@ async def test_custom_nonce(account):
     # docs: end
 
     assert account.nonce_counter == 0
-    await account.sign_invoke_v1_transaction(
-        calls=Call(0x1, 0x1, []), max_fee=10000000000
-    )
+    await account.sign_invoke_v1(calls=Call(0x1, 0x1, []), max_fee=10000000000)
     assert account.nonce_counter == 1

--- a/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
@@ -6,9 +6,9 @@ async def test_declaring_contracts(account, map_compiled_contract):
     contract_compiled = map_compiled_contract
 
     # docs: start
-    # Account.sign_declare_v1_transaction takes contract source code or compiled contract
+    # Account.sign_declare_v1 takes contract source code or compiled contract
     # and returns Declare transaction
-    declare_transaction = await account.sign_declare_v1_transaction(
+    declare_transaction = await account.sign_declare_v1(
         compiled_contract=contract_compiled, max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
@@ -30,7 +30,7 @@ async def test_deploying_in_multicall(account, map_class_hash, map_compiled_cont
 
     # After that multicall transaction can be sent
     # Note that `deploy_call` and `put_call` are two regular calls!
-    invoke_tx = await account.sign_invoke_v1_transaction(
+    invoke_tx = await account.sign_invoke_v1(
         calls=[deploy_call, put_call], max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -80,7 +80,7 @@ async def test_deploying_with_udc(
     )
     # docs: start
     # Or signed and send with an account
-    invoke_tx = await account.sign_invoke_v1_transaction(deploy_call, max_fee=int(1e16))
+    invoke_tx = await account.sign_invoke_v1(deploy_call, max_fee=int(1e16))
     resp = await account.client.send_transaction(invoke_tx)
 
     # Wait for transaction

--- a/starknet_py/tests/e2e/docs/guide/test_sign_for_fee_estimate.py
+++ b/starknet_py/tests/e2e/docs/guide/test_sign_for_fee_estimate.py
@@ -6,7 +6,7 @@ async def test_signing_fee_estimate(account, map_contract):
     # docs: start
     # Create a transaction
     call = map_contract.functions["put"].prepare_invoke_v1(key=10, value=20)
-    transaction = await account.sign_invoke_v1_transaction(calls=call, max_fee=0)
+    transaction = await account.sign_invoke_v1(calls=call, max_fee=0)
 
     # Re-sign a transaction for fee estimation
     estimate_transaction = await account.sign_for_fee_estimate(transaction)
@@ -20,9 +20,7 @@ async def test_signing_fee_estimate(account, map_contract):
     assert estimate.overall_fee > 0
 
     # Use a new fee in original transaction
-    transaction = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=estimate.overall_fee
-    )
+    transaction = await account.sign_invoke_v1(calls=call, max_fee=estimate.overall_fee)
 
     # Send a transaction
     result = await account.client.send_transaction(transaction)

--- a/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
+++ b/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
@@ -27,12 +27,12 @@ async def test_account_comparison(gateway_account, map_contract):
     # docs-2: start
     # Sending transactions
 
-    tx = await account_client.sign_invoke_v1_transaction(call, max_fee)
+    tx = await account_client.sign_invoke_v1(call, max_fee)
     await account_client.send_transaction(tx)
 
     # becomes
 
-    tx = await account.sign_invoke_v1_transaction(call, max_fee=max_fee)
+    tx = await account.sign_invoke_v1(call, max_fee=max_fee)
     # Note that max_fee is now keyword-only argument
     await account.client.send_transaction(tx)
     # docs-2: end

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -296,7 +296,7 @@ async def declare_account(account: BaseAccount, compiled_account_contract: str) 
     Declares a specified account.
     """
 
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=compiled_account_contract,
         max_fee=MAX_FEE,
     )
@@ -317,7 +317,7 @@ async def declare_cairo1_account(
 
     casm_class = create_casm_class(compiled_account_contract_casm)
     casm_class_hash = compute_casm_class_hash(casm_class)
-    declare_v2_transaction = await account.sign_declare_v2_transaction(
+    declare_v2_transaction = await account.sign_declare_v2(
         compiled_contract=compiled_account_contract,
         compiled_class_hash=casm_class_hash,
         max_fee=MAX_FEE,
@@ -362,7 +362,7 @@ async def map_class_hash(account: BaseAccount, map_compiled_contract: str) -> in
     """
     Returns class_hash of the map.cairo.
     """
-    declare = await account.sign_declare_v1_transaction(
+    declare = await account.sign_declare_v1(
         compiled_contract=map_compiled_contract,
         max_fee=int(1e16),
     )
@@ -378,7 +378,7 @@ async def simple_storage_with_event_class_hash(
     """
     Returns class_hash of the simple_storage_with_event.cairo
     """
-    declare = await account.sign_declare_v1_transaction(
+    declare = await account.sign_declare_v1(
         compiled_contract=simple_storage_with_event_compiled_contract,
         max_fee=int(1e16),
     )
@@ -392,7 +392,7 @@ async def erc20_class_hash(account: BaseAccount, erc20_compiled_contract: str) -
     """
     Returns class_hash of the erc20.cairo.
     """
-    declare = await account.sign_declare_v1_transaction(
+    declare = await account.sign_declare_v1(
         compiled_contract=erc20_compiled_contract,
         max_fee=int(1e16),
     )
@@ -438,7 +438,7 @@ async def constructor_with_arguments_class_hash(
     """
     Returns a class_hash of the constructor_with_arguments.cairo.
     """
-    declare = await account.sign_declare_v1_transaction(
+    declare = await account.sign_declare_v1(
         compiled_contract=constructor_with_arguments_compiled,
         max_fee=int(1e16),
     )

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -18,7 +18,7 @@ async def declare_cairo1_contract(
 ) -> Tuple[int, int]:
     casm_class_hash = compute_casm_class_hash(create_casm_class(compiled_contract_casm))
 
-    declare_tx = await account.sign_declare_v2_transaction(
+    declare_tx = await account.sign_declare_v2(
         compiled_contract=compiled_contract,
         compiled_class_hash=casm_class_hash,
         max_fee=MAX_FEE,
@@ -47,7 +47,7 @@ async def declare_v2_hello_starknet(account: BaseAccount) -> DeclareV2:
     compiled_contract_casm = read_contract("hello_starknet_compiled.casm")
     casm_class_hash = compute_casm_class_hash(create_casm_class(compiled_contract_casm))
 
-    declare_tx = await account.sign_declare_v2_transaction(
+    declare_tx = await account.sign_declare_v2(
         compiled_contract, casm_class_hash, max_fee=MAX_FEE
     )
     return declare_tx

--- a/starknet_py/tests/e2e/fixtures/proxy.py
+++ b/starknet_py/tests/e2e/fixtures/proxy.py
@@ -110,7 +110,7 @@ async def deploy_proxy_to_contract(
         compiled_contract_name, directory=CONTRACTS_COMPILED_V0_DIR
     )
 
-    declare_tx = await account.sign_declare_v1_transaction(
+    declare_tx = await account.sign_declare_v1(
         compiled_contract=compiled_contract, max_fee=MAX_FEE
     )
     declare_result = await account.client.declare(declare_tx)

--- a/starknet_py/tests/e2e/tests_on_networks/account_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/account_test.py
@@ -19,7 +19,7 @@ async def test_sign_invoke_tx_for_fee_estimation(account_goerli_integration):
     )
 
     call = map_contract.functions["put"].prepare_invoke_v1(key=40, value=50)
-    transaction = await account.sign_invoke_v1_transaction(calls=call, max_fee=MAX_FEE)
+    transaction = await account.sign_invoke_v1(calls=call, max_fee=MAX_FEE)
 
     estimate_fee_transaction = await account.sign_for_fee_estimate(transaction)
 
@@ -41,7 +41,7 @@ async def test_sign_declare_tx_for_fee_estimation(
 ):
     account = account_goerli_integration
 
-    transaction = await account.sign_declare_v1_transaction(
+    transaction = await account.sign_declare_v1(
         compiled_contract=map_compiled_contract, max_fee=MAX_FEE
     )
 

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -59,9 +59,7 @@ async def test_wait_for_tx_reverted(account_goerli_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[0x1, 0x2, 0x3, 0x4, 0x5],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e16)
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e16))
     invoke = await account.client.send_transaction(sign_invoke)
 
     with pytest.raises(TransactionRevertedError, match="Input too long for arguments"):
@@ -76,9 +74,7 @@ async def test_wait_for_tx_accepted(account_goerli_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e16)
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e16))
     invoke = await account.client.send_transaction(sign_invoke)
 
     result = await account.client.wait_for_tx(tx_hash=invoke.transaction_hash)
@@ -95,9 +91,7 @@ async def test_transaction_not_received_max_fee_too_small(account_goerli_testnet
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e10)
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e10))
 
     with pytest.raises(ClientError, match=r".*Max fee.*"):
         await account.client.send_transaction(sign_invoke)
@@ -111,9 +105,7 @@ async def test_transaction_not_received_max_fee_too_big(account_goerli_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=sys.maxsize
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=sys.maxsize)
 
     with pytest.raises(ClientError, match=r".*max_fee.*"):
         await account.client.send_transaction(sign_invoke)
@@ -127,9 +119,7 @@ async def test_transaction_not_received_invalid_nonce(account_goerli_testnet):
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e16), nonce=0
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e16), nonce=0)
 
     with pytest.raises(ClientError, match=r".*nonce.*"):
         await account.client.send_transaction(sign_invoke)
@@ -143,9 +133,7 @@ async def test_transaction_not_received_invalid_signature(account_goerli_testnet
         selector=get_selector_from_name("empty"),
         calldata=[],
     )
-    sign_invoke = await account.sign_invoke_v1_transaction(
-        calls=call, max_fee=int(1e16)
-    )
+    sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e16))
     sign_invoke = dataclasses.replace(sign_invoke, signature=[0x21, 0x37])
 
     with pytest.raises(ClientError, match=r"Signature.*is invalid") as exc:

--- a/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
@@ -107,7 +107,7 @@ async def test_simulate_transactions_declare_on_network(account_goerli_testnet):
     compiled_contract = read_contract(
         "map_compiled.json", directory=CONTRACTS_COMPILED_V0_DIR
     )
-    declare_tx = await account_goerli_testnet.sign_declare_v1_transaction(
+    declare_tx = await account_goerli_testnet.sign_declare_v1(
         compiled_contract, max_fee=int(1e16)
     )
 

--- a/starknet_py/tests/e2e/utils.py
+++ b/starknet_py/tests/e2e/utils.py
@@ -73,7 +73,7 @@ async def get_deploy_account_transaction(
         key_pair=key_pair,
         chain=StarknetChainId.GOERLI,
     )
-    return await account.sign_deploy_account_v1_transaction(
+    return await account.sign_deploy_account_v1(
         class_hash=class_hash,
         contract_address_salt=salt,
         constructor_calldata=[key_pair.public_key],


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Discussed [here](https://github.com/software-mansion/starknet.py/pull/1275#discussion_r1474817894)

## Introduced changes
<!-- A brief description of the changes -->

- Simplify sign method names in the `Account` class by removing 'transaction' word

##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


