### PR TITLE
Move Revision class and field to separate file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "starknet.py",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/starknet_py/net/models/typed_data.py
+++ b/starknet_py/net/models/typed_data.py
@@ -4,7 +4,7 @@ TypedDict structures for TypedData
 
 from typing import Any, Dict, List, Optional, TypedDict
 
-from starknet_py.net.schemas.common import Revision
+from starknet_py.net.schemas.revision import Revision
 
 
 class ParameterDict(TypedDict):

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -2,12 +2,12 @@ import re
 import sys
 from enum import Enum
 from typing import Any, Mapping, Optional, Union
-
-from starknet_py.net.schemas.revision import Revision , RevisionField
-
-
 from marshmallow import Schema, ValidationError, fields, post_load
 
+
+
+
+from starknet_py.net.schemas.revision import Revision , RevisionField
 from starknet_py.net.client_models import (
     BlockStatus,
     CallType,

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -3,6 +3,9 @@ import sys
 from enum import Enum
 from typing import Any, Mapping, Optional, Union
 
+from starknet_py.net.schemas.revision import Revision , RevisionField
+
+
 from marshmallow import Schema, ValidationError, fields, post_load
 
 from starknet_py.net.client_models import (
@@ -348,30 +351,9 @@ class StorageEntrySchema(Schema):
         return StorageEntry(**data)
 
 
-class Revision(Enum):
-    """
-    Enum representing the revision of the specification to be used.
-    """
-
-    V0 = 0
-    V1 = 1
-
-
-class RevisionField(fields.Field):
-    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs):
-        if value is None or value == Revision.V0:
-            return str(Revision.V0.value)
-        return value.value
-
-    def _deserialize(self, value, attr, data, **kwargs) -> Revision:
-        if isinstance(value, str):
-            value = int(value)
-
-        revisions = [revision.value for revision in Revision]
-        if value not in revisions:
-            allowed_revisions_str = "".join(list(map(str, revisions)))
-            raise ValidationError(
-                f"Invalid value provided for Revision: {value}. Allowed values are {allowed_revisions_str}."
-            )
-
-        return Revision(value)
+class MySchema(Schema):
+    revision = RevisionField(required=True) 
+    data = {"revision": Revision.V0, 
+            "revision": Revision.V1, 
+             
+        }

--- a/starknet_py/net/schemas/revision.py
+++ b/starknet_py/net/schemas/revision.py
@@ -1,6 +1,6 @@
-from starknet_py.net.schemas.common import Enum
 from marshmallow import  ValidationError, fields
 from typing import Any , Optional
+from starknet_py.net.schemas.common import Enum
 
 class Revision(Enum):
     """

--- a/starknet_py/net/schemas/revision.py
+++ b/starknet_py/net/schemas/revision.py
@@ -1,0 +1,31 @@
+from starknet_py.net.schemas.common import Enum
+from marshmallow import  ValidationError, fields
+from typing import Any , Optional
+
+class Revision(Enum):
+    """
+    Enum representing the revision of the specification to be used.
+    """
+
+    V0 = 0
+    V1 = 1
+
+
+class RevisionField(fields.Field):
+    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs):
+        if value is None or value == Revision.V0:
+            return str(Revision.V0.value)
+        return value.value
+
+    def _deserialize(self, value, attr, data, **kwargs) -> Revision:
+        if isinstance(value, str):
+            value = int(value)
+
+        revisions = [revision.value for revision in Revision]
+        if value not in revisions:
+            allowed_revisions_str = "".join(list(map(str, revisions)))
+            raise ValidationError(
+                f"Invalid value provided for Revision: {value}. Allowed values are {allowed_revisions_str}."
+            )
+
+        return Revision(value)


### PR DESCRIPTION



Introduced changes:-

-> Added a new filed named schema/revision.py which has the revision and revisionfeild class which was previously defined in 
     schema/common.py .

-> Fixed a bug that was causing circular imports in between models/typed_data.py and schema/common.py .

##

Breaking changes:-

-> Added a new file at schema called revision.py and added imports at models/typed_data.py and schema/common.py likewise 



