### PR TITLE
Fix `test_get_storage_proof` on sepolia

### DIFF
--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -527,19 +527,10 @@ async def test_get_storage_proof(client_sepolia_testnet):
         class_hashes=[int(STRK_CLASS_HASH, 16)],
     )
 
-    assert len(storage_proof.classes_proof) == 17
-    assert len(storage_proof.contracts_proof.nodes) == 20
-    assert len(storage_proof.contracts_storage_proofs[0]) == 16
-
-    assert storage_proof.global_roots.block_hash == int(
-        "0x404446e37fc08c0bf4979821e50bdac7919b56d19d2df9e16f0aa7a0d506e50", 16
-    )
-    assert storage_proof.global_roots.classes_tree_root == int(
-        "0x43568bf995aacf4b56615e97b7237c1b03d199344ad66d38f38fda250ef1586", 16
-    )
-    assert storage_proof.global_roots.contracts_tree_root == int(
-        "0x2ae204c3378558b33c132f4721612285d9988cc8dc99f47fce92adc6b38a189", 16
-    )
+    # We can't check exact values, as they change with each block
+    assert len(storage_proof.classes_proof) > 0
+    assert len(storage_proof.contracts_proof.nodes) > 0
+    assert len(storage_proof.contracts_storage_proofs[0]) > 16
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -527,7 +527,7 @@ async def test_get_storage_proof(client_sepolia_testnet):
         class_hashes=[int(STRK_CLASS_HASH, 16)],
     )
 
-    # We can't check exact values, as they change with each block
+    # We can't check exact values, as they change over the time
     assert len(storage_proof.classes_proof) > 0
     assert len(storage_proof.contracts_proof.nodes) > 0
     assert len(storage_proof.contracts_storage_proofs[0]) > 16

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -513,8 +513,10 @@ async def test_get_pending_block_with_receipts(client_sepolia_testnet):
 
 @pytest.mark.asyncio
 async def test_get_storage_proof(client_sepolia_testnet):
+    # Nodes don't support storage proofs for blocks that are too far in the past, hence we need to get last block number
+    block_number = await client_sepolia_testnet.get_block_number()
     storage_proof = await client_sepolia_testnet.get_storage_proof(
-        block_id={"block_number": 556669},
+        block_id={"block_number": block_number},
         contract_addresses=[int(STRK_FEE_CONTRACT_ADDRESS, 16)],
         contracts_storage_keys=[
             ContractsStorageKeys(


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->

Nodes don't support storage proofs for blocks that are too far in the past, hence we need to get last block number.
Also we can't check exact values as they change over the time

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


