### PR TITLE
Add missing event context fields

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,17 @@ Migration guide
 ===============
 
 **********************
+0.21.0 Migration guide
+**********************
+
+0.21.0 Minor changes
+-----------------------
+
+.. currentmodule:: starknet_py.net.client_models
+
+1. :class:`EventsChunk` field ``events`` is now a list of :class:`EmittedEvent` instead of :class:`Event`
+
+**********************
 0.20.0 Migration guide
 **********************
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -33,7 +33,7 @@ Calls = Union[Call, Iterable[Call]]
 @dataclass
 class Event:
     """
-    Dataclass representing an event emitted by transaction.
+    Dataclass representing a Starknet event.
     """
 
     from_address: int
@@ -42,12 +42,23 @@ class Event:
 
 
 @dataclass
+class EmittedEvent(Event):
+    """
+    Dataclass representing an event emitted by transaction.
+    """
+
+    transaction_hash: int
+    block_hash: Optional[int] = None
+    block_number: Optional[int] = None
+
+
+@dataclass
 class EventsChunk:
     """
     Dataclass representing events returned by FullNodeClient.get_events method.
     """
 
-    events: List[Event]
+    events: List[EmittedEvent]
     continuation_token: Optional[str] = None
 
 

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -22,6 +22,7 @@ from starknet_py.net.client_models import (
     DeployAccountTransactionV3,
     DeployedContract,
     DeployTransaction,
+    EmittedEvent,
     EntryPoint,
     EntryPointsByType,
     EstimatedFee,
@@ -92,9 +93,19 @@ class EventSchema(Schema):
         return Event(**data)
 
 
+class EmittedEventSchema(EventSchema):
+    transaction_hash = Felt(data_key="transaction_hash", required=True)
+    block_hash = Felt(data_key="block_hash", load_default=None)
+    block_number = fields.Integer(data_key="block_number", load_default=None)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> EmittedEvent:
+        return EmittedEvent(**data)
+
+
 class EventsChunkSchema(Schema):
     events = fields.List(
-        fields.Nested(EventSchema(unknown=EXCLUDE)),
+        fields.Nested(EmittedEventSchema()),
         data_key="events",
         required=True,
     )

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -10,6 +10,7 @@ from starknet_py.net.client_models import (
     DAMode,
     DeclareTransactionV3,
     DeployAccountTransactionV3,
+    EmittedEvent,
     EstimatedFee,
     EventsChunk,
     InvokeTransactionV3,
@@ -425,6 +426,12 @@ async def test_get_events_sepolia_testnet(client_sepolia_testnet):
     assert isinstance(events_chunk, EventsChunk)
     assert len(events_chunk.events) == 10
     assert events_chunk.continuation_token is not None
+    assert isinstance(events_chunk.events[0], EmittedEvent)
+    assert events_chunk.events[0].block_number == 1000
+    assert events_chunk.events[0].block_hash is not None
+    assert events_chunk.events[0].from_address is not None
+    assert events_chunk.events[0].data is not None
+    assert events_chunk.events[0].keys is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1304 


## Introduced changes
<!-- A brief description of the changes -->

- Add `EmittedEvent` class that includes missing [event context ](https://github.com/starkware-libs/starknet-specs/blob/v0.6.0/api/starknet_api_openrpc.json#L909)fields

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


