### PR TITLE
Support serialization of ByteArrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ cython_debug/
 
 # Compiled contracts
 /starknet_py/tests/e2e/mock/contracts_compiled/*
+/starknet_py/tests/e2e/mock/*/Scarb.lock
 
 # Allow precompiled contracts
 !/starknet_py/tests/e2e/mock/contracts_compiled/precompiled/

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -23,6 +23,7 @@ ABI_EBNF = """
     actual_type: type_unit
         | type_bool
         | type_felt
+        | type_bytes
         | type_uint
         | type_contract_address
         | type_class_hash
@@ -36,6 +37,7 @@ ABI_EBNF = """
     
     type_unit: "()"
     type_felt: "core::felt252"
+    type_bytes: "core::bytes_31::bytes31"
     type_bool: "core::bool"
     type_uint: "core::integer::u" INT
     type_contract_address: "core::starknet::contract_address::ContractAddress"
@@ -84,6 +86,12 @@ class ParserTransformer(Transformer):
         return value[0]
 
     def type_felt(self, _value: List[Any]) -> FeltType:
+        """
+        Felt does not contain any additional arguments, so `_value` is just an empty list.
+        """
+        return FeltType()
+
+    def type_bytes(self, _value: List[Any]) -> FeltType:
         """
         Felt does not contain any additional arguments, so `_value` is just an empty list.
         """

--- a/starknet_py/serialization/data_serializers/__init__.py
+++ b/starknet_py/serialization/data_serializers/__init__.py
@@ -1,5 +1,6 @@
 from .array_serializer import ArraySerializer
 from .bool_serializer import BoolSerializer
+from .byte_array_serializer import ByteArraySerializer
 from .cairo_data_serializer import CairoDataSerializer
 from .felt_serializer import FeltSerializer
 from .named_tuple_serializer import NamedTupleSerializer

--- a/starknet_py/serialization/data_serializers/byte_array_serializer.py
+++ b/starknet_py/serialization/data_serializers/byte_array_serializer.py
@@ -15,7 +15,7 @@ from starknet_py.serialization.data_serializers.cairo_data_serializer import (
 )
 from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
 
-BYTES_SIZE_IN_BYTES_31 = 31
+BYTES_31_SIZE = 31
 
 
 @dataclass
@@ -54,13 +54,10 @@ class ByteArraySerializer(CairoDataSerializer[str, str]):
     ) -> Generator[int, None, None]:
         context.ensure_valid_type(value, isinstance(value, str), "str")
         data = [
-            value[i : i + BYTES_SIZE_IN_BYTES_31]
-            for i in range(0, len(value), BYTES_SIZE_IN_BYTES_31)
+            value[i : i + BYTES_31_SIZE] for i in range(0, len(value), BYTES_31_SIZE)
         ]
         pending_word = (
-            ""
-            if len(data) == 0 or len(data[-1]) == BYTES_SIZE_IN_BYTES_31
-            else data.pop(-1)
+            "" if len(data) == 0 or len(data[-1]) == BYTES_31_SIZE else data.pop(-1)
         )
 
         yield len(data)

