### PR TITLE
Change github workflows rust toolchain version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -299,7 +299,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
-          toolchain: 1.79.0
+          toolchain: 1.79.0  # Doesn't work with "stable"
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -435,7 +435,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
-          toolchain: 1.79.0
+          toolchain: 1.79.0 # Doesn't work with "stable"
 
       - name: Download contracts
         uses: actions/download-artifact@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -299,7 +299,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
-          toolchain: stable
+          toolchain: 1.79.0
 
       - name: Download contracts
         uses: actions/download-artifact@v3
@@ -435,7 +435,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@dc6353516c68da0f06325f42ad880f76a5e77ec9
         with:
-          toolchain: stable
+          toolchain: 1.79.0
 
       - name: Download contracts
         uses: actions/download-artifact@v3

--- a/starknet_py/tests/e2e/mock/compile_contracts.sh
+++ b/starknet_py/tests/e2e/mock/compile_contracts.sh
@@ -39,6 +39,8 @@ compile_contracts_v0() {
     CONTRACTS_DIRECTORY="$MOCK_DIRECTORY/contracts"
     CONTRACTS_COMPILED_DIRECTORY="$MOCK_DIRECTORY/contracts_compiled"
 
+    mkdir -p "$CONTRACTS_COMPILED_DIRECTORY"
+
     # delete all artifacts except precompiled ones
     find "$CONTRACTS_COMPILED_DIRECTORY" -maxdepth 1 -type f -delete
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

Changes rust toolchain version in github actions to "1.79.0" because "stable" does not work.

Reference to working state - [gh actions](https://github.com/kkawula/starknet.py/actions/runs/10198910130/job/28214804543) 

## Introduced changes
<!-- A brief description of the changes -->


- Fixed installation of devnet on windows
- Fixed compiling cairo 0 contracts through  `compile_contracts.sh`


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


