### PR TITLE
Support `u128`, `i128`, `timestamp` in `TypedData`

### DIFF
--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -116,7 +116,7 @@ def _encode_value_v1(
 
 def _encode_value_v0(
     basic_type: BasicType,
-    value: Union[int, str, dict, list],
+    value: Union[int, str],
 ) -> Optional[int]:
     if basic_type in (
         BasicType.FELT,

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -408,22 +408,16 @@ def encode_u128(value: Union[str, int]) -> int:
     def is_in_range(n: int):
         return 0 <= n < 2**128
 
-    if isinstance(value, int):
-        if is_in_range(value):
-            return value
-        raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
-
-    if isinstance(value, str):
-        if value.startswith("0x"):
-            int_value = int(value, 16)
-        elif is_digit_string(value):
-            int_value = int(value)
-        else:
-            raise ValueError(f"Value [{value}] is not a valid number.")
-
-        if int_value is not None and is_in_range(int_value):
-            return int_value
-
+    if isinstance(value, str) and value.startswith("0x"):
+        int_value = int(value, 16)
+    elif isinstance(value, str) and is_digit_string(value):
+        int_value = int(value)
+    elif isinstance(value, int):
+        int_value = value
+    else:
+        raise ValueError(f"Value [{value}] is not a valid number.")
+    if is_in_range(int_value):
+        return int_value
     raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
 
 
@@ -431,27 +425,21 @@ def encode_i128(value: Union[str, int]) -> int:
     def is_in_range(n: int):
         return (n < 2**127) or (n >= (FIELD_PRIME - (2**127)))
 
-    int_value = None
-
-    if isinstance(value, int):
+    if isinstance(value, str) and value.startswith("0x"):
+        int_value = int(value, 16)
+    elif isinstance(value, str) and is_digit_string(value, True):
+        int_value = int(value)
+    elif isinstance(value, int):
         int_value = value
-
-    elif isinstance(value, str):
-        if value.startswith("0x"):
-            int_value = int(value, 16)
-        elif is_digit_string(value, True):
-            int_value = int(value)
-        else:
-            raise ValueError(f"Value [{value}] is not a valid number.")
-
-    if int_value is not None:
-        if abs(int_value) >= FIELD_PRIME:
-            raise ValueError(
-                f"Values outside the range (-FIELD_PRIME, FIELD_PRIME) are not allowed, [{value}] given."
-            )
-        int_value %= FIELD_PRIME
-        if is_in_range(int_value):
-            return int_value
+    else:
+        raise ValueError(f"Value [{value}] is not a valid number.")
+    if abs(int_value) >= FIELD_PRIME:
+        raise ValueError(
+            f"Values outside the range (-FIELD_PRIME, FIELD_PRIME) are not allowed, [{value}] given."
+        )
+    int_value %= FIELD_PRIME
+    if is_in_range(int_value):
+        return int_value
 
     raise ValueError(f"Value [{value}] is out of range for '{BasicType.I128}'.")
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -199,8 +199,8 @@ class TypedData:
             return encode_u128(value)
 
         if (basic_type, self.domain.resolved_revision) == (
-                BasicType.I128,
-                Revision.V1,
+            BasicType.I128,
+            Revision.V1,
         ) and isinstance(value, (int, str)):
             return encode_i128(value)
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -400,7 +400,13 @@ def encode_u128(value: Union[str, int]) -> int:
         int_value = None
 
         if value.startswith("0x"):
-            int_value = int(value, 16)
+            try:
+                int_value = int(value, 16)
+            except ValueError:
+                raise ValueError(
+                    f"Value [{value}] is out of range for '{BasicType.U128}'."
+                )
+
         elif is_digit_string(value):
             int_value = int(value)
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -400,13 +400,7 @@ def encode_u128(value: Union[str, int]) -> int:
         int_value = None
 
         if value.startswith("0x"):
-            try:
-                int_value = int(value, 16)
-            except ValueError:
-                raise ValueError(
-                    f"Value [{value}] is out of range for '{BasicType.U128}'."
-                )
-
+            int_value = int(value, 16)
         elif is_digit_string(value):
             int_value = int(value)
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -414,8 +414,6 @@ def encode_u128(value: Union[str, int]) -> int:
         raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
 
     if isinstance(value, str):
-        int_value = None
-
         if value.startswith("0x"):
             int_value = int(value, 16)
         elif is_digit_string(value):

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -169,7 +169,6 @@ class TypedData:
     def _is_struct(self, type_name: str) -> bool:
         return type_name in self.types
 
-    # pylint: disable=too-many-return-statements
     def _encode_value(
         self,
         type_name: str,

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -91,9 +91,7 @@ class BasicType(Enum):
     TIMESTAMP = "timestamp"
 
 
-def _encode_value_v1(
-    basic_type: BasicType, value: Union[int, str]
-) -> Optional[int]:
+def _encode_value_v1(basic_type: BasicType, value: Union[int, str]) -> Optional[int]:
     if basic_type in (
         BasicType.FELT,
         BasicType.SHORT_STRING,
@@ -188,9 +186,14 @@ class TypedData:
 
         basic_type = BasicType(type_name)
 
-        if self.domain.resolved_revision == Revision.V0:
+        encoded_value = None
+        if self.domain.resolved_revision == Revision.V0 and isinstance(
+            value, (str, int)
+        ):
             encoded_value = _encode_value_v0(basic_type, value)
-        else:
+        elif self.domain.resolved_revision == Revision.V1 and isinstance(
+            value, (str, int)
+        ):
             encoded_value = _encode_value_v1(basic_type, value)
 
         if encoded_value is not None:

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -92,7 +92,7 @@ class BasicType(Enum):
 
 
 def _encode_value_v1(
-    basic_type: BasicType, value: Union[int, str, dict, list]
+    basic_type: BasicType, value: Union[int, str]
 ) -> Optional[int]:
     if basic_type in (
         BasicType.FELT,

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -416,6 +416,7 @@ def encode_u128(value: Union[str, int]) -> int:
         int_value = value
     else:
         raise ValueError(f"Value [{value}] is not a valid number.")
+
     if is_in_range(int_value):
         return int_value
     raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
@@ -433,14 +434,15 @@ def encode_i128(value: Union[str, int]) -> int:
         int_value = value
     else:
         raise ValueError(f"Value [{value}] is not a valid number.")
+
     if abs(int_value) >= FIELD_PRIME:
         raise ValueError(
             f"Values outside the range (-FIELD_PRIME, FIELD_PRIME) are not allowed, [{value}] given."
         )
     int_value %= FIELD_PRIME
+
     if is_in_range(int_value):
         return int_value
-
     raise ValueError(f"Value [{value}] is out of range for '{BasicType.I128}'.")
 
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -159,10 +159,10 @@ class TypedData:
 
     # pylint: disable=too-many-return-statements
     def _encode_value(
-            self,
-            type_name: str,
-            value: Union[int, str, dict, list],
-            context: Optional[TypeContext] = None,
+        self,
+        type_name: str,
+        value: Union[int, str, dict, list],
+        context: Optional[TypeContext] = None,
     ) -> int:
         if isinstance(value, Revision):
             value = value.value
@@ -200,8 +200,8 @@ class TypedData:
             return encode_u128(value)
 
         if (basic_type, self.domain.resolved_revision) == (
-                BasicType.I128,
-                Revision.V1,
+            BasicType.I128,
+            Revision.V1,
         ) and isinstance(value, Union[int, str]):
             return encode_i128(value)
 
@@ -242,11 +242,11 @@ class TypedData:
             parameter for type_name in self.types for parameter in self.types[type_name]
         ]
         referenced_types = [
-                               ref_type.contains
-                               if ref_type.contains is not None
-                               else strip_pointer(ref_type.type)
-                               for ref_type in referenced_types
-                           ] + [self.domain.separator_name, self.primary_type]
+            ref_type.contains
+            if ref_type.contains is not None
+            else strip_pointer(ref_type.type)
+            for ref_type in referenced_types
+        ] + [self.domain.separator_name, self.primary_type]
 
         for type_name in self.types:
             if type_name in basic_types:
@@ -422,7 +422,7 @@ def is_digit_string(s: str, signed=False) -> bool:
 
 def encode_u128(value: Union[str, int]) -> int:
     def is_in_range(n: int):
-        return 0 <= n < 2 ** 128
+        return 0 <= n < 2**128
 
     int_value = None
 
@@ -444,7 +444,7 @@ def encode_u128(value: Union[str, int]) -> int:
 
 def encode_i128(value: Union[str, int]) -> int:
     def is_in_range(n: int):
-        return (n < 2 ** 127) or (n >= (FIELD_PRIME - (2 ** 127)))
+        return (n < 2**127) or (n >= (FIELD_PRIME - (2**127)))
 
     int_value = None
 

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -450,6 +450,9 @@ def _get_basic_type_names(revision: Revision) -> List[str]:
         BasicType.SHORT_STRING,
         BasicType.CONTRACT_ADDRESS,
         BasicType.CLASS_HASH,
+        BasicType.U128,
+        BasicType.I128,
+        BasicType.TIMESTAMP,
     ]
 
     basic_types = basic_types_v0 if revision == Revision.V0 else basic_types_v1

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -424,19 +424,20 @@ def encode_u128(value: Union[str, int]) -> int:
     def is_in_range(n: int):
         return 0 <= n < 2**128
 
-    int_value = None
+    if isinstance(value, int):
+        if is_in_range(value):
+            return value
+        raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
 
-    if isinstance(value, int) and is_in_range(value):
-        int_value = value
+    if isinstance(value, str):
+        int_value = None
 
-    if isinstance(value, str) and is_digit_string(str(value)):
-        int_value = int(value)
+        if value.startswith("0x"):
+            int_value = int(value, 16)
+        elif is_digit_string(value):
+            int_value = int(value)
 
-    if isinstance(value, str) and value[:2] == "0x":
-        int_value = int(value, 16)
-
-    if int_value is not None:
-        if is_in_range(int_value):
+        if int_value is not None and is_in_range(int_value):
             return int_value
 
     raise ValueError(f"Value [{value}] is out of range for '{BasicType.U128}'.")
@@ -451,11 +452,11 @@ def encode_i128(value: Union[str, int]) -> int:
     if isinstance(value, int):
         int_value = value
 
-    if isinstance(value, str) and is_digit_string(value, True):
-        int_value = int(value)
-
-    if isinstance(value, str) and value[:2] == "0x":
-        int_value = int(value, 16)
+    elif isinstance(value, str):
+        if value.startswith("0x"):
+            int_value = int(value, 16)
+        elif is_digit_string(value, True):
+            int_value = int(value)
 
     if int_value is not None:
         if abs(int_value) >= FIELD_PRIME:

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -420,6 +420,8 @@ def encode_u128(value: Union[str, int]) -> int:
             int_value = int(value, 16)
         elif is_digit_string(value):
             int_value = int(value)
+        else:
+            raise ValueError(f"Value [{value}] is not a valid number.")
 
         if int_value is not None and is_in_range(int_value):
             return int_value
@@ -441,6 +443,8 @@ def encode_i128(value: Union[str, int]) -> int:
             int_value = int(value, 16)
         elif is_digit_string(value, True):
             int_value = int(value)
+        else:
+            raise ValueError(f"Value [{value}] is not a valid number.")
 
     if int_value is not None:
         if abs(int_value) >= FIELD_PRIME:

--- a/starknet_py/utils/typed_data_test.py
+++ b/starknet_py/utils/typed_data_test.py
@@ -14,6 +14,8 @@ from starknet_py.utils.typed_data import (
     Domain,
     Parameter,
     TypedData,
+    encode_i128,
+    encode_u128,
     get_hex,
     unwrap_bool,
 )
@@ -312,3 +314,71 @@ def test_unwrap_bool(value: Union[bool, str, int], expected: int):
 def test_encode_invalid_bool(value: Union[bool, str, int]):
     with pytest.raises(ValueError, match=fr"Expected boolean value, got \[{value}\]."):
         unwrap_bool(value)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, "0x0"),
+        (1, "0x1"),
+        (1000000, "0xf4240"),
+        ("0x0", "0x0"),
+        ("0x1", "0x1"),
+        ("0x64", "0x64"),
+        (2 ** 128 - 1, "0xffffffffffffffffffffffffffffffff"),
+    ]
+)
+def test_encode_u128(value: Union[str, int], expected: str):
+    assert hex(encode_u128(value)) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        -1,
+        "-1",
+        "example",
+        "0xwrong",
+        2 ** 128,
+        hex(2 ** 128)
+    ]
+)
+def test_encode_invalid_u128(value: Union[str, int]):
+    with pytest.raises(ValueError):
+        encode_u128(value)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, 0),
+        (1, 1),
+        (1000000, 1000000),
+        ("0x0", 0),
+        ("0x1", 1),
+        ("0x64", 100),
+        (2 ** 127 - 1, 2 ** 127 - 1),
+        (-1, 3618502788666131213697322783095070105623107215331596699973092056135872020480),
+        (-1000000, 3618502788666131213697322783095070105623107215331596699973092056135871020481),
+        (-(2 ** 127), 3618502788666131213697322783095070105452966031871127468241404752419987914753),
+    ]
+)
+def test_encode_i128(value: Union[str, int], expected: str):
+    assert encode_i128(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "example",
+        "0xwrong",
+        -2 ** 127 - 1,
+        2 ** 127,
+        str(-2 ** 127 - 1),
+        str(2 ** 127),
+
+    ]
+)
+def test_encode_invalid_i128(value: Union[str, int]):
+    with pytest.raises(ValueError):
+        encode_i128(value)

