### PR TITLE
Add keys (indexed fields aka topics) to the EventType (abi v2)

### DIFF
--- a/starknet_py/abi/v2/parser.py
+++ b/starknet_py/abi/v2/parser.py
@@ -234,6 +234,7 @@ class AbiParser:
             types=self._parse_members(
                 cast(List[TypedParameterDict], members_), event["name"]
             ),
+            keys=self._parse_keys(cast(List[EventStructMemberDict], members_)),
         )
 
     TypedParam = TypeVar(
@@ -249,6 +250,9 @@ class AbiParser:
             (name, self.type_parser.parse_inline_type(param["type"]))
             for name, param in members.items()
         )
+
+    def _parse_keys(self, params: List[EventStructMemberDict]) -> List[str]:
+        return [param["name"] for param in params if param["kind"] == "key"]
 
     def _parse_interface(self, interface: InterfaceDict) -> Abi.Interface:
         return Abi.Interface(

--- a/starknet_py/abi/v2/schemas.py
+++ b/starknet_py/abi/v2/schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 from marshmallow_oneofschema.one_of_schema import OneOfSchema
 
 from starknet_py.abi.v2.shape import (
@@ -9,6 +9,7 @@ from starknet_py.abi.v2.shape import (
     FUNCTION_ENTRY,
     IMPL_ENTRY,
     INTERFACE_ENTRY,
+    KEY_KIND,
     L1_HANDLER_ENTRY,
     NESTED_KIND,
     STRUCT_ENTRY,
@@ -51,7 +52,9 @@ class L1HandlerAbiEntrySchema(FunctionBaseSchema):
 
 
 class EventStructMemberSchema(TypedParameterSchema):
-    kind = fields.Constant(DATA_KIND, data_key="kind", required=True)
+    kind = fields.String(
+        validate=validate.OneOf([KEY_KIND, DATA_KIND]), data_key="kind", required=True
+    )
 
 
 class EventStructAbiEntrySchema(Schema):

--- a/starknet_py/abi/v2/shape.py
+++ b/starknet_py/abi/v2/shape.py
@@ -57,7 +57,7 @@ class EventBaseDict(TypedDict):
 
 
 class EventStructMemberDict(TypedParameterDict):
-    kind: Union[Literal["key"], Literal["data"]]
+    kind: Literal["data", "key"]
 
 
 class EventStructDict(EventBaseDict):

--- a/starknet_py/abi/v2/shape.py
+++ b/starknet_py/abi/v2/shape.py
@@ -11,6 +11,7 @@ L1_HANDLER_ENTRY = "l1_handler"
 IMPL_ENTRY = "impl"
 INTERFACE_ENTRY = "interface"
 
+KEY_KIND = "key"
 DATA_KIND = "data"
 NESTED_KIND = "nested"
 
@@ -56,7 +57,7 @@ class EventBaseDict(TypedDict):
 
 
 class EventStructMemberDict(TypedParameterDict):
-    kind: Literal["data"]
+    kind: Union[Literal["key"], Literal["data"]]
 
 
 class EventStructDict(EventBaseDict):

--- a/starknet_py/cairo/data_types.py
+++ b/starknet_py/cairo/data_types.py
@@ -121,3 +121,4 @@ class EventType(CairoType):
 
     name: str
     types: OrderedDict[str, CairoType]
+    keys: List[str]

--- a/starknet_py/tests/e2e/fixtures/abi_v2_structures.py
+++ b/starknet_py/tests/e2e/fixtures/abi_v2_structures.py
@@ -7,8 +7,7 @@ from starknet_py.cairo.data_types import EventType, StructType, UintType
 pool_id_struct = StructType("PoolId", OrderedDict(value=UintType(256)))
 
 pool_id_added_event: EventType = EventType(
-    "PoolIdAdded",
-    OrderedDict(pool_id=pool_id_struct),
+    "PoolIdAdded", OrderedDict(pool_id=pool_id_struct), []
 )
 
 abi_v2 = Abi(

--- a/starknet_py/tests/unit/abi/v2/parser_test.py
+++ b/starknet_py/tests/unit/abi/v2/parser_test.py
@@ -22,6 +22,7 @@ from starknet_py.tests.e2e.fixtures.misc import ContractVersion, load_contract
         "TestEnum",
         "TestOption",
         "TokenBridge",
+        "l1_l2",
     ],
 )
 def test_abi_parse(contract_name):


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->
Issue: Currently ABI v2 does not preserve the event "kind" information which is necessary for decoding event payloads structured as list of keys + list of data fields.


## Introduced changes
<!-- A brief description of the changes -->

This PR adds new `keys` field to the `EventType` which contains the list of event fields marked with `#[key]` in Cairo code.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


