### PR TITLE
feat: change default cairo ver

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -1079,7 +1079,9 @@ class Contract:
 
         compiled = create_compiled_contract(compiled_contract)
         assert compiled.abi is not None
-        translated_args = translate_constructor_args(compiled.abi, constructor_args)
+        translated_args = translate_constructor_args(
+            compiled.abi, constructor_args, cairo_version=0
+        )
         return compute_address(
             salt=salt,
             class_hash=compute_class_hash(compiled),

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -80,7 +80,7 @@ class ContractData:
         return AbiParserV0(self.abi).parse()
 
     @staticmethod
-    def from_abi(address: int, abi: ABI, cairo_version: int = 0) -> ContractData:
+    def from_abi(address: int, abi: ABI, cairo_version: int = 1) -> ContractData:
         """
         Create ContractData from ABI.
 
@@ -162,7 +162,7 @@ class DeclareResult(SentTransaction):
     """
 
     _account: BaseAccount = None  # pyright: ignore
-    _cairo_version: int = 0
+    _cairo_version: int = 1
 
     class_hash: int = None  # pyright: ignore
     """Class hash of the declared contract."""
@@ -524,7 +524,7 @@ class ContractFunction:
         contract_data: ContractData,
         client: Client,
         account: Optional[BaseAccount],
-        cairo_version: int = 0,
+        cairo_version: int = 1,
         *,
         interface_name: Optional[str] = None,
     ):
@@ -729,7 +729,7 @@ class Contract:
         abi: list,
         provider: Union[BaseAccount, Client],
         *,
-        cairo_version: int = 0,
+        cairo_version: int = 1,
     ):
         """
         Should be used instead of ``from_address`` when ABI is known statically.
@@ -1105,7 +1105,7 @@ class Contract:
         contract_data: ContractData,
         client: Client,
         account: Optional[BaseAccount],
-        cairo_version: int = 0,
+        cairo_version: int = 1,
     ) -> FunctionsRepository:
         repository = {}
         implemented_interfaces = [

--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -1067,10 +1067,10 @@ class Contract:
         deployer_address: int = 0,
     ) -> int:
         """
-        Computes address for given contract.
+        Computes address for given Cairo 0 contract.
 
         :param salt: int
-        :param compiled_contract: String containing compiled contract.
+        :param compiled_contract: String containing compiled Cairo 0 contract.
         :param constructor_args: A ``list`` or ``dict`` of arguments for the constructor.
         :param deployer_address: Address of the deployer (if not provided default 0 is used).
 

--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -61,7 +61,7 @@ class Deployer:
         *,
         salt: Optional[int] = None,
         abi: Optional[List] = None,
