### PR TITLE
Fix parsing ABIs with multiple `l1_handler` entries

### DIFF
--- a/docs/guide/account_and_client.rst
+++ b/docs/guide/account_and_client.rst
@@ -36,6 +36,8 @@ For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1
     by changing ``ESTIMATED_FEE_MULTIPLIER`` for V1 and V2 transactions in :class:`~starknet_py.net.account.account.Account`.
     The same applies to ``ESTIMATED_AMOUNT_MULTIPLIER`` and ``ESTIMATED_UNIT_PRICE_MULTIPLIER`` for V3 transactions.
 
+The fee for a specific transaction or list of transactions can be also estimated using the :meth:`~starknet_py.net.account.account.Account.estimate_fee` of the :ref:`Account` class.
+
 Creating transactions without executing them
 --------------------------------------------
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,7 +5,15 @@ Migration guide
 0.20.0 Migration guide
 **********************
 
-0.20.0 Breaking Changes
+    Version 0.20.0 of **starknet.py** comes with support for Python 3.12!
+
+0.20.0 Targeted versions
+------------------------
+
+- Starknet - `0.13.0 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.0>`_
+- RPC - `0.6.0 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.6.0>`_
+
+0.20.0 Breaking changes
 -----------------------
 
 1. Type of ``l1_handler`` in :class:`~starknet_py.abi.v2.model.Abi` model class for Cairo 2 has been changed from ``Function`` to ``Dict[str, Function]``

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -8,8 +8,9 @@ Migration guide
 0.20.0 Breaking Changes
 -----------------------
 
-1. :class:`StarknetEthProxyCheck` has been removed from the Proxy checks
+1. Type of ``l1_handler`` in :class:`~starknet_py.abi.v2.model.Abi` model class for Cairo 2 has been changed from ``Function`` to ``Dict[str, Function]``
 2. In :ref:`Abi` module the code related to Cairo 0 has been moved from ``starknet_py.abi`` to ``starknet_py.abi.v0``
+3. :class:`StarknetEthProxyCheck` has been removed from the Proxy checks
 
 **********************
 0.19.0 Migration guide

--- a/starknet_py/abi/v2/model.py
+++ b/starknet_py/abi/v2/model.py
@@ -83,7 +83,7 @@ class Abi:
         Constructor
     ]  #: Contract's constructor. It is None if class doesn't define one.
     l1_handler: Optional[
-        Function
-    ]  #: Handler of L1 messages. It is None if class doesn't define one.
+        Dict[str, Function]
+    ]  #: Handlers of L1 messages. It is None if class doesn't define one.
     interfaces: Dict[str, Interface]
     implementations: Dict[str, Impl]

--- a/starknet_py/abi/v2/parser.py
+++ b/starknet_py/abi/v2/parser.py
@@ -100,14 +100,16 @@ class AbiParser:
             Dict[str, ImplDict],
             AbiParser._group_by_entry_name(self._grouped[IMPL_ENTRY], "defined impls"),
         )
+        l1_handlers_dict = cast(
+            Dict[str, FunctionDict],
+            AbiParser._group_by_entry_name(
+                self._grouped[L1_HANDLER_ENTRY], "defined L1 handlers"
+            ),
+        )
         constructors = self._grouped[CONSTRUCTOR_ENTRY]
-        l1_handlers = self._grouped[L1_HANDLER_ENTRY]
 
         if len(constructors) > 1:
             raise AbiParsingError("Constructor in ABI must be defined at most once.")
-
-        if len(l1_handlers) > 1:
-            raise AbiParsingError("L1 handler in ABI must be defined at most once.")
 
         return Abi(
             defined_structures=structures,
@@ -117,11 +119,10 @@ class AbiParser:
                 if constructors
                 else None
             ),
-            l1_handler=(
-                self._parse_function(cast(FunctionDict, l1_handlers[0]))
-                if l1_handlers
-                else None
-            ),
+            l1_handler={
+                name: self._parse_function(entry)
+                for name, entry in l1_handlers_dict.items()
+            },
             functions={
                 name: self._parse_function(entry)
                 for name, entry in functions_dict.items()

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -538,7 +538,12 @@ class ContractFunction:
 
         if abi["type"] == L1_HANDLER_ENTRY:
             assert not isinstance(contract_data.parsed_abi, AbiV1)
-            function = contract_data.parsed_abi.l1_handler
+            function = (
+                contract_data.parsed_abi.l1_handler
+                if contract_data.parsed_abi.l1_handler is None
+                or isinstance(contract_data.parsed_abi.l1_handler, AbiV0.Function)
+                else contract_data.parsed_abi.l1_handler.get(name)
+            )
         elif interface_name is None:
             function = contract_data.parsed_abi.functions.get(name)
         else:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1296 

## Introduced changes
<!-- A brief description of the changes -->

- Fix bug with parsing an ABI with multiple `l1_handler` entries
- Update docs before `0.20.0` release

##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


