### PR TITLE
Bump artifact actions to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,7 +125,7 @@ jobs:
           poetry run poe compile_contracts v1
 
       - name: Upload contracts artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download contracts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download contracts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/
@@ -334,7 +334,7 @@ jobs:
           toolchain: 1.79.0  # Doesn't work with "stable"
 
       - name: Download contracts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/
@@ -411,7 +411,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download contracts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/
@@ -478,7 +478,7 @@ jobs:
           toolchain: 1.79.0 # Doesn't work with "stable"
 
       - name: Download contracts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: contract-artifacts
           path: starknet_py/tests/e2e/mock/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build SDist
         run: poetry build -f sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->


Bump artifact actions of v4 because of [soon v3 deprecation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