--- a/starknet_py/utils/typed_data_test.py
+++ b/starknet_py/utils/typed_data_test.py
@@ -11,6 +11,7 @@ import pytest
 from starknet_py.net.models.typed_data import Revision
 from starknet_py.tests.e2e.fixtures.constants import TYPED_DATA_DIR
 from starknet_py.utils.typed_data import (
+    BasicType,
     Domain,
     Parameter,
     TypedData,
@@ -348,7 +349,7 @@ def test_encode_u128(value: Union[str, int], expected: str):
     ]
 )
 def test_encode_invalid_u128(value: Union[str, int]):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=rf"Value \[{value}\] is out of range for '{BasicType.U128}'."):
         encode_u128(value)
 
 

--- a/starknet_py/utils/typed_data_test.py
+++ b/starknet_py/utils/typed_data_test.py
@@ -11,7 +11,6 @@ import pytest
 from starknet_py.net.models.typed_data import Revision
 from starknet_py.tests.e2e.fixtures.constants import TYPED_DATA_DIR
 from starknet_py.utils.typed_data import (
-    BasicType,
     Domain,
     Parameter,
     TypedData,
@@ -349,7 +348,7 @@ def test_encode_u128(value: Union[str, int], expected: str):
     ]
 )
 def test_encode_invalid_u128(value: Union[str, int]):
