### PR TITLE
Add `NonZeroType`

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,17 @@ Migration guide
 ===============
 
 ******************************
+[unreleased] Migration guide
+******************************
+
+[unreleased] Minor changes
+--------------------------
+
+.. currentmodule:: starknet_py.cairo.data_types
+
+1. Added :class:`NonZeroType` in order to fix parsing ABI which contains Cairo`s `core::zeroable::NonZero <https://github.com/starkware-libs/cairo/blob/a2b9dddeb3212c8d529538454745b27d7a34a6cd/corelib/src/zeroable.cairo#L78>`_
+
+******************************
 0.24.3 Migration guide
 ******************************
 

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -9,6 +9,7 @@ from starknet_py.cairo.data_types import (
     BoolType,
     CairoType,
     FeltType,
+    NonZeroType,
     OptionType,
     TupleType,
     TypeIdentifier,
@@ -35,6 +36,7 @@ ABI_EBNF = """
         | type_span
         | tuple
         | type_identifier
+        | type_non_zero
     
     
     type_unit: "()"
@@ -49,6 +51,7 @@ ABI_EBNF = """
     type_option: "core::option::Option::<" (type | type_identifier) ">"
     type_array: "core::array::Array::<" (type | type_identifier) ">"
     type_span: "core::array::Span::<" (type | type_identifier) ">"
+    type_non_zero: "core::zeroable::NonZero<" (type | type_identifier) ">"
     
     tuple: "(" type? ("," type?)* ")"
     
@@ -184,6 +187,12 @@ class ParserTransformer(Transformer):
         Tuple contains values defined in the `types` argument.
         """
         return TupleType(types)
+
+    def type_non_zero(self, value: List[CairoType]) -> NonZeroType:
+        """
+        NonZero contains value which is never zero.
+        """
+        return NonZeroType(value[0])
 
 
 def parse(

--- a/starknet_py/abi/v2/parser_transformer.py
+++ b/starknet_py/abi/v2/parser_transformer.py
@@ -1,5 +1,5 @@
 from math import log2
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import lark
 from lark import Token, Transformer
@@ -32,11 +32,11 @@ ABI_EBNF = """
         | type_class_hash
         | type_storage_address
         | type_option
+        | type_non_zero
         | type_array
         | type_span
         | tuple
         | type_identifier
-        | type_non_zero
     
     
     type_unit: "()"
@@ -51,7 +51,7 @@ ABI_EBNF = """
     type_option: "core::option::Option::<" (type | type_identifier) ">"
     type_array: "core::array::Array::<" (type | type_identifier) ">"
     type_span: "core::array::Span::<" (type | type_identifier) ">"
-    type_non_zero: "core::zeroable::NonZero<" (type | type_identifier) ">"
+    type_non_zero: "core::zeroable::NonZero::<" (type | type_identifier) ">"
     
     tuple: "(" type? ("," type?)* ")"
     
@@ -188,7 +188,7 @@ class ParserTransformer(Transformer):
         """
         return TupleType(types)
 
-    def type_non_zero(self, value: List[CairoType]) -> NonZeroType:
+    def type_non_zero(self, value: List[Union[FeltType, UintType]]) -> NonZeroType:
         """
         NonZero contains value which is never zero.
         """

--- a/starknet_py/cairo/data_types.py
+++ b/starknet_py/cairo/data_types.py
@@ -121,3 +121,12 @@ class EventType(CairoType):
 
     name: str
     types: OrderedDict[str, CairoType]
+
+
+@dataclass
+class NonZeroType(CairoType):
+    """
+    Type representation of Cairo NonZero.
+    """
+
+    type: CairoType

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -36,5 +36,4 @@ class NonZeroSerializer(CairoDataSerializer[Any, int]):
 
     @staticmethod
     def _ensure_valid_nonzero(value: int, context: Context):
-        print(f"is {value} != 0")
         context.ensure_valid_value(value != 0, "expected value to be non-zero")

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -51,7 +51,8 @@ class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
         if isinstance(value, dict):
             if not isinstance(self.serializer, (UintSerializer, Uint256Serializer)):
                 raise ValueError(
-                    f"Expected serializer to be UintSerializer or Uint256Serializer, got {self.serializer.__class__.__name__}"
+                    f"Expected serializer to be UintSerializer or"
+                    f"Uint256Serializer, got {self.serializer.__class__.__name__}"
                 )
             return self.serializer.serialize_with_context(context, value)
 

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -1,6 +1,5 @@
-import copy
 from dataclasses import dataclass
-from typing import Generator, Union
+from typing import Any, Generator
 
 from starknet_py.serialization._context import (
     Context,
@@ -10,60 +9,31 @@ from starknet_py.serialization._context import (
 from starknet_py.serialization.data_serializers.cairo_data_serializer import (
     CairoDataSerializer,
 )
-from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
-from starknet_py.serialization.data_serializers.uint256_serializer import (
-    Uint256Dict,
-    Uint256Serializer,
-)
-from starknet_py.serialization.data_serializers.uint_serializer import UintSerializer
 
 
 @dataclass
-class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
+class NonZeroSerializer(CairoDataSerializer[Any, int]):
     """
     Serializer for NonZero type.
     Can serialize Cairo numeric types which are non-zero.
     Deserializes data to int.
     """
 
-    serializer: Union[UintSerializer, Uint256Serializer, FeltSerializer]
+    serializer: CairoDataSerializer
 
     def deserialize_with_context(self, context: DeserializationContext) -> int:
-        reader_copy = copy.deepcopy(context.reader)
-        if context.reader.remaining_len == 1:
-            (value,) = reader_copy.read(1)
-            self._ensure_valid_nonzero(value, context)
-        elif context.reader.remaining_len == 2:
-            [low, high] = reader_copy.read(2)
-            self._ensure_valid_nonzero({"low": low, "high": high}, context)
-        else:
-            raise ValueError(
-                f"Expected 1 or 2 elements for numeric type, got {context.reader.remaining_len}"
-            )
-
-        return self.serializer.deserialize_with_context(context)
+        deserialized_value = self.serializer.deserialize_with_context(context)
+        self._ensure_valid_nonzero(deserialized_value, context)
+        return deserialized_value
 
     def serialize_with_context(
-        self, context: SerializationContext, value: Union[int, Uint256Dict]
+        self,
+        context: SerializationContext,
+        value: Any,
     ) -> Generator[int, None, None]:
         self._ensure_valid_nonzero(value, context)
-
-        if isinstance(value, dict):
-            if not isinstance(self.serializer, (UintSerializer, Uint256Serializer)):
-                raise ValueError(
-                    f"Expected serializer to be UintSerializer or"
-                    f"Uint256Serializer, got {self.serializer.__class__.__name__}"
-                )
-            return self.serializer.serialize_with_context(context, value)
-
         return self.serializer.serialize_with_context(context, value)
 
     @staticmethod
-    def _ensure_valid_nonzero(value: Union[int, Uint256Dict], context: Context):
-        if isinstance(value, int):
-            context.ensure_valid_value(value != 0, "expected value to be non-zero")
-        elif isinstance(value, dict):
-            context.ensure_valid_value(
-                value["low"] != 0 or value["high"] != 0,
-                "expected value to be non-zero",
-            )
+    def _ensure_valid_nonzero(value: int, context: Context):
+        context.ensure_valid_value(value != 0, "expected value to be non-zero")

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -54,8 +54,8 @@ class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
                     f"Expected serializer to be UintSerializer or Uint256Serializer, got {self.serializer.__class__.__name__}"
                 )
             return self.serializer.serialize_with_context(context, value)
-        else:
-            return self.serializer.serialize_with_context(context, value)
+
+        return self.serializer.serialize_with_context(context, value)
 
     @staticmethod
     def _ensure_valid_nonzero(value: Union[int, Uint256Dict], context: Context):

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -42,7 +42,7 @@ class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
 
     def serialize_with_context(
         self, context: SerializationContext, value: Union[int, Uint256Dict]
-    ) -> Generator[int, None, None]:
+    ) -> Generator[Union[int, Uint256Dict], None, None]:
         self._ensure_valid_nonzero(value, context)
         return self.serializer.serialize_with_context(context, value)
 

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -1,0 +1,59 @@
+import copy
+from dataclasses import dataclass
+from typing import Generator, Union
+
+from starknet_py.serialization import FeltSerializer
+from starknet_py.serialization._context import (
+    Context,
+    DeserializationContext,
+    SerializationContext,
+)
+from starknet_py.serialization.data_serializers.cairo_data_serializer import (
+    CairoDataSerializer,
+)
+from starknet_py.serialization.data_serializers.uint256_serializer import Uint256Dict
+from starknet_py.serialization.data_serializers.uint_serializer import UintSerializer
+
+CairoNumericTypeSerializer = Union[FeltSerializer, UintSerializer]
+
+
+@dataclass
+class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
+    """
+    Serializer for NonZero type.
+    Can serialize Cairo numeric types which are non-zero.
+    Deserializes data to int.
+    """
+
+    serializer: CairoNumericTypeSerializer
+
+    def deserialize_with_context(self, context: DeserializationContext) -> int:
+        reader_copy = copy.deepcopy(context.reader)
+        if context.reader.remaining_len == 1:
+            (value,) = reader_copy.read(1)
+            self._ensure_valid_nonzero(value, context)
+        elif context.reader.remaining_len == 2:
+            [low, high] = reader_copy.read(2)
+            self._ensure_valid_nonzero({"low": low, "high": high}, context)
+        else:
+            raise ValueError(
+                f"Expected 1 or 2 elements for numeric type, got {context.reader.remaining_len}"
+            )
+
+        return self.serializer.deserialize_with_context(context)
+
+    def serialize_with_context(
+        self, context: SerializationContext, value: Union[int, Uint256Dict]
+    ) -> Generator[int, None, None]:
+        self._ensure_valid_nonzero(value, context)
+        return self.serializer.serialize_with_context(context, value)
+
+    @staticmethod
+    def _ensure_valid_nonzero(value: Union[int, Uint256Dict], context: Context):
+        if isinstance(value, int):
+            context.ensure_valid_value(value != 0, "expected value to be non-zero")
+        elif isinstance(value, dict):
+            context.ensure_valid_value(
+                value["low"] != 0 or value["high"] != 0,
+                "expected value to be non-zero",
+            )

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -2,7 +2,6 @@ import copy
 from dataclasses import dataclass
 from typing import Generator, Union
 
-from starknet_py.serialization import FeltSerializer
 from starknet_py.serialization._context import (
     Context,
     DeserializationContext,
@@ -11,10 +10,9 @@ from starknet_py.serialization._context import (
 from starknet_py.serialization.data_serializers.cairo_data_serializer import (
     CairoDataSerializer,
 )
+from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
 from starknet_py.serialization.data_serializers.uint256_serializer import Uint256Dict
 from starknet_py.serialization.data_serializers.uint_serializer import UintSerializer
-
-CairoNumericTypeSerializer = Union[FeltSerializer, UintSerializer]
 
 
 @dataclass
@@ -25,7 +23,7 @@ class NonZeroSerializer(CairoDataSerializer[Union[int, Uint256Dict], int]):
     Deserializes data to int.
     """
 
-    serializer: CairoNumericTypeSerializer
+    serializer: Union[UintSerializer, FeltSerializer]
 
     def deserialize_with_context(self, context: DeserializationContext) -> int:
         reader_copy = copy.deepcopy(context.reader)

--- a/starknet_py/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/serialization/data_serializers/non_zero_serializer.py
@@ -15,7 +15,7 @@ from starknet_py.serialization.data_serializers.cairo_data_serializer import (
 class NonZeroSerializer(CairoDataSerializer[Any, int]):
     """
     Serializer for NonZero type.
-    Can serialize Cairo numeric types which are non-zero.
+    Can serialize Cairo types which are non-zero.
     Deserializes data to int.
     """
 
@@ -36,4 +36,5 @@ class NonZeroSerializer(CairoDataSerializer[Any, int]):
 
     @staticmethod
     def _ensure_valid_nonzero(value: int, context: Context):
+        print(f"is {value} != 0")
         context.ensure_valid_value(value != 0, "expected value to be non-zero")

--- a/starknet_py/serialization/factory.py
+++ b/starknet_py/serialization/factory.py
@@ -128,6 +128,10 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
         if isinstance(serializer, (UintSerializer, FeltSerializer)):
             return NonZeroSerializer(serializer)
 
+        raise InvalidTypeException(
+            f"Found invalid serializer {serializer.__class__.__name__} for NonZeroType."
+        )
+
     if isinstance(cairo_type, UnitType):
         return UnitSerializer()
 

--- a/starknet_py/serialization/factory.py
+++ b/starknet_py/serialization/factory.py
@@ -124,13 +124,7 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
         return OptionSerializer(serializer_for_type(cairo_type.type))
 
     if isinstance(cairo_type, NonZeroType):
-        serializer = serializer_for_type(cairo_type.type)
-        if isinstance(serializer, (UintSerializer, Uint256Serializer, FeltSerializer)):
-            return NonZeroSerializer(serializer)
-
-        raise InvalidTypeException(
-            f"Found invalid serializer {serializer.__class__.__name__} for NonZeroType."
-        )
+        return NonZeroSerializer(serializer_for_type(cairo_type.type))
 
     if isinstance(cairo_type, UnitType):
         return UnitSerializer()

--- a/starknet_py/serialization/factory.py
+++ b/starknet_py/serialization/factory.py
@@ -125,7 +125,7 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
 
     if isinstance(cairo_type, NonZeroType):
         serializer = serializer_for_type(cairo_type.type)
-        if isinstance(serializer, (UintSerializer, FeltSerializer)):
+        if isinstance(serializer, (UintSerializer, Uint256Serializer, FeltSerializer)):
             return NonZeroSerializer(serializer)
 
         raise InvalidTypeException(

--- a/starknet_py/serialization/factory.py
+++ b/starknet_py/serialization/factory.py
@@ -14,6 +14,7 @@ from starknet_py.cairo.data_types import (
     EventType,
     FeltType,
     NamedTupleType,
+    NonZeroType,
     OptionType,
     StructType,
     TupleType,
@@ -32,6 +33,9 @@ from starknet_py.serialization.data_serializers.enum_serializer import EnumSeria
 from starknet_py.serialization.data_serializers.felt_serializer import FeltSerializer
 from starknet_py.serialization.data_serializers.named_tuple_serializer import (
     NamedTupleSerializer,
+)
+from starknet_py.serialization.data_serializers.non_zero_serializer import (
+    NonZeroSerializer,
 )
 from starknet_py.serialization.data_serializers.option_serializer import (
     OptionSerializer,
@@ -118,6 +122,11 @@ def serializer_for_type(cairo_type: CairoType) -> CairoDataSerializer:
 
     if isinstance(cairo_type, OptionType):
         return OptionSerializer(serializer_for_type(cairo_type.type))
+
+    if isinstance(cairo_type, NonZeroType):
+        serializer = serializer_for_type(cairo_type.type)
+        if isinstance(serializer, (UintSerializer, FeltSerializer)):
+            return NonZeroSerializer(serializer)
 
     if isinstance(cairo_type, UnitType):
         return UnitSerializer()

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
@@ -60,7 +60,7 @@ mod AbiTypes {
                 field_b: 300,
                 field_c: ExampleEnum::variant_b(400.into()),
                 field_d: (),
-                field_e: felt_to_nonzero(0),
+                field_e: felt_to_nonzero(100),
             }
         }
     }

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
@@ -1,5 +1,8 @@
 use core::serde::Serde;
 use starknet::ContractAddress;
+use core::zeroable::NonZero;
+use core::zeroable::IsZeroResult;
+use core::zeroable::NonZeroIntoImpl;
 
 #[derive(Drop, Serde)]
 enum ExampleEnum {
@@ -13,6 +16,7 @@ struct ExampleStruct {
     field_b: felt252,
     field_c: ExampleEnum,
     field_d: (),
+    field_e: NonZero<felt252>,
 }
 
 #[starknet::interface]
@@ -23,13 +27,19 @@ trait IAbiTest<TContractState> {
     ) -> ExampleStruct;
 }
 
+pub fn felt_to_nonzero(value: felt252) -> NonZero<felt252> {
+    match felt252_is_zero(value) {
+        IsZeroResult::Zero(()) => panic(ArrayTrait::new()),
+        IsZeroResult::NonZero(x) => x,
+    }
+}
 
 #[starknet::contract]
 mod AbiTypes {
     use core::array::ArrayTrait;
     use core::traits::Into;
     use starknet::ContractAddress;
-    use super::{ExampleEnum, ExampleStruct};
+    use super::{ExampleEnum, ExampleStruct, felt_to_nonzero};
 
     #[storage]
     struct Storage {}
@@ -46,7 +56,11 @@ mod AbiTypes {
             ref self: ContractState, recipient: ContractAddress, amount: u256
         ) -> ExampleStruct {
             ExampleStruct {
-                field_a: 200, field_b: 300, field_c: ExampleEnum::variant_b(400.into()), field_d: ()
+                field_a: 200,
+                field_b: 300,
+                field_c: ExampleEnum::variant_b(400.into()),
+                field_d: (),
+                field_e: felt_to_nonzero(100),
             }
         }
     }

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
@@ -3,6 +3,7 @@ use starknet::ContractAddress;
 use core::zeroable::NonZero;
 use core::zeroable::IsZeroResult;
 use core::zeroable::NonZeroIntoImpl;
+use core::integer::{u8_try_as_non_zero};
 
 #[derive(Drop, Serde)]
 enum ExampleEnum {
@@ -17,6 +18,7 @@ struct ExampleStruct {
     field_c: ExampleEnum,
     field_d: (),
     field_e: NonZero<felt252>,
+    field_f: NonZero<u8>,
 }
 
 #[starknet::interface]
@@ -34,12 +36,19 @@ pub fn felt_to_nonzero(value: felt252) -> NonZero<felt252> {
     }
 }
 
+pub fn u8_to_nonzero(value: u8) -> NonZero<u8> {
+    match u8_try_as_non_zero(value) {
+        Option::Some(x) => x,
+        Option::None => panic(ArrayTrait::new()),
+    }
+}
+
 #[starknet::contract]
 mod AbiTypes {
     use core::array::ArrayTrait;
     use core::traits::Into;
     use starknet::ContractAddress;
-    use super::{ExampleEnum, ExampleStruct, felt_to_nonzero};
+    use super::{ExampleEnum, ExampleStruct, felt_to_nonzero, u8_to_nonzero};
 
     #[storage]
     struct Storage {}
@@ -61,6 +70,7 @@ mod AbiTypes {
                 field_c: ExampleEnum::variant_b(400.into()),
                 field_d: (),
                 field_e: felt_to_nonzero(100),
+                field_f: u8_to_nonzero(100),
             }
         }
     }

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/abi_types.cairo
@@ -60,7 +60,7 @@ mod AbiTypes {
                 field_b: 300,
                 field_c: ExampleEnum::variant_b(400.into()),
                 field_d: (),
-                field_e: felt_to_nonzero(100),
+                field_e: felt_to_nonzero(0),
             }
         }
     }

--- a/starknet_py/tests/unit/serialization/data_serializers/non_zero_serializer.py
+++ b/starknet_py/tests/unit/serialization/data_serializers/non_zero_serializer.py
@@ -1,0 +1,39 @@
+import pytest
+
+from starknet_py.constants import FIELD_PRIME
+from starknet_py.serialization import FeltSerializer
+from starknet_py.serialization.data_serializers.non_zero_serializer import (
+    NonZeroSerializer,
+)
+from starknet_py.serialization.data_serializers.uint_serializer import UintSerializer
+
+
+@pytest.mark.parametrize(
+    "serializer, value, serialized_value",
+    [
+        (NonZeroSerializer(UintSerializer(128)), 123, [123]),
+        (NonZeroSerializer(UintSerializer(256)), 1, [1, 0]),
+        (NonZeroSerializer(FeltSerializer()), 10, [10]),
+        (NonZeroSerializer(FeltSerializer()), FIELD_PRIME - 1, [FIELD_PRIME - 1]),
+    ],
+)
+def test_valid_values(serializer, value, serialized_value):
+    deserialized = serializer.deserialize(serialized_value)
+    assert deserialized == value
+
+    serialized = serializer.serialize(value)
+    assert serialized == serialized_value
+
+
+@pytest.mark.parametrize(
+    "serializer, value, serialized_value",
+    [
+        (NonZeroSerializer(UintSerializer(128)), 0, [0]),
+        (NonZeroSerializer(UintSerializer(256)), 0, [0, 0]),
+        (NonZeroSerializer(FeltSerializer()), 0, [0]),
+    ],
+)
+def test_invalid_values(serializer, value, serialized_value):
+    with pytest.raises(ValueError, match="expected value to be non-zero"):
+        serializer.deserialize(serialized_value)
+        serializer.serialize(value)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1519 


## Introduced changes

This PR fixes error occurring when contract's ABI contains [`core::zeroable::NonZero`](https://github.com/starkware-libs/cairo/blob/a2b9dddeb3212c8d529538454745b27d7a34a6cd/corelib/src/zeroable.cairo#L78)
- Add `NonZeroType` and `NonZeroTypeSerializer`

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


