### PR TITLE
Restructure fixtures in tests

### DIFF
--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -733,7 +733,7 @@ async def test_sign_transaction_custom_nonce(account, hello_starknet_class_hash)
 
 
 @pytest.mark.asyncio
-async def test_argent_cairo1_account_deploy(
+async def test_argent_account_deploy(
     client,
     argent_account_class_hash,
     deploy_account_details_factory,
@@ -765,7 +765,7 @@ async def test_argent_cairo1_account_deploy(
 
 
 @pytest.mark.asyncio
-async def test_argent_cairo1_account_execute(
+async def test_argent_account_execute(
     deployed_balance_contract,
     argent_account: BaseAccount,
 ):

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -735,11 +735,11 @@ async def test_sign_transaction_custom_nonce(account, hello_starknet_class_hash)
 @pytest.mark.asyncio
 async def test_argent_cairo1_account_deploy(
     client,
-    argent_cairo1_account_class_hash,
+    argent_account_class_hash,
     deploy_account_details_factory,
 ):
     address, key_pair, salt, class_hash = await deploy_account_details_factory.get(
-        class_hash=argent_cairo1_account_class_hash, argent_calldata=True
+        class_hash=argent_account_class_hash, argent_calldata=True
     )
 
     deploy_result = await Account.deploy_account_v1(

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -703,8 +703,8 @@ async def test_sign_deploy_account_v1_for_fee_estimation(
 
 
 @pytest.mark.asyncio
-async def test_sign_transaction_custom_nonce(account, cairo1_hello_starknet_class_hash):
-    deployment = Deployer().create_contract_deployment(cairo1_hello_starknet_class_hash)
+async def test_sign_transaction_custom_nonce(account, hello_starknet_class_hash):
+    deployment = Deployer().create_contract_deployment(hello_starknet_class_hash)
     deploy_tx = await account.sign_invoke_v1(deployment.call, max_fee=MAX_FEE)
 
     new_balance = 30

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -767,7 +767,7 @@ async def test_argent_cairo1_account_deploy(
 @pytest.mark.asyncio
 async def test_argent_cairo1_account_execute(
     deployed_balance_contract,
-    argent_cairo1_account: BaseAccount,
+    argent_account: BaseAccount,
 ):
     # verify that initial balance is 0
     get_balance_call = Call(
@@ -775,7 +775,7 @@ async def test_argent_cairo1_account_execute(
         selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
-    get_balance = await argent_cairo1_account.client.call_contract(
+    get_balance = await argent_account.client.call_contract(
         call=get_balance_call, block_number="latest"
     )
 
@@ -787,11 +787,11 @@ async def test_argent_cairo1_account_execute(
         selector=get_selector_from_name("increase_balance"),
         calldata=[value],
     )
-    execute = await argent_cairo1_account.execute_v1(
+    execute = await argent_account.execute_v1(
         calls=increase_balance_by_20_call, max_fee=MAX_FEE
     )
-    await argent_cairo1_account.client.wait_for_tx(tx_hash=execute.transaction_hash)
-    receipt = await argent_cairo1_account.client.get_transaction_receipt(
+    await argent_account.client.wait_for_tx(tx_hash=execute.transaction_hash)
+    receipt = await argent_account.client.get_transaction_receipt(
         tx_hash=execute.transaction_hash
     )
 
@@ -803,7 +803,7 @@ async def test_argent_cairo1_account_execute(
         selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
-    get_balance = await argent_cairo1_account.client.call_contract(
+    get_balance = await argent_account.client.call_contract(
         call=get_balance_call, block_number="latest"
     )
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -524,9 +524,7 @@ async def test_state_update_deployed_contracts(
 
 
 @pytest.mark.asyncio
-async def test_get_class_by_hash_sierra_program(
-    client, hello_starknet_class_hash: int
-):
+async def test_get_class_by_hash_sierra_program(client, hello_starknet_class_hash: int):
     contract_class = await client.get_class_by_hash(
         class_hash=hello_starknet_class_hash
     )
@@ -592,7 +590,7 @@ async def test_get_block_with_declare_v2(
 @pytest.mark.asyncio
 async def test_get_new_state_update(
     client,
-        hello_starknet_class_hash: int,
+    hello_starknet_class_hash: int,
     declare_v2_hello_starknet: DeclareV2,
     block_with_declare_v2_number: int,
 ):

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -543,10 +543,10 @@ async def test_get_class_by_hash_sierra_program(
 @pytest.mark.asyncio
 async def test_get_declare_v2_transaction(
     client,
-    cairo1_hello_starknet_class_hash_tx_hash: Tuple[int, int],
+        hello_starknet_class_hash_tx_hash,
     declare_v2_hello_starknet: DeclareV2,
 ):
-    (class_hash, tx_hash) = cairo1_hello_starknet_class_hash_tx_hash
+    (class_hash, tx_hash) = hello_starknet_class_hash_tx_hash
 
     transaction = await client.get_transaction(tx_hash=tx_hash)
 
@@ -566,11 +566,11 @@ async def test_get_declare_v2_transaction(
 @pytest.mark.asyncio
 async def test_get_block_with_declare_v2(
     client,
-    cairo1_hello_starknet_class_hash_tx_hash: Tuple[int, int],
+        hello_starknet_class_hash_tx_hash,
     declare_v2_hello_starknet: DeclareV2,
     block_with_declare_v2_number: int,
 ):
-    (class_hash, tx_hash) = cairo1_hello_starknet_class_hash_tx_hash
+    (class_hash, tx_hash) = hello_starknet_class_hash_tx_hash
 
     block = await client.get_block(block_number=block_with_declare_v2_number)
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -1,5 +1,4 @@
 # pylint: disable=too-many-arguments
-from typing import Tuple
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -526,10 +525,10 @@ async def test_state_update_deployed_contracts(
 
 @pytest.mark.asyncio
 async def test_get_class_by_hash_sierra_program(
-    client, cairo1_hello_starknet_class_hash: int
+    client, hello_starknet_class_hash: int
 ):
     contract_class = await client.get_class_by_hash(
-        class_hash=cairo1_hello_starknet_class_hash
+        class_hash=hello_starknet_class_hash
     )
 
     assert isinstance(contract_class.parsed_abi, list)
@@ -543,7 +542,7 @@ async def test_get_class_by_hash_sierra_program(
 @pytest.mark.asyncio
 async def test_get_declare_v2_transaction(
     client,
-        hello_starknet_class_hash_tx_hash,
+    hello_starknet_class_hash_tx_hash,
     declare_v2_hello_starknet: DeclareV2,
 ):
     (class_hash, tx_hash) = hello_starknet_class_hash_tx_hash
@@ -566,7 +565,7 @@ async def test_get_declare_v2_transaction(
 @pytest.mark.asyncio
 async def test_get_block_with_declare_v2(
     client,
-        hello_starknet_class_hash_tx_hash,
+    hello_starknet_class_hash_tx_hash,
     declare_v2_hello_starknet: DeclareV2,
     block_with_declare_v2_number: int,
 ):
@@ -593,7 +592,7 @@ async def test_get_block_with_declare_v2(
 @pytest.mark.asyncio
 async def test_get_new_state_update(
     client,
-    cairo1_hello_starknet_class_hash: int,
+        hello_starknet_class_hash: int,
     declare_v2_hello_starknet: DeclareV2,
     block_with_declare_v2_number: int,
 ):
@@ -603,7 +602,7 @@ async def test_get_new_state_update(
     assert state_update_first.state_diff.replaced_classes == []
     assert (
         DeclaredContractHash(
-            class_hash=cairo1_hello_starknet_class_hash,
+            class_hash=hello_starknet_class_hash,
             compiled_class_hash=declare_v2_hello_starknet.compiled_class_hash,
         )
         in state_update_first.state_diff.declared_classes

--- a/starknet_py/tests/e2e/client/fixtures/prepare_network.py
+++ b/starknet_py/tests/e2e/client/fixtures/prepare_network.py
@@ -15,14 +15,14 @@ from starknet_py.tests.e2e.client.fixtures.prepare_net_for_gateway_test import (
 )
 from starknet_py.tests.e2e.fixtures.accounts import AccountToBeDeployedDetailsFactory
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS_L1
-from starknet_py.tests.e2e.fixtures.contracts_v1 import declare_cairo1_contract
+from starknet_py.tests.e2e.fixtures.contracts_v1 import declare_contract
 from starknet_py.tests.e2e.fixtures.misc import load_contract
 
 
 @pytest_asyncio.fixture(scope="package")
 async def balance_class_and_transaction_hash(account: BaseAccount) -> Tuple[int, int]:
     contract = load_contract("Balance")
-    class_hash, transaction_hash = await declare_cairo1_contract(
+    class_hash, transaction_hash = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -68,11 +68,11 @@ def block_with_deploy_account_number(
 
 @pytest_asyncio.fixture(scope="package")
 async def hello_starknet_deploy_transaction_address(
-    account: Account, cairo1_hello_starknet_class_hash
+    account: Account, hello_starknet_class_hash
 ) -> int:
     deployer = Deployer()
     contract_deployment = deployer.create_contract_deployment_raw(
-        class_hash=cairo1_hello_starknet_class_hash
+        class_hash=hello_starknet_class_hash
     )
     deploy_invoke_transaction = await account.sign_invoke_v1(
         calls=contract_deployment.call, max_fee=MAX_FEE

--- a/starknet_py/tests/e2e/client/fixtures/transactions.py
+++ b/starknet_py/tests/e2e/client/fixtures/transactions.py
@@ -83,13 +83,9 @@ async def hello_starknet_deploy_transaction_address(
 
 
 @pytest_asyncio.fixture(scope="package")
-async def block_with_declare_v2_number(
-    cairo1_hello_starknet_tx_hash: int, client
-) -> int:
+async def block_with_declare_v2_number(hello_starknet_tx_hash: int, client) -> int:
     """
     Returns number of the block with DeclareV2 transaction
     """
-    declare_v2_receipt = await client.get_transaction_receipt(
-        cairo1_hello_starknet_tx_hash
-    )
+    declare_v2_receipt = await client.get_transaction_receipt(hello_starknet_tx_hash)
     return declare_v2_receipt.block_number

--- a/starknet_py/tests/e2e/client_devnet/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/client_devnet/fixtures/contracts.py
@@ -1,8 +1,10 @@
 import pytest_asyncio
 
 from starknet_py.contract import Contract
-from starknet_py.tests.e2e.fixtures.contracts import deploy_v1_contract
-from starknet_py.tests.e2e.fixtures.contracts_v1 import declare_cairo1_contract
+from starknet_py.tests.e2e.fixtures.contracts_v1 import (
+    declare_cairo1_contract,
+    deploy_v1_contract,
+)
 from starknet_py.tests.e2e.fixtures.misc import load_contract
 
 

--- a/starknet_py/tests/e2e/client_devnet/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/client_devnet/fixtures/contracts.py
@@ -2,7 +2,7 @@ import pytest_asyncio
 
 from starknet_py.contract import Contract
 from starknet_py.tests.e2e.fixtures.contracts_v1 import (
-    declare_cairo1_contract,
+    declare_contract,
     deploy_v1_contract,
 )
 from starknet_py.tests.e2e.fixtures.misc import load_contract
@@ -11,7 +11,7 @@ from starknet_py.tests.e2e.fixtures.misc import load_contract
 @pytest_asyncio.fixture(scope="package", name="f_string_contract_class_hash")
 async def declare_string_contract(account_forked_devnet) -> int:
     contract = load_contract("MyString")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account_forked_devnet, contract["sierra"], contract["casm"]
     )
     return class_hash
@@ -31,7 +31,7 @@ async def deploy_string_contract(
 @pytest_asyncio.fixture(scope="package", name="l1_l2_contract_class_hash")
 async def declare_l1_l2_contract(account) -> int:
     contract = load_contract("l1_l2")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
     return class_hash

--- a/starknet_py/tests/e2e/contract_interaction/deploy_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/deploy_test.py
@@ -94,14 +94,14 @@ async def test_throws_on_wrong_abi(account, cairo1_minimal_contract_class_hash: 
 
 
 @pytest.mark.asyncio
-async def test_deploy_contract_v1(account, cairo1_hello_starknet_class_hash: int):
+async def test_deploy_contract_v1(account, hello_starknet_class_hash: int):
     compiled_contract = load_contract("HelloStarknet")["sierra"]
     abi = create_sierra_compiled_contract(
         compiled_contract=compiled_contract
     ).parsed_abi
 
     deploy_result = await Contract.deploy_contract_v1(
-        class_hash=cairo1_hello_starknet_class_hash,
+        class_hash=hello_starknet_class_hash,
         account=account,
         abi=abi,
         max_fee=MAX_FEE,
@@ -120,4 +120,4 @@ async def test_deploy_contract_v1(account, cairo1_hello_starknet_class_hash: int
     class_hash = await account.client.get_class_hash_at(
         contract_address=contract.address
     )
-    assert class_hash == cairo1_hello_starknet_class_hash
+    assert class_hash == hello_starknet_class_hash

--- a/starknet_py/tests/e2e/contract_interaction/deploy_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/deploy_test.py
@@ -15,7 +15,7 @@ from starknet_py.tests.e2e.fixtures.misc import load_contract
 @pytest.mark.asyncio
 async def test_declare_deploy_v1(
     account,
-    cairo1_minimal_contract_class_hash: int,
+    minimal_contract_class_hash: int,
 ):
     compiled_contract = load_contract("MinimalContract")["sierra"]
 
@@ -23,7 +23,7 @@ async def test_declare_deploy_v1(
         _account=account,
         _client=account.client,
         _cairo_version=1,
-        class_hash=cairo1_minimal_contract_class_hash,
+        class_hash=minimal_contract_class_hash,
         compiled_contract=compiled_contract,
         hash=0,
         declare_transaction=Mock(spec=DeclareV2),
@@ -40,7 +40,7 @@ async def test_declare_deploy_v1(
 @pytest.mark.asyncio
 async def test_declare_deploy_v3(
     account,
-    cairo1_minimal_contract_class_hash: int,
+    minimal_contract_class_hash: int,
 ):
     compiled_contract = load_contract("MinimalContract")["sierra"]
 
@@ -48,7 +48,7 @@ async def test_declare_deploy_v3(
         _account=account,
         _client=account.client,
         _cairo_version=1,
-        class_hash=cairo1_minimal_contract_class_hash,
+        class_hash=minimal_contract_class_hash,
         compiled_contract=compiled_contract,
         hash=0,
         declare_transaction=Mock(spec=DeclareV2),
@@ -65,14 +65,14 @@ async def test_declare_deploy_v3(
 
 
 @pytest.mark.asyncio
-async def test_throws_on_wrong_abi(account, cairo1_minimal_contract_class_hash: int):
+async def test_throws_on_wrong_abi(account, minimal_contract_class_hash: int):
     compiled_contract = load_contract("MinimalContract")["sierra"]
 
     declare_result = DeclareResult(
         _account=account,
         _client=account.client,
         _cairo_version=1,
-        class_hash=cairo1_minimal_contract_class_hash,
+        class_hash=minimal_contract_class_hash,
         compiled_contract=compiled_contract,
         hash=0,
         declare_transaction=Mock(spec=DeclareV2),

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -61,11 +61,11 @@ async def test_general_v1_interaction(account, erc20_class_hash: int):
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
-async def test_serializing_struct(account, cairo1_token_bridge_class_hash: int):
+async def test_serializing_struct(account, token_bridge_class_hash: int):
     bridge = await deploy_v1_contract(
         account=account,
         contract_name="TokenBridge",
-        class_hash=cairo1_token_bridge_class_hash,
+        class_hash=token_bridge_class_hash,
         calldata={"governor_address": account.address},
     )
 

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -15,7 +15,7 @@ from starknet_py.tests.e2e.fixtures.contracts import deploy_v1_contract
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
-async def test_general_v1_interaction(account, cairo1_erc20_class_hash: int):
+async def test_general_v1_interaction(account, erc20_class_hash: int):
     calldata = {
         "name_": encode_shortstring("erc20_basic"),
         "symbol_": encode_shortstring("ERC20B"),
@@ -26,7 +26,7 @@ async def test_general_v1_interaction(account, cairo1_erc20_class_hash: int):
     erc20 = await deploy_v1_contract(
         account=account,
         contract_name="ERC20",
-        class_hash=cairo1_erc20_class_hash,
+        class_hash=erc20_class_hash,
         calldata=calldata,
     )
 
@@ -153,7 +153,7 @@ async def test_serializing_enum(account, cairo1_test_enum_class_hash: int):
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
-async def test_from_address_on_v1_contract(account, cairo1_erc20_class_hash: int):
+async def test_from_address_on_v1_contract(account, erc20_class_hash: int):
     calldata = {
         "name_": encode_shortstring("erc20_basic"),
         "symbol_": encode_shortstring("ERC20B"),
@@ -164,7 +164,7 @@ async def test_from_address_on_v1_contract(account, cairo1_erc20_class_hash: int
     erc20 = await deploy_v1_contract(
         account=account,
         contract_name="ERC20",
-        class_hash=cairo1_erc20_class_hash,
+        class_hash=erc20_class_hash,
         calldata=calldata,
     )
 

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -112,11 +112,11 @@ async def test_serializing_option(account, test_option_class_hash: int):
 
 
 @pytest.mark.asyncio
-async def test_serializing_enum(account, cairo1_test_enum_class_hash: int):
+async def test_serializing_enum(account, test_enum_class_hash: int):
     test_enum = await deploy_v1_contract(
         account=account,
         contract_name="TestEnum",
-        class_hash=cairo1_test_enum_class_hash,
+        class_hash=test_enum_class_hash,
     )
 
     (received_enum,) = await test_enum.functions["get_enum"].call()

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -77,11 +77,11 @@ async def test_serializing_struct(account, token_bridge_class_hash: int):
 
 
 @pytest.mark.asyncio
-async def test_serializing_option(account, cairo1_test_option_class_hash: int):
+async def test_serializing_option(account, test_option_class_hash: int):
     test_option = await deploy_v1_contract(
         account=account,
         contract_name="TestOption",
-        class_hash=cairo1_test_option_class_hash,
+        class_hash=test_option_class_hash,
     )
 
     (received_option,) = await test_option.functions["get_option_struct"].call()

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -5,7 +5,7 @@ import pytest
 from starknet_py.cairo.felt import decode_shortstring, encode_shortstring
 from starknet_py.contract import Contract
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
-from starknet_py.tests.e2e.fixtures.contracts import deploy_v1_contract
+from starknet_py.tests.e2e.fixtures.contracts_v1 import deploy_v1_contract
 
 # TODO (#1219): investigate why some of these tests fails for contracts_compiled_v1
 

--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -6,9 +6,9 @@ from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS_L1
 
 
 @pytest.mark.asyncio
-async def test_declare_v2_tx(cairo1_minimal_contract_class_hash: int):
-    assert isinstance(cairo1_minimal_contract_class_hash, int)
-    assert cairo1_minimal_contract_class_hash != 0
+async def test_declare_v2_tx(minimal_contract_class_hash: int):
+    assert isinstance(minimal_contract_class_hash, int)
+    assert minimal_contract_class_hash != 0
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract.py
@@ -134,14 +134,14 @@ async def test_deploy_contract_v1(account, class_hash):
 
 
 @pytest.mark.asyncio
-async def test_deploy_contract_v3(account, cairo1_hello_starknet_class_hash: int):
+async def test_deploy_contract_v3(account, hello_starknet_class_hash: int):
     compiled_contract = load_contract("HelloStarknet")["sierra"]
     # docs-start: deploy_contract_v3
     abi = create_sierra_compiled_contract(
         compiled_contract=compiled_contract
     ).parsed_abi
     # docs-end: deploy_contract_v3
-    class_hash = cairo1_hello_starknet_class_hash
+    class_hash = hello_starknet_class_hash
     # docs-start: deploy_contract_v3
     deploy_result = await Contract.deploy_contract_v3(
         class_hash=class_hash,
@@ -164,15 +164,15 @@ async def test_deploy_contract_v3(account, cairo1_hello_starknet_class_hash: int
     class_hash = await account.client.get_class_hash_at(
         contract_address=contract.address
     )
-    assert class_hash == cairo1_hello_starknet_class_hash
+    assert class_hash == hello_starknet_class_hash
 
 
 @pytest.mark.asyncio
 async def test_deploy_contract_v3_without_abi(
-    account, cairo1_hello_starknet_class_hash: int
+    account, hello_starknet_class_hash: int
 ):
     deploy_result = await Contract.deploy_contract_v3(
-        class_hash=cairo1_hello_starknet_class_hash,
+        class_hash=hello_starknet_class_hash,
         account=account,
         l1_resource_bounds=ResourceBounds(
             max_amount=int(1e5), max_price_per_unit=int(1e13)
@@ -190,4 +190,4 @@ async def test_deploy_contract_v3_without_abi(
     class_hash = await account.client.get_class_hash_at(
         contract_address=contract.address
     )
-    assert class_hash == cairo1_hello_starknet_class_hash
+    assert class_hash == hello_starknet_class_hash

--- a/starknet_py/tests/e2e/docs/code_examples/test_contract.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_contract.py
@@ -168,9 +168,7 @@ async def test_deploy_contract_v3(account, hello_starknet_class_hash: int):
 
 
 @pytest.mark.asyncio
-async def test_deploy_contract_v3_without_abi(
-    account, hello_starknet_class_hash: int
-):
+async def test_deploy_contract_v3_without_abi(account, hello_starknet_class_hash: int):
     deploy_result = await Contract.deploy_contract_v3(
         class_hash=hello_starknet_class_hash,
         account=account,

--- a/starknet_py/tests/e2e/docs/guide/test_simple_deploy.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_deploy.py
@@ -5,7 +5,7 @@ from starknet_py.net.client_models import ResourceBounds
 
 @pytest.mark.asyncio
 async def test_simple_deploy(
-    account, cairo1_hello_starknet_class_hash, cairo1_hello_starknet_abi
+    account, hello_starknet_class_hash, cairo1_hello_starknet_abi
 ):
     # pylint: disable=import-outside-toplevel
     # docs: start
@@ -13,7 +13,7 @@ async def test_simple_deploy(
 
     # docs: end
 
-    class_hash = cairo1_hello_starknet_class_hash
+    class_hash = hello_starknet_class_hash
     abi = cairo1_hello_starknet_abi
 
     # docs: start

--- a/starknet_py/tests/e2e/docs/guide/test_simple_deploy.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_deploy.py
@@ -4,9 +4,7 @@ from starknet_py.net.client_models import ResourceBounds
 
 
 @pytest.mark.asyncio
-async def test_simple_deploy(
-    account, hello_starknet_class_hash, cairo1_hello_starknet_abi
-):
+async def test_simple_deploy(account, hello_starknet_class_hash, hello_starknet_abi):
     # pylint: disable=import-outside-toplevel
     # docs: start
     from starknet_py.contract import Contract
@@ -14,7 +12,7 @@ async def test_simple_deploy(
     # docs: end
 
     class_hash = hello_starknet_class_hash
-    abi = cairo1_hello_starknet_abi
+    abi = hello_starknet_abi
 
     # docs: start
     # To deploy contract just use `Contract.deploy_contract_v1` method

--- a/starknet_py/tests/e2e/docs/guide/test_simple_deploy_cairo1.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_deploy_cairo1.py
@@ -11,7 +11,7 @@ from starknet_py.tests.e2e.fixtures.misc import ContractVersion, load_contract
     reason="Some cairo 1 contracts compiled with v1 compiler fail with new devnet-rs - test simply for a code example.",
 )
 @pytest.mark.asyncio
-async def test_simple_deploy_cairo1(account, cairo1_erc20_class_hash):
+async def test_simple_deploy_cairo1(account, erc20_class_hash):
     # pylint: disable=import-outside-toplevel
     # docs: start
     from starknet_py.cairo.felt import encode_shortstring
@@ -24,7 +24,7 @@ async def test_simple_deploy_cairo1(account, cairo1_erc20_class_hash):
         contract_name="ERC20", version=ContractVersion.V2
     )["sierra"]
 
-    class_hash = cairo1_erc20_class_hash
+    class_hash = erc20_class_hash
 
     # docs: start
     abi = create_sierra_compiled_contract(

--- a/starknet_py/tests/e2e/fixtures/accounts.py
+++ b/starknet_py/tests/e2e/fixtures/accounts.py
@@ -151,12 +151,12 @@ def pre_deployed_account_with_validate_deploy(client) -> BaseAccount:
 
 @pytest_asyncio.fixture(scope="package")
 async def argent_cairo1_account(
-    argent_cairo1_account_class_hash,
+    argent_account_class_hash,
     deploy_account_details_factory: AccountToBeDeployedDetailsFactory,
     client,
 ) -> BaseAccount:
     address, key_pair, salt, class_hash = await deploy_account_details_factory.get(
-        class_hash=argent_cairo1_account_class_hash,
+        class_hash=argent_account_class_hash,
         argent_calldata=True,
     )
     deploy_result = await Account.deploy_account_v1(

--- a/starknet_py/tests/e2e/fixtures/accounts.py
+++ b/starknet_py/tests/e2e/fixtures/accounts.py
@@ -150,7 +150,7 @@ def pre_deployed_account_with_validate_deploy(client) -> BaseAccount:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def argent_cairo1_account(
+async def argent_account(
     argent_account_class_hash,
     deploy_account_details_factory: AccountToBeDeployedDetailsFactory,
     client,

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -1,12 +1,11 @@
 # pylint: disable=redefined-outer-name
-from typing import List
 
 import pytest
 
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.contract import Contract
 from starknet_py.net.account.base_account import BaseAccount
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, STRK_FEE_CONTRACT_ADDRESS
+from starknet_py.tests.e2e.fixtures.constants import STRK_FEE_CONTRACT_ADDRESS
 
 
 @pytest.fixture(scope="package")

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -92,35 +92,35 @@ async def deploy_v1_contract(
 
 
 @pytest.fixture(scope="package")
-def eth_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
+def eth_fee_contract(account: BaseAccount, cairo_0_fee_contract_abi) -> Contract:
     """
     Returns an instance of the ETH fee contract. It is used to transfer tokens.
     """
 
     return Contract(
         address=FEE_CONTRACT_ADDRESS,
-        abi=fee_contract_abi,
+        abi=cairo_0_fee_contract_abi,
         provider=account,
         cairo_version=0,
     )
 
 
 @pytest.fixture(scope="package")
-def strk_fee_contract(account: BaseAccount, fee_contract_abi) -> Contract:
+def strk_fee_contract(account: BaseAccount, cairo_0_fee_contract_abi) -> Contract:
     """
     Returns an instance of the STRK fee contract. It is used to transfer tokens.
     """
 
     return Contract(
         address=STRK_FEE_CONTRACT_ADDRESS,
-        abi=fee_contract_abi,
+        abi=cairo_0_fee_contract_abi,
         provider=account,
         cairo_version=0,
     )
 
 
 @pytest.fixture(scope="package")
-def fee_contract_abi():
+def cairo_0_fee_contract_abi():
     return [
         {
             "inputs": [

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -1,51 +1,12 @@
 # pylint: disable=redefined-outer-name
-from typing import Any, Dict, List, Optional, Tuple
+from typing import List
 
 import pytest
-import pytest_asyncio
 
-from starknet_py.common import create_casm_class, create_sierra_compiled_contract
 from starknet_py.constants import FEE_CONTRACT_ADDRESS
 from starknet_py.contract import Contract
-from starknet_py.hash.casm_class_hash import compute_casm_class_hash
 from starknet_py.net.account.base_account import BaseAccount
-from starknet_py.net.udc_deployer.deployer import Deployer
-from starknet_py.tests.e2e.fixtures.constants import (
-    MAX_FEE,
-    PRECOMPILED_CONTRACTS_DIR,
-    STRK_FEE_CONTRACT_ADDRESS,
-)
-from starknet_py.tests.e2e.fixtures.misc import (
-    ContractVersion,
-    load_contract,
-    read_contract,
-)
-
-
-@pytest.fixture(scope="package")
-def sierra_minimal_compiled_contract_and_class_hash() -> Tuple[str, int]:
-    """
-    Returns minimal contract compiled to sierra and its compiled class hash.
-    """
-    contract = load_contract(contract_name="MinimalContract")
-
-    return (
-        contract["sierra"],
-        compute_casm_class_hash(create_casm_class(contract["casm"])),
-    )
-
-
-@pytest.fixture(scope="package")
-def abi_types_compiled_contract_and_class_hash() -> Tuple[str, int]:
-    """
-    Returns abi_types contract compiled to sierra and its compiled class hash.
-    """
-    contract = load_contract(contract_name="AbiTypes", version=ContractVersion.V2)
-
-    return (
-        contract["sierra"],
-        compute_casm_class_hash(create_casm_class(contract["casm"])),
-    )
+from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, STRK_FEE_CONTRACT_ADDRESS
 
 
 async def deploy_contract(account: BaseAccount, class_hash: int, abi: List) -> Contract:
@@ -57,38 +18,6 @@ async def deploy_contract(account: BaseAccount, class_hash: int, abi: List) -> C
     )
     deployment_result = await deployment_result.wait_for_acceptance()
     return deployment_result.deployed_contract
-
-
-async def deploy_v1_contract(
-    account: BaseAccount,
-    contract_name: str,
-    class_hash: int,
-    calldata: Optional[Dict[str, Any]] = None,
-) -> Contract:
-    """
-    Deploys Cairo1.0 contract.
-
-    :param account: An account which will be used to deploy the Contract.
-    :param contract_name: Name of the contract from project mocks (e.g. `ERC20`).
-    :param class_hash: class_hash of the contract to be deployed.
-    :param calldata: Dict with constructor arguments (can be empty).
-    :returns: Instance of the deployed contract.
-    """
-    contract_sierra = load_contract(contract_name)["sierra"]
-
-    abi = create_sierra_compiled_contract(compiled_contract=contract_sierra).parsed_abi
-
-    deployer = Deployer()
-    deploy_call, address = deployer.create_contract_deployment(
-        class_hash=class_hash,
-        abi=abi,
-        calldata=calldata,
-        cairo_version=1,
-    )
-    res = await account.execute_v1(calls=deploy_call, max_fee=MAX_FEE)
-    await account.client.wait_for_tx(res.transaction_hash)
-
-    return Contract(address, abi, provider=account, cairo_version=1)
 
 
 @pytest.fixture(scope="package")
@@ -141,73 +70,3 @@ def cairo_0_fee_contract_abi():
             "type": "struct",
         },
     ]
-
-
-async def declare_account(
-    account: BaseAccount, compiled_contract: str, compiled_class_hash: int
-) -> int:
-    """
-    Declares a specified account.
-    """
-
-    declare_tx = await account.sign_declare_v2(
-        compiled_contract,
-        compiled_class_hash,
-        max_fee=MAX_FEE,
-    )
-    resp = await account.client.declare(transaction=declare_tx)
-    await account.client.wait_for_tx(resp.transaction_hash)
-
-    return resp.class_hash
-
-
-async def declare_cairo1_account(
-    account: BaseAccount,
-    compiled_account_contract: str,
-    compiled_account_contract_casm: str,
-) -> int:
-    """
-    Declares a specified Cairo1 account.
-    """
-
-    casm_class = create_casm_class(compiled_account_contract_casm)
-    casm_class_hash = compute_casm_class_hash(casm_class)
-    declare_v2_transaction = await account.sign_declare_v2(
-        compiled_contract=compiled_account_contract,
-        compiled_class_hash=casm_class_hash,
-        max_fee=MAX_FEE,
-    )
-    resp = await account.client.declare(transaction=declare_v2_transaction)
-    await account.client.wait_for_tx(resp.transaction_hash)
-    return resp.class_hash
-
-
-@pytest_asyncio.fixture(scope="package")
-async def account_with_validate_deploy_class_hash(
-    pre_deployed_account_with_validate_deploy: BaseAccount,
-) -> int:
-    contract = load_contract("Account")
-    casm_class_hash = compute_casm_class_hash(create_casm_class(contract["casm"]))
-
-    return await declare_account(
-        pre_deployed_account_with_validate_deploy, contract["sierra"], casm_class_hash
-    )
-
-
-@pytest_asyncio.fixture(scope="package")
-async def argent_cairo1_account_class_hash(
-    account: BaseAccount,
-) -> int:
-    # Use precompiled argent account contracts
-    # we don't have the source code for this contract
-    compiled_contract = read_contract(
-        "argent_account.json", directory=PRECOMPILED_CONTRACTS_DIR
-    )
-    compiled_contract_casm = read_contract(
-        "argent_account.casm", directory=PRECOMPILED_CONTRACTS_DIR
-    )
-    return await declare_cairo1_account(
-        account=account,
-        compiled_account_contract=compiled_contract,
-        compiled_account_contract_casm=compiled_contract_casm,
-    )

--- a/starknet_py/tests/e2e/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/fixtures/contracts.py
@@ -9,17 +9,6 @@ from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, STRK_FEE_CONTRACT_ADDRESS
 
 
-async def deploy_contract(account: BaseAccount, class_hash: int, abi: List) -> Contract:
-    """
-    Deploys a contract and returns its instance.
-    """
-    deployment_result = await Contract.deploy_contract_v1(
-        account=account, class_hash=class_hash, abi=abi, max_fee=MAX_FEE
-    )
-    deployment_result = await deployment_result.wait_for_acceptance()
-    return deployment_result.deployed_contract
-
-
 @pytest.fixture(scope="package")
 def eth_fee_contract(account: BaseAccount, cairo_0_fee_contract_abi) -> Contract:
     """

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -107,7 +107,7 @@ def hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_minimal_contract_class_hash(account: BaseAccount) -> int:
+async def minimal_contract_class_hash(account: BaseAccount) -> int:
     contract = load_contract(contract_name="MinimalContract")
     class_hash, _ = await declare_cairo1_contract(
         account,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -312,7 +312,7 @@ async def declare_account(
     return resp.class_hash
 
 
-async def declare_cairo1_account(
+async def account_declare_class_hash(
     account: BaseAccount,
     compiled_account_contract: str,
     compiled_account_contract_casm: str,
@@ -357,7 +357,7 @@ async def argent_account_class_hash(
     compiled_contract_casm = read_contract(
         "argent_account.casm", directory=PRECOMPILED_CONTRACTS_DIR
     )
-    return await declare_cairo1_account(
+    return await account_declare_class_hash(
         account=account,
         compiled_account_contract=compiled_contract,
         compiled_account_contract_casm=compiled_contract_casm,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -211,7 +211,7 @@ async def map_class_hash(account: BaseAccount) -> int:
     return class_hash
 
 
-@pytest_asyncio.fixture(scope="package", name="map_contract")
+@pytest_asyncio.fixture(scope="package")
 async def map_contract(account: BaseAccount, map_class_hash) -> Contract:
     return await deploy_v1_contract(
         account=account,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -346,7 +346,7 @@ async def account_with_validate_deploy_class_hash(
 
 
 @pytest_asyncio.fixture(scope="package")
-async def argent_cairo1_account_class_hash(
+async def argent_account_class_hash(
     account: BaseAccount,
 ) -> int:
     # Use precompiled argent account contracts

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -393,4 +393,4 @@ async def deploy_v1_contract(
     res = await account.execute_v1(calls=deploy_call, max_fee=MAX_FEE)
     await account.client.wait_for_tx(res.transaction_hash)
 
-    return Contract(address, abi, provider=account, cairo_version=1)
+    return Contract(address, abi, provider=account)

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-from typing import List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 import pytest_asyncio
@@ -10,9 +10,13 @@ from starknet_py.contract import Contract
 from starknet_py.hash.casm_class_hash import compute_casm_class_hash
 from starknet_py.net.account.base_account import BaseAccount
 from starknet_py.net.models import DeclareV2
-from starknet_py.tests.e2e.fixtures.constants import MAX_FEE
-from starknet_py.tests.e2e.fixtures.contracts import deploy_v1_contract
-from starknet_py.tests.e2e.fixtures.misc import ContractVersion, load_contract
+from starknet_py.net.udc_deployer.deployer import Deployer
+from starknet_py.tests.e2e.fixtures.constants import MAX_FEE, PRECOMPILED_CONTRACTS_DIR
+from starknet_py.tests.e2e.fixtures.misc import (
+    ContractVersion,
+    load_contract,
+    read_contract,
+)
 
 
 async def declare_cairo1_contract(
@@ -262,3 +266,131 @@ async def simple_storage_with_event_contract(
         contract_name="SimpleStorageWithEvent",
         class_hash=simple_storage_with_event_class_hash,
     )
+
+
+@pytest.fixture(scope="package")
+def sierra_minimal_compiled_contract_and_class_hash() -> Tuple[str, int]:
+    """
+    Returns minimal contract compiled to sierra and its compiled class hash.
+    """
+    contract = load_contract(contract_name="MinimalContract")
+
+    return (
+        contract["sierra"],
+        compute_casm_class_hash(create_casm_class(contract["casm"])),
+    )
+
+
+@pytest.fixture(scope="package")
+def abi_types_compiled_contract_and_class_hash() -> Tuple[str, int]:
+    """
+    Returns abi_types contract compiled to sierra and its compiled class hash.
+    """
+    contract = load_contract(contract_name="AbiTypes", version=ContractVersion.V2)
+
+    return (
+        contract["sierra"],
+        compute_casm_class_hash(create_casm_class(contract["casm"])),
+    )
+
+
+async def declare_account(
+    account: BaseAccount, compiled_contract: str, compiled_class_hash: int
+) -> int:
+    """
+    Declares a specified account.
+    """
+
+    declare_tx = await account.sign_declare_v2(
+        compiled_contract,
+        compiled_class_hash,
+        max_fee=MAX_FEE,
+    )
+    resp = await account.client.declare(transaction=declare_tx)
+    await account.client.wait_for_tx(resp.transaction_hash)
+
+    return resp.class_hash
+
+
+async def declare_cairo1_account(
+    account: BaseAccount,
+    compiled_account_contract: str,
+    compiled_account_contract_casm: str,
+) -> int:
+    """
+    Declares a specified Cairo1 account.
+    """
+
+    casm_class = create_casm_class(compiled_account_contract_casm)
+    casm_class_hash = compute_casm_class_hash(casm_class)
+    declare_v2_transaction = await account.sign_declare_v2(
+        compiled_contract=compiled_account_contract,
+        compiled_class_hash=casm_class_hash,
+        max_fee=MAX_FEE,
+    )
+    resp = await account.client.declare(transaction=declare_v2_transaction)
+    await account.client.wait_for_tx(resp.transaction_hash)
+    return resp.class_hash
+
+
+@pytest_asyncio.fixture(scope="package")
+async def account_with_validate_deploy_class_hash(
+    pre_deployed_account_with_validate_deploy: BaseAccount,
+) -> int:
+    contract = load_contract("Account")
+    casm_class_hash = compute_casm_class_hash(create_casm_class(contract["casm"]))
+
+    return await declare_account(
+        pre_deployed_account_with_validate_deploy, contract["sierra"], casm_class_hash
+    )
+
+
+@pytest_asyncio.fixture(scope="package")
+async def argent_cairo1_account_class_hash(
+    account: BaseAccount,
+) -> int:
+    # Use precompiled argent account contracts
+    # we don't have the source code for this contract
+    compiled_contract = read_contract(
+        "argent_account.json", directory=PRECOMPILED_CONTRACTS_DIR
+    )
+    compiled_contract_casm = read_contract(
+        "argent_account.casm", directory=PRECOMPILED_CONTRACTS_DIR
+    )
+    return await declare_cairo1_account(
+        account=account,
+        compiled_account_contract=compiled_contract,
+        compiled_account_contract_casm=compiled_contract_casm,
+    )
+
+
+async def deploy_v1_contract(
+    account: BaseAccount,
+    contract_name: str,
+    class_hash: int,
+    calldata: Optional[Dict[str, Any]] = None,
+) -> Contract:
+    """
+    Deploys Cairo1.0 contract.
+
+    :param account: An account which will be used to deploy the Contract.
+    :param contract_name: Name of the contract from project mocks (e.g. `ERC20`).
+    :param class_hash: class_hash of the contract to be deployed.
+    :param calldata: Dict with constructor arguments (can be empty).
+    :returns: Instance of the deployed contract.
+    """
+    contract_sierra = load_contract(contract_name)["sierra"]
+
+    abi = create_sierra_compiled_contract(compiled_contract=contract_sierra).parsed_abi
+
+    deployer = Deployer()
+    deploy_call, address = deployer.create_contract_deployment(
+        class_hash=class_hash,
+        abi=abi,
+        calldata=calldata,
+        cairo_version=1,
+    )
+    res = await account.execute_v1(calls=deploy_call, max_fee=MAX_FEE)
+    await account.client.wait_for_tx(res.transaction_hash)
+
+    return Contract(address, abi, provider=account, cairo_version=1)

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -101,7 +101,7 @@ def hello_starknet_class_hash(hello_starknet_class_hash_tx_hash) -> int:
 
 
 @pytest.fixture(scope="package")
-def cairo1_hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
+def hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
     _, tx_hash = hello_starknet_class_hash_tx_hash
     return tx_hash
 
@@ -168,9 +168,7 @@ async def cairo1_erc20_deploy(account, erc20_class_hash):
 
 
 @pytest_asyncio.fixture(scope="package", name="hello_starknet_contract")
-async def cairo1_hello_starknet_deploy(
-    account: BaseAccount, hello_starknet_class_hash
-):
+async def cairo1_hello_starknet_deploy(account: BaseAccount, hello_starknet_class_hash):
     return await deploy_v1_contract(
         account=account,
         contract_name="HelloStarknet",

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -171,8 +171,8 @@ async def cairo1_erc20_deploy(account, erc20_class_hash):
     )
 
 
-@pytest_asyncio.fixture(scope="package", name="hello_starknet_contract")
-async def cairo1_hello_starknet_deploy(account: BaseAccount, hello_starknet_class_hash):
+@pytest_asyncio.fixture(scope="package")
+async def hello_starknet_contract(account: BaseAccount, hello_starknet_class_hash):
     return await deploy_v1_contract(
         account=account,
         contract_name="HelloStarknet",

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -144,7 +144,7 @@ async def cairo1_test_option_class_hash(account: BaseAccount) -> int:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_token_bridge_class_hash(account: BaseAccount) -> int:
+async def token_bridge_class_hash(account: BaseAccount) -> int:
     contract = load_contract(contract_name="TokenBridge")
     class_hash, _ = await declare_cairo1_contract(
         account,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -75,7 +75,7 @@ async def declare_v2_hello_starknet(account: BaseAccount) -> DeclareV2:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_hello_starknet_class_hash_tx_hash(
+async def hello_starknet_class_hash_tx_hash(
     account: BaseAccount, declare_v2_hello_starknet: DeclareV2
 ) -> Tuple[int, int]:
     resp = await account.client.declare(declare_v2_hello_starknet)
@@ -96,17 +96,17 @@ async def cairo1_hello_starknet_abi() -> List:
 
 @pytest.fixture(scope="package")
 def cairo1_hello_starknet_class_hash(
-    cairo1_hello_starknet_class_hash_tx_hash: Tuple[int, int]
+        hello_starknet_class_hash_tx_hash
 ) -> int:
-    class_hash, _ = cairo1_hello_starknet_class_hash_tx_hash
+    class_hash, _ = hello_starknet_class_hash_tx_hash
     return class_hash
 
 
 @pytest.fixture(scope="package")
 def cairo1_hello_starknet_tx_hash(
-    cairo1_hello_starknet_class_hash_tx_hash: Tuple[int, int]
+        hello_starknet_class_hash_tx_hash
 ) -> int:
-    _, tx_hash = cairo1_hello_starknet_class_hash_tx_hash
+    _, tx_hash = hello_starknet_class_hash_tx_hash
     return tx_hash
 
 

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -123,7 +123,7 @@ async def minimal_contract_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def test_enum_class_hash(account: BaseAccount) -> int:
-    contract = load_contract(contract_name="TestEnum")
+    contract = load_contract("TestEnum")
     class_hash, _ = await declare_cairo1_contract(
         account,
         contract["sierra"],
@@ -134,7 +134,7 @@ async def test_enum_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def test_option_class_hash(account: BaseAccount) -> int:
-    contract = load_contract(contract_name="TestOption")
+    contract = load_contract("TestOption")
     class_hash, _ = await declare_cairo1_contract(
         account,
         contract["sierra"],
@@ -145,7 +145,7 @@ async def test_option_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def token_bridge_class_hash(account: BaseAccount) -> int:
-    contract = load_contract(contract_name="TokenBridge")
+    contract = load_contract("TokenBridge")
     class_hash, _ = await declare_cairo1_contract(
         account,
         contract["sierra"],
@@ -273,7 +273,7 @@ def sierra_minimal_compiled_contract_and_class_hash() -> Tuple[str, int]:
     """
     Returns minimal contract compiled to sierra and its compiled class hash.
     """
-    contract = load_contract(contract_name="MinimalContract")
+    contract = load_contract("MinimalContract")
 
     return (
         contract["sierra"],

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -112,7 +112,7 @@ def hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def minimal_contract_class_hash(account: BaseAccount) -> int:
-    contract = load_contract(contract_name="MinimalContract")
+    contract = load_contract("MinimalContract")
     class_hash, _ = await declare_cairo1_contract(
         account,
         contract["sierra"],

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -371,7 +371,7 @@ async def deploy_v1_contract(
     calldata: Optional[Dict[str, Any]] = None,
 ) -> Contract:
     """
-    Deploys Cairo1.0 contract.
+    Deploys Cairo1 contract.
 
     :param account: An account which will be used to deploy the Contract.
     :param contract_name: Name of the contract from project mocks (e.g. `ERC20`).

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -133,7 +133,7 @@ async def cairo1_test_enum_class_hash(account: BaseAccount) -> int:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_test_option_class_hash(account: BaseAccount) -> int:
+async def test_option_class_hash(account: BaseAccount) -> int:
     contract = load_contract(contract_name="TestOption")
     class_hash, _ = await declare_cairo1_contract(
         account,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -122,7 +122,7 @@ async def cairo1_minimal_contract_class_hash(account: BaseAccount) -> int:
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_test_enum_class_hash(account: BaseAccount) -> int:
+async def test_enum_class_hash(account: BaseAccount) -> int:
     contract = load_contract(contract_name="TestEnum")
     class_hash, _ = await declare_cairo1_contract(
         account,

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -19,7 +19,7 @@ from starknet_py.tests.e2e.fixtures.misc import (
 )
 
 
-async def declare_cairo1_contract(
+async def declare_contract(
     account: BaseAccount, compiled_contract: str, compiled_contract_casm: str
 ) -> Tuple[int, int]:
     casm_class_hash = compute_casm_class_hash(create_casm_class(compiled_contract_casm))
@@ -40,7 +40,7 @@ async def declare_cairo1_contract(
 @pytest_asyncio.fixture(scope="package")
 async def erc20_class_hash(account: BaseAccount) -> int:
     contract = load_contract("ERC20")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
     return class_hash
@@ -49,7 +49,7 @@ async def erc20_class_hash(account: BaseAccount) -> int:
 @pytest_asyncio.fixture(scope="package")
 async def constructor_with_arguments_class_hash(account: BaseAccount) -> int:
     contract = load_contract("ConstructorWithArguments")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
     return class_hash
@@ -113,7 +113,7 @@ def hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
 @pytest_asyncio.fixture(scope="package")
 async def minimal_contract_class_hash(account: BaseAccount) -> int:
     contract = load_contract("MinimalContract")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],
@@ -124,7 +124,7 @@ async def minimal_contract_class_hash(account: BaseAccount) -> int:
 @pytest_asyncio.fixture(scope="package")
 async def test_enum_class_hash(account: BaseAccount) -> int:
     contract = load_contract("TestEnum")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],
@@ -135,7 +135,7 @@ async def test_enum_class_hash(account: BaseAccount) -> int:
 @pytest_asyncio.fixture(scope="package")
 async def test_option_class_hash(account: BaseAccount) -> int:
     contract = load_contract("TestOption")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],
@@ -146,7 +146,7 @@ async def test_option_class_hash(account: BaseAccount) -> int:
 @pytest_asyncio.fixture(scope="package")
 async def token_bridge_class_hash(account: BaseAccount) -> int:
     contract = load_contract("TokenBridge")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],
@@ -183,7 +183,7 @@ async def hello_starknet_contract(account: BaseAccount, hello_starknet_class_has
 @pytest_asyncio.fixture(scope="package", name="string_contract_class_hash")
 async def declare_string_contract(account: BaseAccount) -> int:
     contract = load_contract("MyString", version=ContractVersion.V2)
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
     return class_hash
@@ -203,7 +203,7 @@ async def deploy_string_contract(
 @pytest_asyncio.fixture(scope="package")
 async def map_class_hash(account: BaseAccount) -> int:
     contract = load_contract("Map")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
         contract["casm"],
@@ -250,7 +250,7 @@ def map_compiled_contract_casm() -> str:
 @pytest_asyncio.fixture(scope="package")
 async def simple_storage_with_event_class_hash(account: BaseAccount) -> int:
     contract = load_contract("SimpleStorageWithEvent")
-    class_hash, _ = await declare_cairo1_contract(
+    class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
     return class_hash

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -381,7 +381,7 @@ async def deploy_v1_contract(
     """
     contract_sierra = load_contract(contract_name)["sierra"]
 
-    abi = create_sierra_compiled_contract(compiled_contract=contract_sierra).parsed_abi
+    abi = create_sierra_compiled_contract(contract_sierra).parsed_abi
 
     deployer = Deployer()
     deploy_call, address = deployer.create_contract_deployment(

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -95,17 +95,13 @@ async def cairo1_hello_starknet_abi() -> List:
 
 
 @pytest.fixture(scope="package")
-def cairo1_hello_starknet_class_hash(
-        hello_starknet_class_hash_tx_hash
-) -> int:
+def hello_starknet_class_hash(hello_starknet_class_hash_tx_hash) -> int:
     class_hash, _ = hello_starknet_class_hash_tx_hash
     return class_hash
 
 
 @pytest.fixture(scope="package")
-def cairo1_hello_starknet_tx_hash(
-        hello_starknet_class_hash_tx_hash
-) -> int:
+def cairo1_hello_starknet_tx_hash(hello_starknet_class_hash_tx_hash) -> int:
     _, tx_hash = hello_starknet_class_hash_tx_hash
     return tx_hash
 
@@ -173,12 +169,12 @@ async def cairo1_erc20_deploy(account, erc20_class_hash):
 
 @pytest_asyncio.fixture(scope="package", name="hello_starknet_contract")
 async def cairo1_hello_starknet_deploy(
-    account: BaseAccount, cairo1_hello_starknet_class_hash
+    account: BaseAccount, hello_starknet_class_hash
 ):
     return await deploy_v1_contract(
         account=account,
         contract_name="HelloStarknet",
-        class_hash=cairo1_hello_starknet_class_hash,
+        class_hash=hello_starknet_class_hash,
     )
 
 

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -89,7 +89,7 @@ async def hello_starknet_class_hash_tx_hash(
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_hello_starknet_abi() -> List:
+async def hello_starknet_abi() -> List:
     contract = load_contract("HelloStarknet")
     compiled_contract = create_sierra_compiled_contract(
         compiled_contract=contract["sierra"]

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -154,8 +154,8 @@ async def token_bridge_class_hash(account: BaseAccount) -> int:
     return class_hash
 
 
-@pytest_asyncio.fixture(scope="package", name="erc20_contract")
-async def cairo1_erc20_deploy(account, erc20_class_hash):
+@pytest_asyncio.fixture(scope="package")
+async def erc20_contract(account, erc20_class_hash):
     calldata = {
         "name_": encode_shortstring("erc20_basic"),
         "symbol_": encode_shortstring("ERC20B"),

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -388,7 +388,6 @@ async def deploy_v1_contract(
         class_hash=class_hash,
         abi=abi,
         calldata=calldata,
-        cairo_version=1,
     )
     res = await account.execute_v1(calls=deploy_call, max_fee=MAX_FEE)
     await account.client.wait_for_tx(res.transaction_hash)

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -34,7 +34,7 @@ async def declare_cairo1_contract(
 
 
 @pytest_asyncio.fixture(scope="package")
-async def cairo1_erc20_class_hash(account: BaseAccount) -> int:
+async def erc20_class_hash(account: BaseAccount) -> int:
     contract = load_contract("ERC20")
     class_hash, _ = await declare_cairo1_contract(
         account, contract["sierra"], contract["casm"]
@@ -155,7 +155,7 @@ async def cairo1_token_bridge_class_hash(account: BaseAccount) -> int:
 
 
 @pytest_asyncio.fixture(scope="package", name="erc20_contract")
-async def cairo1_erc20_deploy(account, cairo1_erc20_class_hash):
+async def cairo1_erc20_deploy(account, erc20_class_hash):
     calldata = {
         "name_": encode_shortstring("erc20_basic"),
         "symbol_": encode_shortstring("ERC20B"),
@@ -166,7 +166,7 @@ async def cairo1_erc20_deploy(account, cairo1_erc20_class_hash):
     return await deploy_v1_contract(
         account=account,
         contract_name="ERC20",
-        class_hash=cairo1_erc20_class_hash,
+        class_hash=erc20_class_hash,
         calldata=calldata,
     )
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Relates #1219

The current version of the fixture code is `cairo 1` so it isn't required to highlight it, so I removed this prefix from fixture to improve readabillity.

## Introduced changes
<!-- A brief description of the changes -->


- Deleted `cairo1` prefix from fixtures
- Added `cairo0` prefix to fixtures
- Moved `cairo1` fixture to proper file
- Renamed tests and function names that contain `cairo1` word


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


