### PR TITLE
Add `Dict` suffix to typed dict names

### DIFF
--- a/docs/api/typed_data.rst
+++ b/docs/api/typed_data.rst
@@ -20,6 +20,6 @@ Parameter
 StarkNetDomain
 --------------
 
-.. autoclass:: starknet_py.net.models.typed_data.StarkNetDomain
+.. autoclass:: starknet_py.net.models.typed_data.StarkNetDomainDict
     :members:
     :undoc-members:

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -36,7 +36,7 @@ from starknet_py.net.models.transaction import (
     InvokeV3,
     TypeAccountTransaction,
 )
-from starknet_py.net.models.typed_data import TypedData
+from starknet_py.net.models.typed_data import TypedDataDict
 from starknet_py.net.signer import BaseSigner
 from starknet_py.net.signer.stark_curve_signer import KeyPair, StarkCurveSigner
 from starknet_py.serialization.data_serializers.array_serializer import ArraySerializer
@@ -584,11 +584,11 @@ class Account(BaseAccount):
         )
         return await self._client.send_transaction(execute_transaction)
 
-    def sign_message(self, typed_data: TypedData) -> List[int]:
+    def sign_message(self, typed_data: TypedDataDict) -> List[int]:
         typed_data_dataclass = TypedDataDataclass.from_dict(typed_data)
         return self.signer.sign_message(typed_data_dataclass, self.address)
 
-    def verify_message(self, typed_data: TypedData, signature: List[int]) -> bool:
+    def verify_message(self, typed_data: TypedDataDict, signature: List[int]) -> bool:
         typed_data_dataclass = TypedDataDataclass.from_dict(typed_data)
         message_hash = typed_data_dataclass.message_hash(account_address=self.address)
         return verify_message_signature(message_hash, signature, self.signer.public_key)

--- a/starknet_py/net/account/base_account.py
+++ b/starknet_py/net/account/base_account.py
@@ -22,7 +22,7 @@ from starknet_py.net.models.transaction import (
     InvokeV3,
     TypeAccountTransaction,
 )
-from starknet_py.net.models.typed_data import TypedData
+from starknet_py.net.models.typed_data import TypedDataDict
 
 
 class BaseAccount(ABC):
@@ -314,7 +314,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    def sign_message(self, typed_data: TypedData) -> List[int]:
+    def sign_message(self, typed_data: TypedDataDict) -> List[int]:
         """
         Sign an TypedData TypedDict for off-chain usage with the Starknet private key and return the signature.
         This adds a message prefix, so it can't be interchanged with transactions.
@@ -324,7 +324,7 @@ class BaseAccount(ABC):
         """
 
     @abstractmethod
-    def verify_message(self, typed_data: TypedData, signature: List[int]) -> bool:
+    def verify_message(self, typed_data: TypedDataDict, signature: List[int]) -> bool:
         """
         Verify a signature of a TypedData dict on Starknet.
 

--- a/starknet_py/net/models/typed_data.py
+++ b/starknet_py/net/models/typed_data.py
@@ -5,7 +5,7 @@ TypedDict structures for TypedData
 from typing import Any, Dict, List, TypedDict, Union
 
 
-class Parameter(TypedDict):
+class ParameterDict(TypedDict):
     """
     TypedDict representing a Parameter object
     """
@@ -14,7 +14,7 @@ class Parameter(TypedDict):
     type: str
 
 
-class StarkNetDomain(TypedDict):
+class StarkNetDomainDict(TypedDict):
     """
     TypedDict representing a StarkNetDomain object
     """
@@ -24,12 +24,12 @@ class StarkNetDomain(TypedDict):
     chainId: Union[str, int]
 
 
-class TypedData(TypedDict):
+class TypedDataDict(TypedDict):
     """
     TypedDict representing a TypedData object
     """
 
-    types: Dict[str, List[Parameter]]
+    types: Dict[str, List[ParameterDict]]
     primaryType: str
-    domain: StarkNetDomain
+    domain: StarkNetDomainDict
     message: Dict[str, Any]

--- a/starknet_py/tests/e2e/docs/code_examples/test_account.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_account.py
@@ -9,7 +9,7 @@ from starknet_py.net.account.account import Account
 from starknet_py.net.client_models import Call
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.models import StarknetChainId
-from starknet_py.net.models.typed_data import TypedData
+from starknet_py.net.models.typed_data import TypedDataDict
 from starknet_py.net.signer.stark_curve_signer import KeyPair
 
 
@@ -66,7 +66,7 @@ async def test_get_balance(account):
 def test_sign_message(account):
     # docs-start: sign_message
     signature = account.sign_message(
-        typed_data=TypedData(
+        typed_data=TypedDataDict(
             types={
                 "StarkNetDomain": [
                     {"name": "name", "type": "felt"},
@@ -88,7 +88,7 @@ def test_sign_message(account):
 def test_verify_message(account):
     # docs-start: verify_message
     is_correct = account.verify_message(
-        typed_data=TypedData(
+        typed_data=TypedDataDict(
             types={
                 "StarkNetDomain": [
                     {"name": "name", "type": "felt"},

--- a/starknet_py/tests/e2e/fixtures/misc.py
+++ b/starknet_py/tests/e2e/fixtures/misc.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pytest
 
 from starknet_py.net.full_node_client import FullNodeClient
-from starknet_py.net.models.typed_data import TypedData
+from starknet_py.net.models.typed_data import TypedDataDict
 from starknet_py.tests.e2e.fixtures.constants import (
     CONTRACTS_V1_ARTIFACTS_MAP,
     CONTRACTS_V1_COMPILED,
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
         "typed_data_struct_array_example.json",
     ],
 )
-def typed_data(request) -> TypedData:
+def typed_data(request) -> TypedDataDict:
     """
     Returns TypedData dictionary example.
     """

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -6,8 +6,7 @@ from marshmallow import Schema, fields, post_load
 from starknet_py.cairo.felt import encode_shortstring
 from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.hash.utils import compute_hash_on_elements
-from starknet_py.net.models.typed_data import StarkNetDomain
-from starknet_py.net.models.typed_data import TypedData as TypedDataDict
+from starknet_py.net.models.typed_data import StarkNetDomainDict, TypedDataDict
 
 
 @dataclass(frozen=True)
@@ -28,7 +27,7 @@ class TypedData:
 
     types: Dict[str, List[Parameter]]
     primary_type: str
-    domain: StarkNetDomain
+    domain: StarkNetDomainDict
     message: dict
 
     @staticmethod


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1364 


## Introduced changes
<!-- A brief description of the changes -->

Rename typed dicts in `models/typed_data.py` - add `Dict` suffix to their names


##

- [x] This PR contains breaking changes
- Rename `Parameter` -> `ParameterDict`
- Rename `StarkNetDomain` -> `StarknetDomain`
- Rename `TypedData` -> `TypedDataDict`
<!-- List of all breaking changes -->


