### PR TITLE
Use pre-compiled devnet binary from release assets

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,8 @@
 name: Checks
 
 env:
-  DEVNET_SHA: "c6ffb99"
   CAIRO_LANG_VERSION: "0.13.1"
+  DEVNET_VERSION: "0.0.5"
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install poetry
         run: |
@@ -71,7 +71,7 @@ jobs:
 
       # ====================== SETUP ====================== #
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: asdf-vm/actions/setup@v3
       - uses: actions/setup-python@v4
         with:
@@ -160,9 +160,7 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v4
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -196,10 +194,7 @@ jobs:
       # ====================== SETUP DEVNET ====================== #
 
       - name: Install devnet
-        run: |
-          cargo install --locked \
-          --git https://github.com/0xSpaceShard/starknet-devnet-rs.git \
-          --rev ${{ env.DEVNET_SHA }}
+        run: ./starknet_py/tests/install_devnet.sh
 
       # ====================== RUN TESTS ====================== #
 
@@ -237,7 +232,7 @@ jobs:
       SEPOLIA_INTEGRATION_ACCOUNT_PRIVATE_KEY: ${{ secrets.SEPOLIA_INTEGRATION_ACCOUNT_PRIVATE_KEY }}
       SEPOLIA_INTEGRATION_ACCOUNT_ADDRESS: ${{ secrets.SEPOLIA_INTEGRATION_ACCOUNT_ADDRESS }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -299,9 +294,10 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
+        with:
+          toolchain: stable
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -317,7 +313,9 @@ jobs:
       # ====================== SETUP DEVNET ====================== #
 
       - name: Install devnet
-        run: cargo install --locked --git https://github.com/0xSpaceShard/starknet-devnet-rs.git --rev ${{ env.DEVNET_SHA }}
+        run: |
+          $DEVNET_INSTALL_DIR = "$(git rev-parse --show-toplevel)/starknet_py/tests/e2e/devnet"
+          cargo install starknet-devnet --version ${{ env.DEVNET_VERSION }} --root $DEVNET_INSTALL_DIR
 
       # ====================== SETUP PYTHON ====================== #
 
@@ -368,9 +366,7 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v4
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -404,10 +400,7 @@ jobs:
       # ====================== SETUP DEVNET ====================== #
 
       - name: Install devnet
-        run: |
-          cargo install --locked \
-          --git https://github.com/0xSpaceShard/starknet-devnet-rs.git \
-          --rev ${{ env.DEVNET_SHA }}
+        run: ./starknet_py/tests/install_devnet.sh
 
       # ====================== RUN TESTS ====================== #
 
@@ -437,9 +430,10 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
+        with:
+          toolchain: stable
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -473,7 +467,9 @@ jobs:
       # ====================== SETUP DEVNET ====================== #
 
       - name: Install devnet
-        run: cargo install --locked --git https://github.com/0xSpaceShard/starknet-devnet-rs.git --rev ${{ env.DEVNET_SHA }}
+        run: |
+          $DEVNET_INSTALL_DIR = "$(git rev-parse --show-toplevel)/starknet_py/tests/e2e/devnet"
+          cargo install starknet-devnet --version ${{ env.DEVNET_VERSION }} --root $DEVNET_INSTALL_DIR
 
       # ====================== RUN TESTS ====================== #
 

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ cython_debug/
 
 # Test variables
 /starknet_py/tests/e2e/test-variables.env
+
+# Devnet binary
+/starknet_py/tests/e2e/devnet

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -15,22 +15,13 @@ Development dependencies
 Setup
 -----
 
-In order to run tests on devnet, you need to install `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_.
-The correct version of devnet to use corresponds to the Starknet and RPC specification that are currently supported by Starknet.py.
-Information about the supported version for the latest release can be found in the :doc:`migration guide<migration_guide>`.
+Starknet devnet
+^^^^^^^^^^^^^^^
 
-To avoid version discrepancies or other related issues, we recommend installing this dependency using the ``cargo install`` command, and specifying a certain commit along with the correct Starknet and RPC versions.
+To install `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_ run the script ``./starknet_py/tests/install_devnet.sh``.
 
-Below is the command you can use to do this, designed for compatibility with the current version of Starknet.py:
-
-.. code-block:: bash
-
-    cargo install \
-    --locked \
-    --git https://github.com/0xSpaceShard/starknet-devnet-rs.git \
-    --rev c6ffb99
-
-If you choose to install `starknet-devnet-rs <https://github.com/0xSpaceShard/starknet-devnet-rs>`_ using a different method, please make sure to add the executable ``starknet-devnet`` to your ``PATH`` environment variable.
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
 
 In order to be able to run tests on testnet and integration networks (``starknet_py/tests/e2e/tests_on_networks/``), you must set some environmental variables:
 
@@ -44,17 +35,19 @@ In order to be able to run tests on testnet and integration networks (``starknet
 The best way to set environment variables is to create ``test-variables.env`` file in ``starknet_py/tests/e2e/`` directory, so they can be loaded by the ``python-dotenv`` library.
 You can find an example file ``test-variables.env.template`` in the same directory with the format of how it should look like.
 
+Dependencies
+^^^^^^^^^^^^
+
 .. code-block:: bash
 
-    # Install dependencies
     poetry install
 
-    # Compile contracts
+Contracts
+^^^^^^^^^
+
+.. code-block:: bash
+
     poe compile_contracts
-
-    # Make sure everything was installed properly
-    poe test
-
 
 Git hooks
 ---------
@@ -90,24 +83,17 @@ Tests
     # Run whole suite
     poe test
 
+    # Run only tests on networks
+    poe test_ci_on_networks
+
+    # Run unit tests and tests on devnet
+    poe test_ci
+
     # Generate test report in terminal
     poe test_report
 
     # Generate HTML report and open it in the browser
     poe test_html
-
-    # Run only unit tests
-    poe test_unit
-
-    # Run only e2e tests
-    poe test_e2e
-
-Running e2e tests in PyCharm
-----------------------------
-1. Run ``starkware-devnet`` script before running e2e tests in PyCharm.
-2. Use ``E2E tests`` configuration to run or debug.
-
-⚠️ **Warning**: Make sure to fill your interpreter in the configuration, to match your project's poetry venv.
 
 Code style guide
 ----------------

--- a/starknet_py/tests/e2e/fixtures/devnet.py
+++ b/starknet_py/tests/e2e/fixtures/devnet.py
@@ -2,6 +2,7 @@ import socket
 import subprocess
 import time
 from contextlib import closing
+from pathlib import Path
 from typing import Generator, List
 
 import pytest
@@ -25,8 +26,9 @@ def start_devnet():
 
 
 def get_start_devnet_command(devnet_port: int) -> List[str]:
+    devnet_path = Path(__file__).parent.parent / "devnet" / "bin" / "starknet-devnet"
     return [
-        "starknet-devnet",
+        str(devnet_path),
         "--port",
         str(devnet_port),
         "--accounts",  # deploys specified number of accounts

--- a/starknet_py/tests/install_devnet.sh
+++ b/starknet_py/tests/install_devnet.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+DEVNET_INSTALL_DIR="$(git rev-parse --show-toplevel)/starknet_py/tests/e2e/devnet/bin"
+DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs"
+DEVNET_VERSION="v0.0.5"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+      echo "$1 is not available"
+      echo "Please install $1 and run the script again"
+      exit 1
+  fi
+}
+
+get_architecture() {
+  local _ostype _cputype _arch _clibtype
+  _ostype="$(uname -s)"
+  _cputype="$(uname -m)"
+  _clibtype="gnu"
+
+  if [ "$_ostype" = Linux ] && ldd --_requested_version 2>&1 | grep -q 'musl'; then
+    _clibtype="musl"
+  fi
+
+  if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ] && sysctl hw.optional.x86_64 | grep -q ': 1'; then
+    _cputype=x86_64
+  fi
+
+  case "$_ostype" in
+  Linux)
+    _ostype=unknown-linux-$_clibtype
+    ;;
+
+  Darwin)
+    _ostype=apple-darwin
+    ;;
+  *)
+    err "unsupported OS type: $_ostype"
+    ;;
+  esac
+
+  case "$_cputype" in
+  aarch64 | arm64)
+    _cputype=aarch64
+    ;;
+
+  x86_64 | x86-64 | x64 | amd64)
+    _cputype=x86_64
+    ;;
+  *)
+    err "unknown CPU type: $_cputype"
+    ;;
+  esac
+
+  _arch="${_cputype}-${_ostype}"
+
+  RETVAL="$_arch"
+}
+
+require_cmd curl
+require_cmd tar
+
+get_architecture
+SYSTEM_TRIPLET="$RETVAL"
+
+mkdir -p "${DEVNET_INSTALL_DIR}"
+curl -L "${DEVNET_REPO}/releases/download/${DEVNET_VERSION}/starknet-devnet-${SYSTEM_TRIPLET}.tar.gz" | tar -xz -C "${DEVNET_INSTALL_DIR}" || exit 1
+
+echo "All done!"
+exit 0


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes
<!-- A brief description of the changes -->

- Install devnet from the release assets to speed up CI and installation locally
- On Windows install the same version from the crate
- Reuse the existing [installation script](https://github.com/foundry-rs/starknet-foundry/blob/609022cc6bdf0c27fea9a891017eebf14261b165/scripts/install_devnet.sh) from `starknet-foundry`
- Update `actions/checkout`
- Modify and update development docs

Windows tests checked in the fork repository: https://github.com/ddoktorski/starknet.py/actions/runs/8981825634

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


