### PR TITLE
Make `execution_resources` required in `L1HandlerTransactionTrace`

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,7 +5,11 @@ Migration guide
 0.22.0 Migration guide
 ******************************
 
-Version 0.22.0 of **starknet.py**
+0.22.0 Targeted versions
+------------------------
+
+- Starknet - `0.13.1.1 <https://docs.starknet.io/documentation/starknet_versions/version_notes/#version0.13.1.1>`_
+- RPC - `0.7.1 <https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.1>`_
 
 0.22.0 Breaking changes
 -----------------------
@@ -20,7 +24,7 @@ Version 0.22.0 of **starknet.py**
 
 3. Parameter ``chain`` has been removed from the methods :meth:`Account.deploy_account_v1` and :meth:`Account.deploy_account_v3`
 4. Parameter ``chain_id`` has been removed from the method :meth:`~Account.get_balance`
-
+5. :class:`~starknet_py.net.client_models.L1HandlerTransactionTrace` field ``execution_resources`` is now required
 
 
 ******************************

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -989,7 +989,7 @@ class L1HandlerTransactionTrace:
     Dataclass representing a transaction trace of an L1_HANDLER transaction.
     """
 
-    execution_resources: Optional[ExecutionResources]
+    execution_resources: ExecutionResources
     function_invocation: FunctionInvocation
     state_diff: Optional[StateDiff] = None
 

--- a/starknet_py/net/schemas/rpc.py
+++ b/starknet_py/net/schemas/rpc.py
@@ -965,9 +965,8 @@ class DeployAccountTransactionTraceSchema(Schema):
 
 
 class L1HandlerTransactionTraceSchema(Schema):
-    # TODO (#1323): Explain with starknet, because spec doesn't contain execution_resources
     execution_resources = fields.Nested(
-        ExecutionResourcesSchema(), data_key="execution_resources", load_default=None
+        ExecutionResourcesSchema(), data_key="execution_resources", required=True
     )
 
     function_invocation = fields.Nested(

--- a/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/trace_api_test.py
@@ -123,6 +123,7 @@ async def test_trace_transaction_l1_handler(client_sepolia_integration):
     assert (type(tx)) is L1HandlerTransaction
     assert type(trace) is L1HandlerTransactionTrace
     assert trace.function_invocation is not None
+    assert trace.execution_resources is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to #1323 

## Introduced changes
<!-- A brief description of the changes -->

- Make `execution_resources` required in `L1HandlerTransactionTrace` after fix in the RPC spec [v0.7.1](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.7.1)


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