--- a/starknet_py/serialization/data_serializers/byte_array_serializer.py
+++ b/starknet_py/serialization/data_serializers/byte_array_serializer.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Generator
+
+from starknet_py.cairo.felt import decode_shortstring, encode_shortstring
+from starknet_py.serialization._context import (
+    DeserializationContext,
+    SerializationContext,
+)
+from starknet_py.serialization.data_serializers._common import (
+    deserialize_to_list,
+    serialize_from_list,
+)
+from starknet_py.serialization.data_serializers.cairo_data_serializer import (
+    CairoDataSerializer,
+)
+from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
+
+BYTES_SIZE_IN_BYTES_31 = 31
+
+
+@dataclass
+class ByteArraySerializer(CairoDataSerializer[str, str]):
+    """
+    Serializer for ByteArrays. Serializes to and deserializes from str values.
+
+    Examples:
+    "" => [0,0,0]
+    "hello" => [0,448378203247,5]
+    """
+
+    def deserialize_with_context(self, context: DeserializationContext) -> str:
+        with context.push_entity("data_array_len"):
+            [size] = context.reader.read(1)
+
+        data = deserialize_to_list([FeltSerializer()] * size, context)
+
+        with context.push_entity("pending_word"):
+            [pending_word] = context.reader.read(1)
+
+        with context.push_entity("pending_word_len"):
+            [pending_word_len] = context.reader.read(1)
+
+        pending_word = decode_shortstring(pending_word)
+        context.ensure_valid_value(
+            len(pending_word) == pending_word_len,
+            f"Invalid length {pending_word_len} for pending word {pending_word}",
+        )
+
+        data_joined = "".join(map(decode_shortstring, data))
+        return data_joined + pending_word
+
+    def serialize_with_context(
+        self, context: SerializationContext, value: str
+    ) -> Generator[int, None, None]:
+        context.ensure_valid_type(value, isinstance(value, str), "str")
+        data = [
+            value[i : i + BYTES_SIZE_IN_BYTES_31]
+            for i in range(0, len(value), BYTES_SIZE_IN_BYTES_31)
+        ]
+        pending_word = (
+            ""
+            if len(data) == 0 or len(data[-1]) == BYTES_SIZE_IN_BYTES_31
+            else data.pop(-1)
+        )
+
+        yield len(data)
+        yield from serialize_from_list([FeltSerializer()] * len(data), context, data)
+        yield encode_shortstring(pending_word)
+        yield len(pending_word)

--- a/starknet_py/serialization/data_serializers/byte_array_serializer_test.py
+++ b/starknet_py/serialization/data_serializers/byte_array_serializer_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from starknet_py.serialization.data_serializers.byte_array_serializer import (
+    ByteArraySerializer,
+)
+
+byte_array_serializer = ByteArraySerializer()
+
+
+@pytest.mark.parametrize(
+    "value, serialized_value",
+    [
+        ("", [0, 0, 0]),
+        ("hello", [0, 0x68656C6C6F, 5]),
+        (
+            "Long string, more than 31 characters.",
+            [
+                1,
+                0x4C6F6E6720737472696E672C206D6F7265207468616E203331206368617261,
+                0x63746572732E,
+                6,
+            ],
+        ),
+    ],
+)
+def test_values(value, serialized_value):
+    serialized = byte_array_serializer.serialize(value)
+    deserialized = byte_array_serializer.deserialize(serialized_value)
+
+    assert deserialized == value
+    assert serialized == serialized_value

--- a/starknet_py/serialization/factory.py
+++ b/starknet_py/serialization/factory.py
@@ -20,7 +20,10 @@ from starknet_py.cairo.data_types import (
     UintType,
     UnitType,
 )