-    with pytest.raises(ValueError, match=rf"Value \[{value}\] is out of range for '{BasicType.U128}'."):
+    with pytest.raises(ValueError):
         encode_u128(value)
 
 

--- a/starknet_py/utils/typed_data_test.py
+++ b/starknet_py/utils/typed_data_test.py
@@ -319,17 +319,17 @@ def test_encode_invalid_bool(value: Union[bool, str, int]):
 @pytest.mark.parametrize(
     "value, expected",
     [
-        (0, "0x0"),
-        (1, "0x1"),
-        (1000000, "0xf4240"),
-        ("0x0", "0x0"),
-        ("0x1", "0x1"),
-        ("0x64", "0x64"),
-        (2 ** 128 - 1, "0xffffffffffffffffffffffffffffffff"),
+        (0, 0),
+        (1, 1),
+        (1000000, 1000000),
+        ("0x0", 0),
+        ("0x1", 1),
+        ("0x64", 100),
+        (2 ** 128 - 1, 2 ** 128 - 1),
     ]
 )
 def test_encode_u128(value: Union[str, int], expected: str):
-    assert hex(encode_u128(value)) == expected
+    assert encode_u128(value) == expected
 
 
 @pytest.mark.parametrize(

--- a/starknet_py/utils/typed_data_test.py
+++ b/starknet_py/utils/typed_data_test.py
@@ -337,10 +337,14 @@ def test_encode_u128(value: Union[str, int], expected: str):
     [
         -1,
         "-1",
+        1.23,
+        -1.23,
+        "1.23",
+        "-1.23",
         "example",
         "0xwrong",
         2 ** 128,
-        hex(2 ** 128)
+        hex(2 ** 128),
     ]
 )
 def test_encode_invalid_u128(value: Union[str, int]):
@@ -372,6 +376,10 @@ def test_encode_i128(value: Union[str, int], expected: str):
     [
         "example",
         "0xwrong",
+        1.23,
+        -1.23,
+        "1.23",
+        "-1.23",
         -2 ** 127 - 1,
         2 ** 127,
         str(-2 ** 127 - 1),


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Relates #1353 


## Introduced changes
<!-- A brief description of the changes -->


Support `u128`, `i128`, `timestamp` basic types
- Add `encode_u128()`, `encode_i128()`
- Add `u128` and `i128` encoding tests

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


