### PR TITLE
Automatic py-pi package upload

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,9 @@
 name: Build wheels
-on: workflow_dispatch
+
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build_sdist:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Relates #1399 


## Introduced changes
<!-- A brief description of the changes -->

- Automatically run the `Build wheels` action responsible for uploading py-pi package when new tag is pushed (same as in [JVM workflow](https://github.com/software-mansion/starknet-jvm/blob/main/.github/workflows/build-and-publish.yml))
##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