-from starknet_py.serialization.data_serializers import BoolSerializer
+from starknet_py.serialization.data_serializers import (
+    BoolSerializer,
+    ByteArraySerializer,
+)
 from starknet_py.serialization.data_serializers.array_serializer import ArraySerializer
 from starknet_py.serialization.data_serializers.cairo_data_serializer import (
     CairoDataSerializer,
@@ -55,6 +58,14 @@ from starknet_py.serialization.function_serialization_adapter import (
 )
 
 _uint256_type = StructType("Uint256", OrderedDict(low=FeltType(), high=FeltType()))
+_byte_array_type = StructType(
+    "core::byte_array::ByteArray",
+    OrderedDict(
+        data=ArrayType(FeltType()),
+        pending_word=FeltType(),
+        pending_word_len=UintType(bits=32),
+    ),
+)
 
 
 def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
@@ -64,7 +75,7 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
     :param cairo_type: CairoType.
     :return: CairoDataSerializer.
     """
-    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-return-statements, too-many-branches
     if isinstance(cairo_type, FeltType):
         return FeltSerializer()
 
@@ -75,6 +86,9 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
         # Special case: Uint256 is represented as struct
         if cairo_type == _uint256_type:
             return Uint256Serializer()
+
+        if cairo_type == _byte_array_type:
+            return ByteArraySerializer()
 
         return StructSerializer(
             OrderedDict(

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -174,3 +174,24 @@ async def test_from_address_on_v1_contract(account, cairo1_erc20_class_hash: int
     assert erc20_from_address.account == erc20.account
     assert erc20_from_address.functions.keys() == erc20.functions.keys()
     assert erc20_from_address.data == erc20.data
+
+
+@pytest.mark.skipif(
+    "--contract_dir=v1" in sys.argv,
+    reason="Contract exists only in v2 directory",
+)
+@pytest.mark.asyncio
+async def test_invoke_contract_with_bytearray(string_contract):
+    (initial_string,) = await string_contract.functions["get_string"].call()
+    assert initial_string == "Hello"
+
+    value_to_set = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    """
+
+    await string_contract.functions["set_string"].invoke_v3(
+        new_string=value_to_set, auto_estimate=True
+    )
+    (new_string,) = await string_contract.functions["get_string"].call()
+    assert new_string == value_to_set

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -5,12 +5,13 @@ import pytest
 import pytest_asyncio
 
 from starknet_py.common import create_casm_class
+from starknet_py.contract import Contract
 from starknet_py.hash.casm_class_hash import compute_casm_class_hash
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.models import DeclareV2
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
 from starknet_py.tests.e2e.fixtures.contracts import deploy_v1_contract
-from starknet_py.tests.e2e.fixtures.misc import load_contract
+from starknet_py.tests.e2e.fixtures.misc import ContractVersion, load_contract
 
 
 async def declare_cairo1_contract(
@@ -129,4 +130,24 @@ async def cairo1_hello_starknet_deploy(
         account=account,
         contract_name="HelloStarknet",
         class_hash=cairo1_hello_starknet_class_hash,
+    )
+
+
+@pytest_asyncio.fixture(scope="package", name="string_contract_class_hash")
+async def declare_string_contract(account: BaseAccount) -> int:
+    contract = load_contract("MyString", version=ContractVersion.V2)
+    class_hash, _ = await declare_cairo1_contract(
+        account, contract["sierra"], contract["casm"]
+    )
+    return class_hash
+
+
+@pytest_asyncio.fixture(scope="package", name="string_contract")
+async def deploy_string_contract(
+    account: BaseAccount, string_contract_class_hash
+) -> Contract:
+    return await deploy_v1_contract(
+        account=account,
+        contract_name="MyString",
+        class_hash=string_contract_class_hash,
     )

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/lib.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/lib.cairo
@@ -4,6 +4,7 @@ mod hello_starknet;
 mod hello2;
 mod minimal_contract;
 mod new_syntax_test_contract;
+mod string;
 mod test_contract;
 mod test_enum;
 mod test_option;

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/string.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/string.cairo
@@ -1,0 +1,22 @@
+#[starknet::contract]
+mod MyString {
+    #[storage]
+    struct Storage {
+        string: ByteArray,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.string.write("Hello");
+    }
+
+    #[external(v0)]
+    fn set_string(ref self: ContractState, new_string: ByteArray) {
+        self.string.write(new_string);
+    }
+
+    #[external(v0)]
+    fn get_string(self: @ContractState) -> ByteArray {
+        self.string.read()
+    }
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1330 

## Introduced changes
<!-- A brief description of the changes -->

- Enable serializing and deserializing Cairo `ByteArray` into and from Python `str`
- Allow using contracts that utilize `ByteArray` type,  in contract serialization logic:
  - `bytes_31` is treated as `felt`
  - `ByteArray` is handled as a special case of a struct instead of a separate type

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


