### PR TITLE
Support RPC 0.7.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 name: Checks
 
 env:
-  DEVNET_SHA: "1bd447d"
+  DEVNET_SHA: "79a90fd"
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,6 @@
 name: Checks
 
 env:
-  STARKNET_VERSION: "0.13.0"
-  RPC_SPEC_VERSION: "0.6.0"
   DEVNET_SHA: "1bd447d"
 
 on:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 name: Checks
 
 env:
-  DEVNET_SHA: "79a90fd"
+  DEVNET_SHA: "c6ffb99"
 
 on:
   push:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -24,11 +24,10 @@ Below is the command you can use to do this, designed for compatibility with the
 
 .. code-block:: bash
 
-    STARKNET_VERSION="0.13.0" RPC_SPEC_VERSION="0.6.0" \
     cargo install \
     --locked \
     --git https://github.com/0xSpaceShard/starknet-devnet-rs.git \
-    --rev 1bd447d
+    --rev 79a90fd
 
 If you choose to install `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_ using a different method, please make sure to add the executable ``starknet-devnet`` to your ``PATH`` environment variable.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,7 +27,7 @@ Below is the command you can use to do this, designed for compatibility with the
     cargo install \
     --locked \
     --git https://github.com/0xSpaceShard/starknet-devnet-rs.git \
-    --rev 79a90fd
+    --rev c6ffb99
 
 If you choose to install `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_ using a different method, please make sure to add the executable ``starknet-devnet`` to your ``PATH`` environment variable.
 

--- a/docs/guide/account_and_client.rst
+++ b/docs/guide/account_and_client.rst
@@ -27,7 +27,8 @@ To enable auto estimation, set the ``auto_estimate`` parameter to ``True``.
 
     It is strongly discouraged to use automatic fee estimation in production code as it may lead to an unexpectedly high fee.
 
-The returned estimated fee is multiplied by ``1.5`` to mitigate fluctuations in price.
+The returned estimated fee is multiplied by ``1.5`` for V1 and V2 transactions to mitigate fluctuations in price.
+For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1.5`` and ``1.5`` respectively.
 
 .. note::
     It is possible to configure the value by which the estimated fee is multiplied,

--- a/docs/guide/account_and_client.rst
+++ b/docs/guide/account_and_client.rst
@@ -27,9 +27,7 @@ To enable auto estimation, set the ``auto_estimate`` parameter to ``True``.
 
     It is strongly discouraged to use automatic fee estimation in production code as it may lead to an unexpectedly high fee.
 
-The returned estimated fee is multiplied by ``1.5`` for V1 and V2 transactions to mitigate fluctuations in price.
-For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1.5``.
-
+The returned estimated fee is multiplied by ``1.5`` to mitigate fluctuations in price.
 
 .. note::
     It is possible to configure the value by which the estimated fee is multiplied,

--- a/docs/guide/account_and_client.rst
+++ b/docs/guide/account_and_client.rst
@@ -28,7 +28,7 @@ To enable auto estimation, set the ``auto_estimate`` parameter to ``True``.
     It is strongly discouraged to use automatic fee estimation in production code as it may lead to an unexpectedly high fee.
 
 The returned estimated fee is multiplied by ``1.5`` for V1 and V2 transactions to mitigate fluctuations in price.
-For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1.1`` and ``1.5`` respectively.
+For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1.5``.
 
 
 .. note::

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,12 +5,7 @@ Migration guide
 0.21.0 Migration guide
 **********************
 
-
-Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0 and python 3.12!
-
-New classes added to mirror the recent changes in the RPC v0.7.0 specification include:
-:class:`StarknetBlockWithReceipts`, :class:`PendingStarknetBlockWithReceipts`, :class:`TransactionWithReceipt` :class:`DataResources`.
-
+Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0!
 
 0.21.0 Targeted versions
 ------------------------
@@ -18,12 +13,19 @@ New classes added to mirror the recent changes in the RPC v0.7.0 specification i
 - Starknet - `0.13.1 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.1>`_
 - RPC - `0.7.0 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.0>`_
 
-0.21.0 Minor changes
---------------------
+0.21.0 Breaking changes
+-----------------------
 
-1. :class:`ExecutionResources` now has an additional optional field: ``data_availability``
-2. :class:`StarknetBlock`, :class:`StarknetBlockWithTxHashes`, :class:`PendingStarknetBlock` and :class:`PendingStarknetBlockWithTxHashes` now have two additional option fields: ``l1_data_gas_price`` and ``l1_da_mode``.
-3. :class:`DeclareTransactionTrace`, :class:`InvokeTransactionTrace` and :class:`DeployAccountTransactionTrace` have additional field ``execution_resources``
+.. currentmodule:: starknet_py.net.client_models
+
+1. :class:`ExecutionResources` has a new required field ``data_availability``
+2. :class:`InvokeTransactionTrace`, :class:`DeclareTransactionTrace` and :class:`DeployAccountTransactionTrace` have a new required field ``execution_resources``
+3. :class:`PendingStarknetBlock` and :class:`PendingStarknetBlockWithTxHashes` field ``parent_block_hash`` has been renamed to ``parent_hash``
+4. :class:`StarknetBlockCommon` has been renamed to :class:`BlockHeader`
+5. :class:`StarknetBlock` and :class:`StarknetBlockWithTxHashes` fields ``parent_block_hash`` and ``root`` have been renamed to ``parent_hash`` and ``new_root`` respectively
+6. :class:`EstimatedFee` has new required fields ``data_gas_consumed`` and ``data_gas_price``
+7. :class:`FunctionInvocation` field ``execution_resources`` has been renamed to ``computation_resources``
+8. :class:`StarknetBlock`, :class:`PendingStarknetBlock`, :class:`StarknetBlockWithTxHashes`, :class:`PendingStarknetBlockWithTxHashes` have new required fields ``l1_data_gas_price`` and ``l1_da_mode``
 
 **********************
 0.20.0 Migration guide

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -18,19 +18,19 @@ Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0!
 
 .. currentmodule:: starknet_py.net.client_models
 
