### PR TITLE
Use previous Ledger app version and re-enable Ledger signer tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -191,6 +191,7 @@ jobs:
       - name: Clone LedgerHQ Starknet app repository
         run: |
           git clone https://github.com/LedgerHQ/app-starknet.git
+          cd app-starknet
           git checkout ${{ env.LEDGER_APP_SHA }}
 
       - name: Build the app inside Docker container

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -189,8 +189,7 @@ jobs:
 
 
       - name: Clone LedgerHQ Starknet app repository
-        run: |
-          git clone https://github.com/LedgerHQ/app-starknet.git
+        run: git clone https://github.com/LedgerHQ/app-starknet.git
 
       - name: Build the app inside Docker container
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -191,8 +191,6 @@ jobs:
       - name: Clone LedgerHQ Starknet app repository
         run: |
           git clone https://github.com/LedgerHQ/app-starknet.git
-          cd app-starknet
-          git checkout ${{ env.LEDGER_APP_SHA }}
 
       - name: Build the app inside Docker container
         uses: addnab/docker-run-action@v3
@@ -200,7 +198,8 @@ jobs:
           image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools
           options: --rm -v ${{ github.workspace }}:/apps
           run: |
-            cd /apps/app-starknet/starknet
+            cd /apps/app-starknet
+            git checkout ${{ env.LEDGER_APP_SHA }}
             cargo clean
             cargo ledger build nanox
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ env:
   CAIRO_LANG_VERSION: "0.13.1"
   DEVNET_VERSION: "0.1.2"
   DEVNET_SHA: 7e7dbb5
+  LEDGER_APP_SHA: dd58c5c
 
 on:
   push:
@@ -190,7 +191,7 @@ jobs:
       - name: Clone LedgerHQ Starknet app repository
         run: |
           git clone https://github.com/LedgerHQ/app-starknet.git
-          git checkout main
+          git checkout ${{ env.LEDGER_APP_SHA }}
 
       - name: Build the app inside Docker container
         uses: addnab/docker-run-action@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -188,7 +188,9 @@ jobs:
 
 
       - name: Clone LedgerHQ Starknet app repository
-        run: git clone https://github.com/LedgerHQ/app-starknet.git
+        run: |
+          git clone https://github.com/LedgerHQ/app-starknet.git
+          git checkout main
 
       - name: Build the app inside Docker container
         uses: addnab/docker-run-action@v3

--- a/docs/guide/signing.rst
+++ b/docs/guide/signing.rst
@@ -15,6 +15,7 @@ signing algorithm, it is possible to create ``Account`` with custom
 Signing with Ledger
 -------------------
 :ref:`LedgerSigner` allows you to sign transactions using a Ledger device. The device must be unlocked and Starknet app needs to be open.
+Currently used version of Starknet app is ``1.1.1`` and only blind-signing is possible. Clear-signing will be available in the near future.
 
 .. codesnippet:: ../../starknet_py/tests/unit/signer/test_ledger_signer.py
     :language: python

--- a/starknet_py/tests/unit/signer/test_ledger_signer.py
+++ b/starknet_py/tests/unit/signer/test_ledger_signer.py
@@ -1,3 +1,5 @@
+from sys import platform
+
 import pytest
 
 from starknet_py.common import create_sierra_compiled_contract
@@ -18,8 +20,11 @@ from starknet_py.tests.e2e.fixtures.constants import (
 from starknet_py.tests.e2e.fixtures.misc import load_contract
 
 
-# TODO (#1476): Should be re-enabled once Ledger signer is updated with new APDU spec.
-@pytest.mark.skip
+# TODO (#1425): Currently Ledger tests are skipped on Windows due to different Speculos setup.
+@pytest.mark.skipif(
+    platform == "win32",
+    reason="Testing Ledger is skipped on Windows due to different Speculos setup.",
+)
 def test_init_with_invalid_derivation_path():
     with pytest.raises(ValueError, match="Empty derivation path"):
         LedgerSigner(derivation_path_str="", chain_id=StarknetChainId.SEPOLIA)
@@ -76,8 +81,11 @@ sierra_contract_class = create_sierra_compiled_contract(compiled_contract)
         ),
     ],
 )
-# TODO (#1476): Should be re-enabled once Ledger signer is updated with new APDU spec.
-@pytest.mark.skip
+# TODO (#1425): Currently Ledger tests are skipped on Windows due to different Speculos setup.
+@pytest.mark.skipif(
+    platform == "win32",
+    reason="Testing Ledger is skipped on Windows due to different Speculos setup.",
+)
 def test_sign_transaction(transaction):
     # docs: start
 
@@ -97,8 +105,11 @@ def test_sign_transaction(transaction):
     assert all(i != 0 for i in signature)
 
 
-# TODO (#1476): Should be re-enabled once Ledger signer is updated with new APDU spec.
-@pytest.mark.skip
+# TODO (#1425): Currently Ledger tests are skipped on Windows due to different Speculos setup.
+@pytest.mark.skipif(
+    platform == "win32",
+    reason="Testing Ledger is skipped on Windows due to different Speculos setup.",
+)
 def test_create_account_with_ledger_signer():
     # pylint: disable=unused-variable
     signer = LedgerSigner(
@@ -132,8 +143,11 @@ async def _get_account_balance_strk(client: FullNodeClient, address: int):
 
 
 @pytest.mark.asyncio
-# TODO (#1476): Should be re-enabled once Ledger signer is updated with new APDU spec.
-@pytest.mark.skip
+# TODO (#1425): Currently Ledger tests are skipped on Windows due to different Speculos setup.
+@pytest.mark.skipif(
+    platform == "win32",
+    reason="Testing Ledger is skipped on Windows due to different Speculos setup.",
+)
 async def test_deploy_account_and_transfer(client):
     signer = LedgerSigner(
         derivation_path_str="m/2645'/1195502025'/1470455285'/0'/0'/0",


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->

[Ledger Starknet app](https://github.com/LedgerHQ/app-starknet) latest version has changed APDU command. It doesn't support e.g. signing deploy account transaction) which is used in our tests. Due to it, we use previous version.
Once future release of Starknet app will support features used in out tests, updating versions and tests should be addressed in https://github.com/software-mansion/starknet.py/issues/1473.


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