-        cairo_version: int = 0,
+        cairo_version: int = 1,
         calldata: Optional[Union[List, dict]] = None,
     ) -> ContractDeployment:
         """

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -67,7 +67,10 @@ async def test_balance_when_token_specified(account, erc20_contract):
 @pytest.mark.asyncio
 async def test_estimated_fee_greater_than_zero(account, erc20_contract):
     erc20_contract = Contract(
-        address=erc20_contract.address, abi=erc20_contract.data.abi, provider=account
+        address=erc20_contract.address,
+        abi=erc20_contract.data.abi,
+        provider=account,
+        cairo_version=0,
     )
 
     estimated_fee = (

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -43,7 +43,7 @@ async def test_throws_when_calldata_not_provided(constructor_with_arguments_abi)
         match="Provided contract has a constructor and no arguments were provided.",
     ):
         deployer.create_contract_deployment(
-            class_hash=1234, abi=constructor_with_arguments_abi
+            class_hash=1234, abi=constructor_with_arguments_abi, cairo_version=0
         )
 
 
@@ -72,6 +72,7 @@ async def test_constructor_arguments_contract_deploy(
         class_hash=constructor_with_arguments_class_hash,
         abi=constructor_with_arguments_abi,
         calldata=calldata,
+        cairo_version=0,
     )
 
     deploy_invoke_transaction = await account.sign_invoke_v1(
@@ -84,6 +85,7 @@ async def test_constructor_arguments_contract_deploy(
         address=contract_address,
         abi=constructor_with_arguments_abi,
         provider=account,
+        cairo_version=0,
     )
 
     result = await contract.functions["get"].call(block_number="latest")
@@ -145,7 +147,7 @@ async def test_create_deployment_call_raw(
     deployer = Deployer(account_address=account.address)
 
     raw_calldata = translate_constructor_args(
-        abi=constructor_with_arguments_abi, constructor_args=calldata
+        abi=constructor_with_arguments_abi, constructor_args=calldata, cairo_version=0
     )
 
     (
@@ -182,7 +184,9 @@ async def test_create_deployment_call_raw_supports_seed_0(
     deployer = Deployer()
 
     raw_calldata = translate_constructor_args(
-        abi=constructor_with_arguments_abi, constructor_args=sample_calldata
+        abi=constructor_with_arguments_abi,
+        constructor_args=sample_calldata,
+        cairo_version=0,
     )
 
     expected_address = compute_address(

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract.py
@@ -26,6 +26,7 @@ def test_init():
             key_pair=KeyPair(12, 34),
             chain=StarknetChainId.SEPOLIA,
         ),
+        cairo_version=0,
     )
     # docs-end: init
 

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_in_multicall.py
@@ -23,7 +23,9 @@ async def test_deploying_in_multicall(account, map_class_hash, map_compiled_cont
     # docs: start
 
     # Address of the `map` contract is known here, so we can create its instance!
-    map_contract = Contract(address=address, abi=map_abi, provider=account)
+    map_contract = Contract(
+        address=address, abi=map_abi, provider=account, cairo_version=0
+    )
 
     # And now we can prepare a call
     put_call = map_contract.functions["put"].prepare_invoke_v1(key=10, value=20)

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -56,6 +56,7 @@ async def test_deploying_with_udc(
     deploy_call, address = deployer.create_contract_deployment(
         class_hash=contract_with_constructor_class_hash,
         abi=contract_with_constructor_abi,
+        cairo_version=0,
         calldata={
             "single_value": 10,
             "tuple": (1, (2, 3)),
@@ -77,6 +78,7 @@ async def test_deploying_with_udc(
             "arr": [1],
             "dict": {"value": 12, "nested_struct": {"value": 99}},
         },
+        cairo_version=0,
     )
     # docs: start
     # Or signed and send with an account

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -32,7 +32,7 @@ async def test_using_existing_contracts(account, erc20_contract):
     address = "0x00178130dd6286a9a0e031e4c73b2bd04ffa92804264a25c1c08c1612559f458"
 
     # When ABI is known statically just use the Contract constructor
-    contract = Contract(address=address, abi=abi, provider=account)
+    contract = Contract(address=address, abi=abi, provider=account, cairo_version=0)
     # or if it is not known
     # Contract.from_address makes additional request to fetch the ABI
     # docs: end

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_contract.py
@@ -34,6 +34,7 @@ async def test_using_contract(account, map_contract):
         address=contract_address,
         abi=abi,
         provider=account,
+        cairo_version=0,
     )
 
     # All exposed functions are available at contract.functions.

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -238,6 +238,7 @@ def eth_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
         address=FEE_CONTRACT_ADDRESS,
         abi=fee_contract_abi,
         provider=account,
+        cairo_version=0,
     )
 
 
@@ -251,6 +252,7 @@ def strk_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
         address=STRK_FEE_CONTRACT_ADDRESS,
         abi=fee_contract_abi,
         provider=account,
+        cairo_version=0,
     )
 
 

--- a/starknet_py/utils/constructor_args_translator.py
+++ b/starknet_py/utils/constructor_args_translator.py
@@ -15,7 +15,7 @@ from starknet_py.serialization.factory import (
 
 
 def translate_constructor_args(
-    abi: List, constructor_args: Optional[Union[List, dict]], *, cairo_version: int = 0
+    abi: List, constructor_args: Optional[Union[List, dict]], *, cairo_version: int = 1
 ) -> List[int]:
     serializer = (
         _get_constructor_serializer_v1(abi)


### PR DESCRIPTION
Partial fix for #1271

## Introduced changes
Set the default `cairo_version` to 1 since Cairo 1 contracts are now the default. Otherwise, initializing a Cairo 1 contract without setting `cairo_version=1` throws a validation error.

##

- [x] This PR contains breaking changes

Cairo version now defaults to 1.