-1. :class:`ExecutionResources` has a new required field ``data_availability``
-2. :class:`InvokeTransactionTrace`, :class:`DeclareTransactionTrace` and :class:`DeployAccountTransactionTrace` have a new required field ``execution_resources``
-3. :class:`PendingStarknetBlock` and :class:`PendingStarknetBlockWithTxHashes` field ``parent_block_hash`` has been renamed to ``parent_hash``
-4. :class:`StarknetBlockCommon` has been renamed to :class:`BlockHeader`
-5. :class:`StarknetBlock` and :class:`StarknetBlockWithTxHashes` fields ``parent_block_hash`` and ``root`` have been renamed to ``parent_hash`` and ``new_root`` respectively
-6. :class:`EstimatedFee` has new required fields ``data_gas_consumed`` and ``data_gas_price``
-7. :class:`FunctionInvocation` field ``execution_resources`` has been renamed to ``computation_resources``
-8. :class:`StarknetBlock`, :class:`PendingStarknetBlock`, :class:`StarknetBlockWithTxHashes`, :class:`PendingStarknetBlockWithTxHashes` have new required fields ``l1_data_gas_price`` and ``l1_da_mode``
+1. :class:`PendingStarknetBlock` and :class:`PendingStarknetBlockWithTxHashes` field ``parent_block_hash`` has been renamed to ``parent_hash``
+2. :class:`StarknetBlockCommon` has been renamed to :class:`BlockHeader`
+3. :class:`StarknetBlock` and :class:`StarknetBlockWithTxHashes` fields ``parent_block_hash`` and ``root`` have been renamed to ``parent_hash`` and ``new_root`` respectively
+4. :class:`FunctionInvocation` field ``execution_resources`` has been renamed to ``computation_resources``
 
 0.21.0 Minor changes
 -----------------------
 
 1. :class:`EventsChunk` field ``events`` is now a list of :class:`EmittedEvent` instead of :class:`Event`
+2. :class:`ExecutionResources` has a new required field ``data_availability``
+3. :class:`InvokeTransactionTrace`, :class:`DeclareTransactionTrace` and :class:`DeployAccountTransactionTrace` have a new required field ``execution_resources``
+4. :class:`EstimatedFee` has new required fields ``data_gas_consumed`` and ``data_gas_price``
+5. :class:`StarknetBlock`, :class:`PendingStarknetBlock`, :class:`StarknetBlockWithTxHashes`, :class:`PendingStarknetBlockWithTxHashes` have new required fields ``l1_data_gas_price`` and ``l1_da_mode``
 
 **********************
 0.20.0 Migration guide

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -1,9 +1,9 @@
 Migration guide
 ===============
 
-**********************
-0.21.0 Migration guide
-**********************
+******************************
+0.21.0 (alpha) Migration guide
+******************************
 
 Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0!
 
@@ -11,7 +11,7 @@ Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0!
 ------------------------
 
 - Starknet - `0.13.1 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.1>`_
-- RPC - `0.7.0 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.0>`_
+- RPC - `0.7.0-rc2 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.0-rc2>`_
 
 0.21.0 Breaking changes
 -----------------------

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,30 @@ Migration guide
 ===============
 
 **********************
+0.21.0 Migration guide
+**********************
+
+
+Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0 and python 3.12!
+
+New classes added to mirror the recent changes in the RPC v0.7.0 specification include:
+:class:`StarknetBlockWithReceipts`, :class:`PendingStarknetBlockWithReceipts`, :class:`TransactionWithReceipt` :class:`DataResources`.
+
+
+0.21.0 Targeted versions
+------------------------
+
+- Starknet - `0.13.1 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.1>`_
+- RPC - `0.7.0 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.0>`_
+
+0.21.0 Minor changes
+--------------------
+
+1. :class:`ExecutionResources` now has an additional optional field: ``data_availability``
+2. :class:`StarknetBlock`, :class:`StarknetBlockWithTxHashes`, :class:`PendingStarknetBlock` and :class:`PendingStarknetBlockWithTxHashes` now have two additional option fields: ``l1_data_gas_price`` and ``l1_da_mode``.
+3. :class:`DeclareTransactionTrace`, :class:`InvokeTransactionTrace` and :class:`DeployAccountTransactionTrace` have additional field ``execution_resources``
+
+**********************
 0.20.0 Migration guide
 **********************
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,7 +5,7 @@ Migration guide
 0.21.0 (alpha) Migration guide
 ******************************
 
-Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0!
+Version 0.21.0 of **starknet.py** comes with support for RPC 0.7.0-rc2!
 
 0.21.0 Targeted versions
 ------------------------

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -167,6 +167,8 @@ class Account(BaseAccount):
                 max_amount=int(
                     (estimated_fee.overall_fee / estimated_fee.gas_price)
                     * Account.ESTIMATED_AMOUNT_MULTIPLIER
+                    if estimated_fee.gas_price != 0
+                    else 0
                 ),
                 max_price_per_unit=int(
                     estimated_fee.gas_price * Account.ESTIMATED_UNIT_PRICE_MULTIPLIER

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -60,7 +60,7 @@ class Account(BaseAccount):
     ESTIMATED_FEE_MULTIPLIER: float = 1.5
     """Amount by which each estimated fee is multiplied when using `auto_estimate`."""
 
-    ESTIMATED_AMOUNT_MULTIPLIER: float = 1.1
+    ESTIMATED_AMOUNT_MULTIPLIER: float = 1.5
     ESTIMATED_UNIT_PRICE_MULTIPLIER: float = 1.5
     """Values by which each estimated `max_amount` and `max_price_per_unit` are multiplied when using 
     `auto_estimate`. Used only for V3 transactions"""
@@ -165,7 +165,8 @@ class Account(BaseAccount):
 
             l1_resource_bounds = ResourceBounds(
                 max_amount=int(
-                    estimated_fee.gas_consumed * Account.ESTIMATED_AMOUNT_MULTIPLIER
+                    (estimated_fee.overall_fee / estimated_fee.gas_price)
+                    * Account.ESTIMATED_AMOUNT_MULTIPLIER
                 ),
                 max_price_per_unit=int(
                     estimated_fee.gas_price * Account.ESTIMATED_UNIT_PRICE_MULTIPLIER

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -470,6 +470,8 @@ class PendingBlockHeader:
     timestamp: int
     sequencer_address: int
     l1_gas_price: ResourcePrice
+    l1_data_gas_price: ResourcePrice
+    l1_da_mode: L1DAMode
     starknet_version: str
 
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -370,24 +370,24 @@ class ComputationResources:
     # pylint: disable=too-many-instance-attributes
 
     steps: int
-    range_check_builtin_applications: Optional[int] = None
-    pedersen_builtin_applications: Optional[int] = None
-    poseidon_builtin_applications: Optional[int] = None
-    ec_op_builtin_applications: Optional[int] = None
-    ecdsa_builtin_applications: Optional[int] = None
-    bitwise_builtin_applications: Optional[int] = None
-    keccak_builtin_applications: Optional[int] = None
-    memory_holes: Optional[int] = None
-    segment_arena_builtin: Optional[int] = None
+    memory_holes: Optional[int]
+    range_check_builtin_applications: Optional[int]
+    pedersen_builtin_applications: Optional[int]
+    poseidon_builtin_applications: Optional[int]
+    ec_op_builtin_applications: Optional[int]
+    ecdsa_builtin_applications: Optional[int]
+    bitwise_builtin_applications: Optional[int]
+    keccak_builtin_applications: Optional[int]
+    segment_arena_builtin: Optional[int]
 
 
 @dataclass
 class ExecutionResources(ComputationResources):
     """
-    Dataclass representing the the resources consumed by the transaction, includes both computation and data.
+    Dataclass representing the resources consumed by the transaction, includes both computation and data.
     """
 
-    data_availability: Optional[DataResources] = None
+    data_availability: DataResources
 
 
 # TODO (#1219): split into PendingTransactionReceipt and TransactionReceipt
@@ -594,12 +594,12 @@ class EstimatedFee:
     Dataclass representing estimated fee.
     """
 
-    overall_fee: int
-    gas_price: int
     gas_consumed: int
+    gas_price: int
+    data_gas_consumed: int
+    data_gas_price: int
+    overall_fee: int
     unit: PriceUnit
-    data_gas_consumed: Optional[int]
-    data_gas_price: Optional[int]
 
 
 @dataclass
@@ -883,7 +883,7 @@ class FunctionInvocation:
     calls: List["FunctionInvocation"]
     events: List[OrderedEvent]
     messages: List[OrderedMessage]
-    execution_resources: ExecutionResources
+    computation_resources: ComputationResources
 
 
 @dataclass
@@ -902,7 +902,7 @@ class InvokeTransactionTrace:
     """
 
     execute_invocation: Union[FunctionInvocation, RevertedFunctionInvocation]
-    execution_resources: Optional[ExecutionResources] = None
+    execution_resources: ExecutionResources
     validate_invocation: Optional[FunctionInvocation] = None
     fee_transfer_invocation: Optional[FunctionInvocation] = None
     state_diff: Optional[StateDiff] = None
@@ -914,7 +914,7 @@ class DeclareTransactionTrace:
     Dataclass representing a transaction trace of an DECLARE transaction.
     """
 
-    execution_resources: Optional[ExecutionResources] = None
+    execution_resources: ExecutionResources
     validate_invocation: Optional[FunctionInvocation] = None
     fee_transfer_invocation: Optional[FunctionInvocation] = None
     state_diff: Optional[StateDiff] = None
@@ -927,7 +927,7 @@ class DeployAccountTransactionTrace:
     """
 
     constructor_invocation: FunctionInvocation
-    execution_resources: Optional[ExecutionResources] = None
+    execution_resources: ExecutionResources
     validate_invocation: Optional[FunctionInvocation] = None
     fee_transfer_invocation: Optional[FunctionInvocation] = None
     state_diff: Optional[StateDiff] = None

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -131,6 +131,11 @@ class DAMode(Enum):
     L2 = 1
 
 
+class L1DAMode(Enum):
+    BLOB = "BLOB"
+    CALLDATA = "CALLDATA"
+
+
 class TransactionType(Enum):
     """
     Enum representing transaction types.
@@ -415,6 +420,12 @@ class TransactionReceipt:
 
 
 @dataclass
+class TransactionWithReceipt:
+    transaction: Transaction
+    receipt: TransactionReceipt
+
+
+@dataclass
 class SentTransactionResponse:
     """
     Dataclass representing a result of sending a transaction to Starknet.
@@ -451,79 +462,66 @@ class BlockStatus(Enum):
     REJECTED = "REJECTED"
     ACCEPTED_ON_L2 = "ACCEPTED_ON_L2"
     ACCEPTED_ON_L1 = "ACCEPTED_ON_L1"
-    PROVEN = "PROVEN"
 
 
 @dataclass
-class PendingStarknetBlock:
+class PendingBlockHeader:
+    parent_hash: int
+    timestamp: int
+    sequencer_address: int
+    l1_gas_price: ResourcePrice
+    starknet_version: str
+
+
+@dataclass
+class PendingStarknetBlock(PendingBlockHeader):
     """
     Dataclass representing a pending block on Starknet.
     """
 
     transactions: List[Transaction]
-    parent_block_hash: int
-    timestamp: int
-    sequencer_address: int
-    l1_gas_price: ResourcePrice
-    starknet_version: str
 
 
 @dataclass
-class PendingStarknetBlockWithTxHashes:
+class PendingStarknetBlockWithTxHashes(PendingBlockHeader):
     """
     Dataclass representing a pending block on Starknet containing transaction hashes.
     """
 
     transactions: List[int]
-    parent_block_hash: int
-    timestamp: int
-    sequencer_address: int
-    l1_gas_price: ResourcePrice
-    starknet_version: str
 
 
 @dataclass
-class PendingStarknetBlockWithReceipts:
+class PendingStarknetBlockWithReceipts(PendingBlockHeader):
     """
     Dataclass representing a pending block on Starknet with txs and receipts result
     """
 
-    transactions: List[TransactionReceipt]
-    parent_block_hash: int
-    timestamp: int
-    sequencer_address: int
-    l1_gas_price: ResourcePrice
-    starknet_version: str
-
-
-class DaModeType(Enum):
-    BLOB = "BLOB"
-    CALLDATA = "CALLDATA"
+    transactions: List[TransactionWithReceipt]
 
 
 @dataclass
-class StarknetBlockCommon:
+class BlockHeader:
     """
     Dataclass representing a block header.
     """
 
-    # TODO (#1219): change that into composition
     # pylint: disable=too-many-instance-attributes
 
     block_hash: int
-    parent_block_hash: int
+    parent_hash: int
     block_number: int
-    root: int
+    new_root: int
     timestamp: int
     sequencer_address: int
     l1_gas_price: ResourcePrice
-    l1_data_gas_price: Optional[ResourcePrice]
-    l1_da_mode: Optional[DaModeType]
+    l1_data_gas_price: ResourcePrice
+    l1_da_mode: L1DAMode
     starknet_version: str
 
 
 @dataclass
-class StarknetBlock(StarknetBlockCommon):
+class StarknetBlock(BlockHeader):
     """
     Dataclass representing a block on Starknet.
     """
@@ -533,7 +531,7 @@ class StarknetBlock(StarknetBlockCommon):
 
 
 @dataclass
-class StarknetBlockWithTxHashes(StarknetBlockCommon):
+class StarknetBlockWithTxHashes(BlockHeader):
     """
     Dataclass representing a block on Starknet containing transaction hashes.
     """
@@ -543,13 +541,7 @@ class StarknetBlockWithTxHashes(StarknetBlockCommon):
 
 
 @dataclass
-class TransactionWithReceipt:
-    transaction: Transaction
-    receipt: TransactionReceipt
-
-
-@dataclass
-class StarknetBlockWithReceipts(StarknetBlockCommon):
+class StarknetBlockWithReceipts(BlockHeader):
     """
     Dataclass representing a block on Starknet with txs and receipts result
     """

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -420,12 +420,11 @@ class TransactionReceipt:
     events: List[Event] = field(default_factory=list)
     messages_sent: List[L2toL1Message] = field(default_factory=list)
 
-    contract_address: Optional[int] = None
-
     block_number: Optional[int] = None
     block_hash: Optional[int] = None
 
-    message_hash: Optional[int] = None  # L1_HANDLER_TXN_RECEIPT-only
+    contract_address: Optional[int] = None  # DEPLOY_ACCOUNT_TXN_RECEIPT only
+    message_hash: Optional[int] = None  # L1_HANDLER_TXN_RECEIPT only
 
     revert_reason: Optional[str] = None
 

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -716,7 +716,7 @@ class FullNodeClient(Client):
         res = await self._client.call(
             method_name="traceTransaction",
             params={
-                "transaction_hash": tx_hash,
+                "transaction_hash": _to_rpc_felt(tx_hash),
             },
         )
         return cast(

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -21,12 +21,14 @@ from starknet_py.net.client_models import (
     L1HandlerTransaction,
     PendingBlockStateUpdate,
     PendingStarknetBlock,
+    PendingStarknetBlockWithReceipts,
     PendingStarknetBlockWithTxHashes,
     SentTransactionResponse,
     SierraContractClass,
     SimulatedTransaction,
     SimulationFlag,
     StarknetBlock,
+    StarknetBlockWithReceipts,
     StarknetBlockWithTxHashes,
     SyncStatus,
     Tag,
@@ -60,11 +62,13 @@ from starknet_py.net.schemas.rpc import (
     EventsChunkSchema,
     PendingBlockStateUpdateSchema,
     PendingStarknetBlockSchema,
+    PendingStarknetBlockWithReceiptsSchema,
     PendingStarknetBlockWithTxHashesSchema,
     SentTransactionSchema,
     SierraContractClassSchema,
     SimulatedTransactionSchema,
     StarknetBlockSchema,
+    StarknetBlockWithReceiptsSchema,
     StarknetBlockWithTxHashesSchema,
     SyncStatusSchema,
     TransactionReceiptSchema,
@@ -144,6 +148,29 @@ class FullNodeClient(Client):
         return cast(
             StarknetBlockWithTxHashes,
             StarknetBlockWithTxHashesSchema().load(res, unknown=EXCLUDE),
+        )
+
+    async def get_block_with_receipt(
+        self,
+        block_hash: Optional[Union[Hash, Tag]] = None,
+        block_number: Optional[Union[int, Tag]] = None,
+    ):
+        block_identifier = get_block_identifier(
+            block_hash=block_hash, block_number=block_number
+        )
+
+        res = await self._client.call(
+            method_name="getBlockWithReceipts",
+            params=block_identifier,
+        )
+        if block_identifier == {"block_id": "pending"}:
+            return cast(
+                PendingStarknetBlockWithReceipts,
+                PendingStarknetBlockWithReceiptsSchema().load(res, unknown=EXCLUDE),
+            )
+        return cast(
+            StarknetBlockWithReceipts,
+            StarknetBlockWithReceiptsSchema().load(res, unknown=EXCLUDE),
         )
 
     # TODO (#809): add tests with multiple emitted keys

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -150,7 +150,7 @@ class FullNodeClient(Client):
             StarknetBlockWithTxHashesSchema().load(res, unknown=EXCLUDE),
         )
 
-    async def get_block_with_receipt(
+    async def get_block_with_receipts(
         self,
         block_hash: Optional[Union[Hash, Tag]] = None,
         block_number: Optional[Union[int, Tag]] = None,

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -163,6 +163,7 @@ class FullNodeClient(Client):
             method_name="getBlockWithReceipts",
             params=block_identifier,
         )
+
         if block_identifier == {"block_id": "pending"}:
             return cast(
                 PendingStarknetBlockWithReceipts,

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -8,6 +8,7 @@ from starknet_py.net.client_models import (
     BlockStatus,
     CallType,
     DAMode,
+    DaModeType,
     EntryPointType,
     PriceUnit,
     StorageEntry,
@@ -268,6 +269,25 @@ class CallTypeField(fields.Field):
             raise ValidationError(f"Invalid value provided for CallType: {value}.")
 
         return CallType(value)
+
+
+class DaModeTypeField(fields.Field):
+    def _serialize(self, value: Any, attr: str, obj: Any, **kwargs):
+        return value.name if value is not None else ""
+
+    def _deserialize(
+        self,
+        value: Any,
+        attr: Optional[str],
+        data: Optional[Mapping[str, Any]],
+        **kwargs,
+    ) -> DaModeType:
+        values = [v.value for v in DaModeType]
+
+        if value not in values:
+            raise ValidationError(f"Invalid value provided for DaModeType: {value}.")
+
+        return DaModeType(value)
 
 
 class PriceUnitField(fields.Field):

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -8,8 +8,8 @@ from starknet_py.net.client_models import (
     BlockStatus,
     CallType,
     DAMode,
-    DaModeType,
     EntryPointType,
+    L1DAMode,
     PriceUnit,
     StorageEntry,
     TransactionExecutionStatus,
@@ -271,7 +271,7 @@ class CallTypeField(fields.Field):
         return CallType(value)
 
 
-class DaModeTypeField(fields.Field):
+class L1DAModeField(fields.Field):
     def _serialize(self, value: Any, attr: str, obj: Any, **kwargs):
         return value.name if value is not None else ""
 
@@ -281,13 +281,13 @@ class DaModeTypeField(fields.Field):
         attr: Optional[str],
         data: Optional[Mapping[str, Any]],
         **kwargs,
-    ) -> DaModeType:
-        values = [v.value for v in DaModeType]
+    ) -> L1DAMode:
+        values = [v.value for v in L1DAMode]
 
         if value not in values:
-            raise ValidationError(f"Invalid value provided for DaModeType: {value}.")
+            raise ValidationError(f"Invalid value provided for L1DAMode: {value}.")
 
-        return DaModeType(value)
+        return L1DAMode(value)
 
 
 class PriceUnitField(fields.Field):

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -469,6 +469,10 @@ class PendingBlockHeaderSchema(Schema):
     l1_gas_price = fields.Nested(
         ResourcePriceSchema(), data_key="l1_gas_price", required=True
     )
+    l1_data_gas_price = fields.Nested(
+        ResourcePriceSchema(), data_key="l1_data_gas_price", required=True
+    )
+    l1_da_mode = L1DAModeField(data_key="l1_da_mode", required=True)
     starknet_version = fields.String(data_key="starknet_version", required=True)
 
 

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -124,8 +124,8 @@ class L2toL1MessageSchema(Schema):
 
 
 class DataResourcesSchema(Schema):
-    l1_gas = Felt(data_key="l1_gas", required=True)
-    l1_data_gas = Felt(data_key="l1_data_gas", required=True)
+    l1_gas = fields.Integer(data_key="l1_gas", required=True)
+    l1_data_gas = fields.Integer(data_key="l1_data_gas", required=True)
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> DataResources:
@@ -133,8 +133,9 @@ class DataResourcesSchema(Schema):
 
 
 class ComputationResourcesSchema(Schema):
-    steps = Felt(data_key="steps", required=True)
-    range_check_builtin_applications = Felt(
+    steps = fields.Integer(data_key="steps", required=True)
+    memory_holes = fields.Integer(data_key="memory_holes", load_default=None)
+    range_check_builtin_applications = fields.Integer(
         data_key="range_check_builtin_applications", load_default=None
     )
     pedersen_builtin_applications = fields.Integer(
@@ -158,7 +159,6 @@ class ComputationResourcesSchema(Schema):
     segment_arena_builtin = fields.Integer(
         data_key="segment_arena_builtin", load_default=None
     )
-    memory_holes = fields.Integer(data_key="memory_holes", load_default=None)
 
     @post_load
     def make_dataclass(self, data, **kwargs) -> ComputationResources:
@@ -167,7 +167,7 @@ class ComputationResourcesSchema(Schema):
 
 class ExecutionResourcesSchema(ComputationResourcesSchema):
     data_availability = fields.Nested(
-        DataResourcesSchema(), data_key="data_availability", load_default=None
+        DataResourcesSchema(), data_key="data_availability", required=True
     )
 
     @post_load
@@ -211,15 +211,15 @@ class TransactionReceiptSchema(Schema):
 
 
 class EstimatedFeeSchema(Schema):
-    overall_fee = Felt(data_key="overall_fee", required=True)
-    gas_price = Felt(data_key="gas_price", required=True)
     gas_consumed = Felt(data_key="gas_consumed", required=True)
+    gas_price = Felt(data_key="gas_price", required=True)
+    data_gas_consumed = Felt(data_key="data_gas_consumed", required=True)
+    data_gas_price = Felt(data_key="data_gas_price", required=True)
+    overall_fee = Felt(data_key="overall_fee", required=True)
     unit = PriceUnitField(data_key="unit", required=True)
-    data_gas_consumed = PriceUnitField(data_key="data_gas_consumed", load_default=None)
-    data_gas_price = PriceUnitField(data_key="data_gas_price", load_default=None)
 
     @post_load
-    def make_dataclass(self, data, **kwargs):
+    def make_dataclass(self, data, **kwargs) -> EstimatedFee:
         return EstimatedFee(**data)
 
 
@@ -854,8 +854,8 @@ class FunctionInvocationSchema(Schema):
     messages = fields.List(
         fields.Nested(L2toL1MessageSchema()), data_key="messages", required=True
     )
-    execution_resources = fields.Nested(
-        ExecutionResourcesSchema(), data_key="execution_resources", required=True
+    computation_resources = fields.Nested(
+        ComputationResourcesSchema(), data_key="execution_resources", required=True
     )
 
     @post_load
@@ -887,6 +887,9 @@ class InvokeTransactionTraceSchema(Schema):
     execute_invocation = fields.Nested(
         ExecuteInvocationSchema(), data_key="execute_invocation", required=True
     )
+    execution_resources = fields.Nested(
+        ExecutionResourcesSchema(), data_key="execution_resources", required=True
+    )
     validate_invocation = fields.Nested(
         FunctionInvocationSchema(), data_key="validate_invocation", load_default=None
     )
@@ -897,10 +900,6 @@ class InvokeTransactionTraceSchema(Schema):
     )
     state_diff = fields.Nested(
         StateDiffSchema(), data_key="state_diff", load_default=None
-    )
-
-    execution_resources = fields.Nested(
-        ExecutionResourcesSchema(), data_key="execution_resources", load_default=None
     )
 
     @post_load
@@ -909,6 +908,9 @@ class InvokeTransactionTraceSchema(Schema):
 
 
 class DeclareTransactionTraceSchema(Schema):
+    execution_resources = fields.Nested(
+        ExecutionResourcesSchema(), data_key="execution_resources", required=True
+    )
     validate_invocation = fields.Nested(
         FunctionInvocationSchema(), data_key="validate_invocation", load_default=None
     )
@@ -919,10 +921,6 @@ class DeclareTransactionTraceSchema(Schema):
     )
     state_diff = fields.Nested(
         StateDiffSchema(), data_key="state_diff", load_default=None
-    )
-
-    execution_resources = fields.Nested(
-        ExecutionResourcesSchema(), data_key="execution_resources", load_default=None
     )
 
     @post_load
@@ -934,6 +932,9 @@ class DeployAccountTransactionTraceSchema(Schema):
     constructor_invocation = fields.Nested(
         FunctionInvocationSchema(), data_key="constructor_invocation", required=True
     )
+    execution_resources = fields.Nested(
+        ExecutionResourcesSchema(), data_key="execution_resources", required=True
+    )
     validate_invocation = fields.Nested(
         FunctionInvocationSchema(), data_key="validate_invocation", load_default=None
     )
@@ -944,10 +945,6 @@ class DeployAccountTransactionTraceSchema(Schema):
     )
     state_diff = fields.Nested(
         StateDiffSchema(), data_key="state_diff", load_default=None
-    )
-
-    execution_resources = fields.Nested(
-        ExecutionResourcesSchema(), data_key="execution_resources", load_default=None
     )
 
     @post_load

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -863,7 +863,7 @@ class FunctionInvocationSchema(Schema):
         fields.Nested(OrderedEventSchema()), data_key="events", required=True
     )
     messages = fields.List(
-        fields.Nested(L2toL1MessageSchema()), data_key="messages", required=True
+        fields.Nested(OrderedMessageSchema()), data_key="messages", required=True
     )
     computation_resources = fields.Nested(
         ComputationResourcesSchema(), data_key="execution_resources", required=True

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -79,6 +79,7 @@ async def test_estimated_fee_greater_than_zero(account, erc20_contract):
     assert estimated_fee.overall_fee > 0
     assert (
         estimated_fee.gas_price * estimated_fee.gas_consumed
+        + estimated_fee.data_gas_price * estimated_fee.data_gas_consumed
         == estimated_fee.overall_fee
     )
 
@@ -94,7 +95,8 @@ async def test_estimate_fee_for_declare_transaction(account, map_compiled_contra
     assert isinstance(estimated_fee.overall_fee, int)
     assert estimated_fee.overall_fee > 0
     assert (
-        estimated_fee.gas_consumed * estimated_fee.gas_price
+        estimated_fee.gas_price * estimated_fee.gas_consumed
+        + estimated_fee.data_gas_price * estimated_fee.data_gas_consumed
         == estimated_fee.overall_fee
     )
 
@@ -113,7 +115,8 @@ async def test_account_estimate_fee_for_declare_transaction(
     assert isinstance(estimated_fee.overall_fee, int)
     assert estimated_fee.overall_fee > 0
     assert (
-        estimated_fee.gas_consumed * estimated_fee.gas_price
+        estimated_fee.gas_price * estimated_fee.gas_consumed
+        + estimated_fee.data_gas_price * estimated_fee.data_gas_consumed
         == estimated_fee.overall_fee
     )
 
@@ -143,6 +146,7 @@ async def test_account_estimate_fee_for_transactions(
     assert estimated_fee[0].overall_fee > 0
     assert (
         estimated_fee[0].gas_consumed * estimated_fee[0].gas_price
+        + estimated_fee[0].data_gas_consumed * estimated_fee[0].data_gas_price
         == estimated_fee[0].overall_fee
     )
 
@@ -786,7 +790,7 @@ async def test_argent_cairo1_account_deploy(
         client=client,
         constructor_calldata=[key_pair.public_key, 0],
         chain=StarknetChainId.GOERLI,
-        max_fee=int(1e16),
+        max_fee=int(1e18),
     )
     await deploy_result.wait_for_acceptance()
     account = deploy_result.account
@@ -825,7 +829,7 @@ async def test_argent_cairo1_account_execute(
         calldata=[value],
     )
     execute = await argent_cairo1_account.execute_v1(
-        calls=increase_balance_by_20_call, max_fee=int(1e16)
+        calls=increase_balance_by_20_call, max_fee=int(1e18)
     )
     await argent_cairo1_account.client.wait_for_tx(tx_hash=execute.transaction_hash)
     receipt = await argent_cairo1_account.client.get_transaction_receipt(

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -790,7 +790,7 @@ async def test_argent_cairo1_account_deploy(
         client=client,
         constructor_calldata=[key_pair.public_key, 0],
         chain=StarknetChainId.GOERLI,
-        max_fee=int(1e18),
+        max_fee=MAX_FEE,
     )
     await deploy_result.wait_for_acceptance()
     account = deploy_result.account
@@ -829,7 +829,7 @@ async def test_argent_cairo1_account_execute(
         calldata=[value],
     )
     execute = await argent_cairo1_account.execute_v1(
-        calls=increase_balance_by_20_call, max_fee=int(1e18)
+        calls=increase_balance_by_20_call, max_fee=MAX_FEE
     )
     await argent_cairo1_account.client.wait_for_tx(tx_hash=execute.transaction_hash)
     receipt = await argent_cairo1_account.client.get_transaction_receipt(

--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -60,9 +60,9 @@ async def test_block_with_tx_hashes_latest(
     assert isinstance(blk.transactions, list)
     assert map_contract_declare_hash in blk.transactions
     assert blk.block_hash is not None
-    assert blk.parent_block_hash is not None
+    assert blk.parent_hash is not None
     assert blk.block_number is not None
-    assert blk.root is not None
+    assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
 
@@ -86,9 +86,9 @@ async def test_get_block_with_txs_latest(
     assert isinstance(blk.transactions, list)
     assert blk.transactions[0].hash == map_contract_declare_hash
     assert blk.block_hash is not None
-    assert blk.parent_block_hash is not None
+    assert blk.parent_hash is not None
     assert blk.block_number is not None
-    assert blk.root is not None
+    assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
 
@@ -105,9 +105,9 @@ async def test_block_with_receipts_latest(
     assert isinstance(blk.transactions, list)
     assert map_contract_declare_hash in blk.transactions
     assert blk.block_hash is not None
-    assert blk.parent_block_hash is not None
+    assert blk.parent_hash is not None
     assert blk.block_number is not None
-    assert blk.root is not None
+    assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
 

--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -4,9 +4,11 @@ from starknet_py.contract import Contract
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client_models import (
     PendingStarknetBlock,
+    PendingStarknetBlockWithReceipts,
     PendingStarknetBlockWithTxHashes,
     StarknetBlock,
     StarknetBlockWithTxHashes,
+    TransactionWithReceipt,
 )
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 
@@ -89,3 +91,32 @@ async def test_get_block_with_txs_latest(
     assert blk.root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
+
+
+@pytest.mark.skip
+@pytest.mark.asyncio
+async def test_block_with_receipts_latest(
+    account,
+    map_contract_declare_hash,
+):
+    blk = await account.client.get_block_with_tx_hashes(block_number="latest")
+
+    assert isinstance(blk, StarknetBlockWithTxHashes)
+    assert isinstance(blk.transactions, list)
+    assert map_contract_declare_hash in blk.transactions
+    assert blk.block_hash is not None
+    assert blk.parent_block_hash is not None
+    assert blk.block_number is not None
+    assert blk.root is not None
+    assert blk.timestamp is not None
+    assert blk.sequencer_address is not None
+
+
+@pytest.mark.skip
+@pytest.mark.asyncio
+async def test_block_with_receipts_pending(account):
+    blk = await account.client.get_block_with_receipts(block_number="pending")
+
+    assert isinstance(blk, PendingStarknetBlockWithReceipts)
+    assert isinstance(blk.transactions, list)
+    assert isinstance(blk.transactions[0], TransactionWithReceipt)

--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -3,12 +3,12 @@ import pytest
 from starknet_py.contract import Contract
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client_models import (
+    BlockStatus,
     PendingStarknetBlock,
-    PendingStarknetBlockWithReceipts,
     PendingStarknetBlockWithTxHashes,
     StarknetBlock,
+    StarknetBlockWithReceipts,
     StarknetBlockWithTxHashes,
-    TransactionWithReceipt,
 )
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 
@@ -65,6 +65,9 @@ async def test_block_with_tx_hashes_latest(
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
+    assert blk.l1_gas_price is not None
+    assert blk.l1_data_gas_price is not None
+    assert blk.l1_da_mode is not None
 
 
 @pytest.mark.asyncio
@@ -91,32 +94,24 @@ async def test_get_block_with_txs_latest(
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
+    assert blk.l1_gas_price is not None
+    assert blk.l1_data_gas_price is not None
+    assert blk.l1_da_mode is not None
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
-async def test_block_with_receipts_latest(
-    account,
-    map_contract_declare_hash,
-):
-    blk = await account.client.get_block_with_tx_hashes(block_number="latest")
+async def test_block_with_receipts_latest(account):
+    blk = await account.client.get_block_with_receipts(block_number="latest")
 
-    assert isinstance(blk, StarknetBlockWithTxHashes)
+    assert isinstance(blk, StarknetBlockWithReceipts)
     assert isinstance(blk.transactions, list)
-    assert map_contract_declare_hash in blk.transactions
+    assert blk.status == BlockStatus.ACCEPTED_ON_L2
     assert blk.block_hash is not None
     assert blk.parent_hash is not None
     assert blk.block_number is not None
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
-
-
-@pytest.mark.skip
-@pytest.mark.asyncio
-async def test_block_with_receipts_pending(account):
-    blk = await account.client.get_block_with_receipts(block_number="pending")
-
-    assert isinstance(blk, PendingStarknetBlockWithReceipts)
-    assert isinstance(blk.transactions, list)
-    assert isinstance(blk.transactions[0], TransactionWithReceipt)
+    assert blk.l1_gas_price is not None
+    assert blk.l1_data_gas_price is not None
+    assert blk.l1_da_mode is not None

--- a/starknet_py/tests/e2e/block_test.py
+++ b/starknet_py/tests/e2e/block_test.py
@@ -4,6 +4,7 @@ from starknet_py.contract import Contract
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.client_models import (
     BlockStatus,
+    L1DAMode,
     PendingStarknetBlock,
     PendingStarknetBlockWithTxHashes,
     StarknetBlock,
@@ -65,9 +66,11 @@ async def test_block_with_tx_hashes_latest(
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
-    assert blk.l1_gas_price is not None
-    assert blk.l1_data_gas_price is not None
-    assert blk.l1_da_mode is not None
+    assert blk.l1_gas_price.price_in_wei > 0
+    assert blk.l1_gas_price.price_in_fri > 0
+    assert blk.l1_data_gas_price.price_in_wei >= 0
+    assert blk.l1_data_gas_price.price_in_fri >= 0
+    assert blk.l1_da_mode in L1DAMode
 
 
 @pytest.mark.asyncio
@@ -94,9 +97,11 @@ async def test_get_block_with_txs_latest(
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
-    assert blk.l1_gas_price is not None
-    assert blk.l1_data_gas_price is not None
-    assert blk.l1_da_mode is not None
+    assert blk.l1_gas_price.price_in_wei > 0
+    assert blk.l1_gas_price.price_in_fri > 0
+    assert blk.l1_data_gas_price.price_in_wei >= 0
+    assert blk.l1_data_gas_price.price_in_fri >= 0
+    assert blk.l1_da_mode in L1DAMode
 
 
 @pytest.mark.asyncio
@@ -112,6 +117,8 @@ async def test_block_with_receipts_latest(account):
     assert blk.new_root is not None
     assert blk.timestamp is not None
     assert blk.sequencer_address is not None
-    assert blk.l1_gas_price is not None
-    assert blk.l1_data_gas_price is not None
-    assert blk.l1_da_mode is not None
+    assert blk.l1_gas_price.price_in_wei > 0
+    assert blk.l1_gas_price.price_in_fri > 0
+    assert blk.l1_data_gas_price.price_in_wei >= 0
+    assert blk.l1_data_gas_price.price_in_fri >= 0
+    assert blk.l1_da_mode in L1DAMode

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -154,6 +154,8 @@ async def test_estimate_fee_invoke(account, contract_address):
     assert estimate_fee.overall_fee > 0
     assert estimate_fee.gas_price > 0
     assert estimate_fee.gas_consumed > 0
+    assert estimate_fee.data_gas_price > 0
+    assert estimate_fee.data_gas_consumed > 0
 
 
 @pytest.mark.asyncio
@@ -174,6 +176,8 @@ async def test_estimate_fee_invoke_v3(account, contract_address):
     assert estimate_fee.overall_fee > 0
     assert estimate_fee.gas_price > 0
     assert estimate_fee.gas_consumed > 0
+    assert estimate_fee.data_gas_price > 0
+    assert estimate_fee.data_gas_consumed > 0
 
 
 @pytest.mark.asyncio
@@ -192,6 +196,8 @@ async def test_estimate_fee_declare(account):
     assert estimate_fee.overall_fee > 0
     assert estimate_fee.gas_price > 0
     assert estimate_fee.gas_consumed > 0
+    assert estimate_fee.data_gas_price > 0
+    assert estimate_fee.data_gas_consumed > 0
 
 
 @pytest.mark.asyncio
@@ -203,6 +209,8 @@ async def test_estimate_fee_deploy_account(client, deploy_account_transaction):
     assert estimate_fee.overall_fee > 0
     assert estimate_fee.gas_price > 0
     assert estimate_fee.gas_consumed > 0
+    assert estimate_fee.data_gas_price > 0
+    assert estimate_fee.data_gas_consumed > 0
 
 
 @pytest.mark.asyncio
@@ -240,6 +248,8 @@ async def test_estimate_fee_for_multiple_transactions(
         assert estimated_fee.overall_fee > 0
         assert estimated_fee.gas_price > 0
         assert estimated_fee.gas_consumed > 0
+        assert estimated_fee.data_gas_price > 0
+        assert estimated_fee.data_gas_consumed > 0
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -456,6 +456,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(simulated_txs[0], SimulatedTransaction)
     assert isinstance(simulated_txs[0].transaction_trace, InvokeTransactionTrace)
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
+    assert simulated_txs[0].transaction_trace.execution_resources is not None
 
     invoke_tx = await account.sign_invoke_v1(calls=[call, call], auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
@@ -465,6 +466,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(simulated_txs[0].transaction_trace, InvokeTransactionTrace)
     assert simulated_txs[0].transaction_trace.validate_invocation is not None
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
+    assert simulated_txs[0].transaction_trace.execution_resources is not None
 
 
 @pytest.mark.asyncio
@@ -481,6 +483,7 @@ async def test_simulate_transactions_declare(account):
     assert isinstance(simulated_txs[0].transaction_trace, DeclareTransactionTrace)
     assert simulated_txs[0].fee_estimation.overall_fee > 0
     assert simulated_txs[0].transaction_trace.validate_invocation is not None
+    assert simulated_txs[0].transaction_trace.execution_resources is not None
 
 
 @pytest.mark.asyncio
@@ -518,10 +521,12 @@ async def test_simulate_transactions_two_txs(account, deployed_balance_contract)
     assert simulated_txs[0].fee_estimation.overall_fee > 0
     assert simulated_txs[0].transaction_trace.validate_invocation is not None
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
+    assert simulated_txs[0].transaction_trace.execution_resources is not None
 
     assert isinstance(simulated_txs[1].transaction_trace, DeclareTransactionTrace)
     assert simulated_txs[1].fee_estimation.overall_fee > 0
     assert simulated_txs[1].transaction_trace.validate_invocation is not None
+    assert simulated_txs[1].transaction_trace.execution_resources is not None
 
 
 @pytest.mark.asyncio
@@ -555,3 +560,4 @@ async def test_simulate_transactions_deploy_account(
     assert isinstance(simulated_txs[0].transaction_trace, DeployAccountTransactionTrace)
     assert simulated_txs[0].fee_estimation.overall_fee > 0
     assert simulated_txs[0].transaction_trace.constructor_invocation is not None
+    assert simulated_txs[0].transaction_trace.execution_resources is not None

--- a/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy.py
@@ -15,13 +15,13 @@ async def test_simple_declare_and_deploy(account, map_compiled_contract):
     # To declare through Contract class you have to compile a contract and pass it
     # to Contract.declare_v1 or Contract.declare_v3
     declare_result = await Contract.declare_v1(
-        account=account, compiled_contract=compiled_contract, max_fee=int(1e16)
+        account=account, compiled_contract=compiled_contract, max_fee=int(1e18)
     )
     # Wait for the transaction
     await declare_result.wait_for_acceptance()
 
     # After contract is declared it can be deployed
-    deploy_result = await declare_result.deploy_v1(max_fee=int(1e16))
+    deploy_result = await declare_result.deploy_v1(max_fee=int(1e18))
     await deploy_result.wait_for_acceptance()
 
     # You can pass more arguments to the `deploy` method. Check `API` section to learn more

--- a/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy_cairo1.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy_cairo1.py
@@ -19,12 +19,12 @@ async def test_simple_declare_and_deploy(account):
         account=account,
         compiled_contract=compiled_contract,
         compiled_contract_casm=compiled_contract_casm,
-        max_fee=int(1e16),
+        max_fee=int(1e18),
     )
     await declare_result.wait_for_acceptance()
 
     deploy_result = await declare_result.deploy_v1(
-        constructor_args=constructor_args, max_fee=int(1e16)
+        constructor_args=constructor_args, max_fee=int(1e18)
     )
     await deploy_result.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/fixtures/constants.py
+++ b/starknet_py/tests/e2e/fixtures/constants.py
@@ -90,9 +90,11 @@ STRK_FEE_CONTRACT_ADDRESS = (
     "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 )
 
-MAX_FEE = int(1e16)
+MAX_FEE = int(1e18)
 
-MAX_RESOURCE_BOUNDS_L1 = ResourceBounds(max_amount=5000, max_price_per_unit=int(2e12))
+MAX_RESOURCE_BOUNDS_L1 = ResourceBounds(
+    max_amount=int(1e5), max_price_per_unit=int(1e13)
+)
 MAX_RESOURCE_BOUNDS = ResourceBoundsMapping(
     l1_gas=MAX_RESOURCE_BOUNDS_L1, l2_gas=ResourceBounds.init_with_zeros()
 )

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -365,18 +365,6 @@ async def test_get_block_with_tx_hashes_new_header_fields(client_goerli_testnet)
     assert pending_block.l1_gas_price.price_in_wei > 0
 
 
-@pytest.mark.asyncio
-async def test_get_tx_receipt_new_fields(client_goerli_testnet):
-    l1_handler_tx_hash = (
-        0xBEFE411182979262478CA8CA73BED724237D03D303CE420D94DE7664A78347
-    )
-    receipt = await client_goerli_testnet.get_transaction_receipt(
-        tx_hash=l1_handler_tx_hash
-    )
-
-    assert receipt.execution_resources is not None
-
-
 @pytest.mark.parametrize(
     "tx_hash, tx_type",
     [

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -174,6 +174,8 @@ async def test_estimate_message_fee(client_goerli_integration):
     assert estimated_message.overall_fee > 0
     assert estimated_message.gas_price > 0
     assert estimated_message.gas_consumed > 0
+    assert estimated_message.data_gas_price > 0
+    assert estimated_message.data_gas_consumed >= 0
     assert estimated_message.unit is not None
 
 
@@ -428,6 +430,7 @@ async def test_get_tx_receipt_with_execution_resources(client_sepolia_integratio
     )
 
     assert receipt.execution_resources is not None
+    assert receipt.execution_resources.data_availability is not None
     assert receipt.execution_resources.steps is not None
     assert receipt.execution_resources.segment_arena_builtin is not None
     assert receipt.execution_resources.bitwise_builtin_applications is not None

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -16,7 +16,6 @@ from starknet_py.net.client_models import (
     EstimatedFee,
     EventsChunk,
     InvokeTransactionV3,
-    L1DAMode,
     PendingBlockHeader,
     PendingStarknetBlockWithReceipts,
     ResourceBoundsMapping,
@@ -100,7 +99,7 @@ async def test_transaction_not_received_max_fee_too_small(account_goerli_testnet
     )
     sign_invoke = await account.sign_invoke_v1(calls=call, max_fee=int(1e10))
 
-    with pytest.raises(ClientError, match=r".*Max fee.*"):
+    with pytest.raises(ClientError, match=r".*MaxFeeTooLow.*"):
         await account.client.send_transaction(sign_invoke)
 
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1281

Initial PR #1282 

## Introduced changes
<!-- A brief description of the changes -->

- Replace `StarknetBlockCommon` with `BlockHeader` and add `PendingBlockHeader` to align with the RPC specification
  - Rename `parent_block_hash`, `root` -> `parent_hash`, `new_root`
  - Use `BlockHeader` in `StarknetBlock`, `StarknetBlockWithTxHashes` and `StarknetBlockWithReceipts`, the same for respective pending classes
- Change logic in auto estimation for V3 transactions in the `Account` class
- Add `FullNodeClient.get_block_with_receipts`
- Increase `max_fee`/`l1_resource_bounds` for devnet tests


##

- [X] This PR contains breaking changes

<!-- List of all breaking changes -->


