### PR TITLE
Typo Update account_and_client.rst

### DIFF
--- a/docs/guide/account_and_client.rst
+++ b/docs/guide/account_and_client.rst
@@ -35,7 +35,7 @@ For V3 transactions, ``max_amount`` and ``max_price_per_unit`` are scaled by ``1
     by changing ``ESTIMATED_FEE_MULTIPLIER`` for V1 and V2 transactions in :class:`~starknet_py.net.account.account.Account`.
     The same applies to ``ESTIMATED_AMOUNT_MULTIPLIER`` and ``ESTIMATED_UNIT_PRICE_MULTIPLIER`` for V3 transactions.
 
-The fee for a specific transaction or list of transactions can be also estimated using the :meth:`~starknet_py.net.account.account.Account.estimate_fee` of the :ref:`Account` class.
+The fee for a specific transaction or list of transactions can also be estimated using the :meth:`~starknet_py.net.account.account.Account.estimate_fee` of the :ref:`Account` class.
 
 Creating transactions without executing them
 --------------------------------------------


### PR DESCRIPTION
**Description:**  
This pull request fixes a minor grammatical issue in the "Transaction Fee" section of the documentation. The original sentence:  

> "The fee for a specific transaction or list of transactions can be also estimated using the :meth:`~starknet_py.net.account.account.Account.estimate_fee` of the :ref:`Account` class."  

contained incorrect word order in the phrase **"can be also estimated."**  

The corrected sentence is:  

> "The fee for a specific transaction or list of transactions can also be estimated using the :meth:`~starknet_py.net.account.account.Account.estimate_fee` of the :ref:`Account` class."  

### Why is this change important?  
- **Clarity:** Fixing the grammar improves the readability and professionalism of the documentation.  
- **Accuracy:** Proper grammar helps users better understand the content without misinterpretation.  

Thank you for maintaining such high-quality documentation!