### PR TITLE
Change `seed` default value to `None`

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -6,7 +6,7 @@ Migration guide
 ******************************
 
 0.25.0 Breaking changes
---------------------
+-----------------------
 
 .. currentmodule:: starknet_py.hash.utils
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,18 @@ Migration guide
 ===============
 
 ******************************
+0.25.0 Migration guide
+******************************
+
+0.25.0 Breaking changes
+--------------------
+
+.. currentmodule:: starknet_py.hash.utils
+
+1. :meth:`message_signature` param ``seed`` has now a default value of ``None`` instead of previous ``32``.
+
+
+******************************
 0.24.2 Migration guide
 ******************************
 

--- a/starknet_py/hash/utils.py
+++ b/starknet_py/hash/utils.py
@@ -52,7 +52,7 @@ def compute_hash_on_elements(data: Sequence) -> int:
 
 
 def message_signature(
-    msg_hash: int, priv_key: int, seed: Optional[int] = 32
+    msg_hash: int, priv_key: int, seed: Optional[int] = None
 ) -> ECSignature:
     """
     Signs the message with private key.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1501


## Introduced changes
<!-- A brief description of the changes -->


- Change `seed` default value to `None` in `message_signature` function. It was done due to discrepancy in default value between our implementation and [`sign` function in cairo-lang](https://github.com/starkware-libs/cairo-lang/blob/a86e92bfde9c171c0856d7b46580c66e004922f3/src/starkware/crypto/signature/signature.py#L137).


##

- [x] This PR contains breaking changes

<!-- List of all breaking changes -->
- `message_signature` param `seed` has now a default value of `None` instead of previous `32`.


