### PR TITLE
Add BoundedInt terminal to grammar definition for parsing ABI

### DIFF
--- a/starknet_py/abi/v2/parser_test.py
+++ b/starknet_py/abi/v2/parser_test.py
@@ -1,8 +1,10 @@
 import json
+from typing import cast
 
 import pytest
 
 from starknet_py.abi.v2 import Abi, AbiParser
+from starknet_py.cairo.data_types import UintType
 from starknet_py.tests.e2e.fixtures.misc import ContractVersion, load_contract
 
 
@@ -31,3 +33,40 @@ def test_abi_parse(contract_name):
     parsed_abi = parser.parse()
 
     assert isinstance(parsed_abi, Abi)
+
+
+def test_bounded_int_parse():
+    abi_list = [
+        {
+            "type": "struct",
+            "name": "core::circuit::u384",
+            "members": [
+                {
+                    "name": "limb0",
+                    "type": "core::internal::BoundedInt::<0, 79228162514264337593543950335>",
+                },
+                {
+                    "name": "limb1",
+                    "type": "core::internal::BoundedInt::<0, 79228162514264337593543950335>",
+                },
+                {
+                    "name": "limb2",
+                    "type": "core::internal::BoundedInt::<0, 79228162514264337593543950335>",
+                },
+                {
+                    "name": "limb3",
+                    "type": "core::internal::BoundedInt::<0, 79228162514264337593543950335>",
+                },
+            ],
+        }
+    ]
+
+    parser = AbiParser(abi_list)
+    parsed_abi = parser.parse()
+
+    assert isinstance(parsed_abi, Abi)
+
+    uint = cast(
+        UintType, parsed_abi.defined_structures["core::circuit::u384"].types["limb0"]
+    )
+    assert uint.bits == 96

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -1,3 +1,4 @@
+from math import log2
 from typing import Any, List, Optional
 
 import lark
@@ -25,6 +26,7 @@ ABI_EBNF = """
         | type_felt
         | type_bytes
         | type_uint
+        | type_bounded_int
         | type_contract_address
         | type_class_hash
         | type_storage_address
@@ -39,7 +41,8 @@ ABI_EBNF = """
     type_felt: "core::felt252"
     type_bytes: "core::bytes_31::bytes31"
     type_bool: "core::bool"
-    type_uint: "core::integer::u" INT | "core::internal::BoundedInt::<" INT "," WS? INT ">"
+    type_uint: "core::integer::u" INT
+    type_bounded_int: "core::internal::BoundedInt::<" INT "," WS? INT ">"
     type_contract_address: "core::starknet::contract_address::ContractAddress"
     type_class_hash: "core::starknet::class_hash::ClassHash"
     type_storage_address: "core::starknet::storage_access::StorageAddress"
@@ -108,6 +111,17 @@ class ParserTransformer(Transformer):
         Uint type contains information about its size. It is present in the value[0].
         """
         return UintType(int(value[0]))
+
+    def type_bounded_int(self, value: List[Token]) -> UintType:
+        """
+        BoundedInt Uint type contains information about its ranges. They are present in the value[0] and value[2].
+        """
+        if value[0] != "0":
+            raise ValueError("BoundedInt should start from 0.")
+
+        bits = log2(int(value[2]))
+
+        return UintType(int(bits))
 
     def type_unit(self, _value: List[Any]) -> UnitType:
         """

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -119,7 +119,7 @@ class ParserTransformer(Transformer):
         if value[0] != "0":
             raise ValueError("BoundedInt should start from 0.")
 
-        bits = log2(int(value[2]))
+        bits = log2(int(value[2]) + 1)
 
         return UintType(int(bits))
 

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -39,7 +39,7 @@ ABI_EBNF = """
     type_felt: "core::felt252"
     type_bytes: "core::bytes_31::bytes31"
     type_bool: "core::bool"
-    type_uint: "core::integer::u" INT
+    type_uint: "core::integer::u" INT | "core::internal::BoundedInt::<" INT "," WS? INT ">"
     type_contract_address: "core::starknet::contract_address::ContractAddress"
     type_class_hash: "core::starknet::class_hash::ClassHash"
     type_storage_address: "core::starknet::storage_access::StorageAddress"

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -473,6 +473,7 @@ async def test_deploy_account_v1(client, deploy_account_details_factory, map_con
         key_pair=key_pair,
         client=client,
         max_fee=int(1e16),
+        constructor_calldata=[key_pair.public_key]
     )
     await deploy_result.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -473,7 +473,6 @@ async def test_deploy_account_v1(client, deploy_account_details_factory, map_con
         key_pair=key_pair,
         client=client,
         max_fee=int(1e16),
-        constructor_calldata=[key_pair.public_key]
     )
     await deploy_result.wait_for_acceptance()
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

BoundedInt was [refactored](https://github.com/starkware-libs/cairo/blob/95fd09bab0cc44c4f101987c62491454890e3ba4/corelib/src/circuit.cairo#L43
) in new release of cairo 2.7.0 and now u96 abi is generated new way

## Introduced changes
<!-- A brief description of the changes -->


- Updated grammar definition for parsing ABI


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


