### PR TITLE
Restore auto estimation in tests

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -7,9 +7,10 @@ Migration guide
 
 0.26.1 Bugfixes
 ---------------
+
 .. py:currentmodule:: starknet_py.net.client_models
 
-1. Changed type of ``execution_resources`` in :class:`FunctionInvocation` to :class:`InnerCallExecutionResources`.
+1. In :class:`FunctionInvocation`, ``execution_resources`` field is now of type :class:`InnerCallExecutionResources`.
 
 **********************
 0.26.0 Migration guide

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,15 @@ Migration guide
 ===============
 
 **********************
+0.26.1 Migration guide
+**********************
+
+.. py:currentmodule:: starknet_py.net.client_models
+
+1. Restored ``amount_multiplier`` and ``unit_price_multiplier`` params in :meth:`EstimatedFee.to_resource_bounds`
+
+
+**********************
 0.26.0 Migration guide
 **********************
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,15 +2,6 @@ Migration guide
 ===============
 
 **********************
-0.26.1 Migration guide
-**********************
-
-.. py:currentmodule:: starknet_py.net.client_models
-
-1. Restored ``amount_multiplier`` and ``unit_price_multiplier`` params in :meth:`EstimatedFee.to_resource_bounds`
-
-
-**********************
 0.26.0 Migration guide
 **********************
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,16 @@ Migration guide
 ===============
 
 **********************
+0.26.1 Migration guide
+**********************
+
+0.26.1 Bugfixes
+---------------
+.. py:currentmodule:: starknet_py.net.client_models
+
+1. Changed type of ``execution_resources`` in :class:`FunctionInvocation` to :class:`InnerCallExecutionResources`.
+
+**********************
 0.26.0 Migration guide
 **********************
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -420,6 +420,16 @@ class TransactionFinalityStatus(Enum):
 
 
 @dataclass
+class InnerCallExecutionResources:
+    """
+    Dataclass representing the resource consumed by an inner call (does not account for state diffs).
+    """
+
+    l1_gas: int
+    l2_gas: int
+
+
+@dataclass
 class ExecutionResources:
     """
     Dataclass representing the resources consumed by the transaction, includes both computation and data.
@@ -1023,7 +1033,7 @@ class FunctionInvocation:
     calls: List["FunctionInvocation"]
     events: List[OrderedEvent]
     messages: List[OrderedMessage]
-    execution_resources: ExecutionResources
+    execution_resources: InnerCallExecutionResources
     is_reverted: bool
 
 

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -646,30 +646,26 @@ class EstimatedFee:
     overall_fee: int
     unit: PriceUnit
 
-    def to_resource_bounds(
-        self, amount_multiplier=1.5, unit_price_multiplier=1.5
-    ) -> ResourceBoundsMapping:
+    def to_resource_bounds(self) -> ResourceBoundsMapping:
         """
         Converts estimated fee to resource bounds with applied multipliers.
 
-        :param amount_multiplier: Multiplier for max amount, defaults to 1.5.
-        :param unit_price_multiplier: Multiplier for max price per unit, defaults to 1.5.
         :return: Resource bounds with applied multipliers.
         """
 
         l1_resource_bounds = ResourceBounds(
-            max_amount=int(self.l1_gas_consumed * amount_multiplier),
-            max_price_per_unit=int(self.l1_gas_price * unit_price_multiplier),
+            max_amount=self.l1_gas_consumed,
+            max_price_per_unit=self.l1_gas_price,
         )
 
         l2_resource_bounds = ResourceBounds(
-            max_amount=int(self.l2_gas_consumed * amount_multiplier),
-            max_price_per_unit=int(self.l2_gas_price * unit_price_multiplier),
+            max_amount=self.l2_gas_consumed,
+            max_price_per_unit=self.l2_gas_price,
         )
 
         l1_data_resource_bounds = ResourceBounds(
-            max_amount=int(self.l1_data_gas_consumed * amount_multiplier),
-            max_price_per_unit=int(self.l1_data_gas_price * unit_price_multiplier),
+            max_amount=self.l1_data_gas_consumed,
+            max_price_per_unit=self.l1_data_gas_price,
         )
 
         return ResourceBoundsMapping(

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -646,26 +646,30 @@ class EstimatedFee:
     overall_fee: int
     unit: PriceUnit
 
-    def to_resource_bounds(self) -> ResourceBoundsMapping:
+    def to_resource_bounds(
+        self, amount_multiplier=1.5, unit_price_multiplier=1.5
+    ) -> ResourceBoundsMapping:
         """
         Converts estimated fee to resource bounds with applied multipliers.
 
+        :param amount_multiplier: Multiplier for max amount, defaults to 1.5.
+        :param unit_price_multiplier: Multiplier for max price per unit, defaults to 1.5.
         :return: Resource bounds with applied multipliers.
         """
 
         l1_resource_bounds = ResourceBounds(
-            max_amount=self.l1_gas_consumed,
-            max_price_per_unit=self.l1_gas_price,
+            max_amount=int(self.l1_gas_consumed * amount_multiplier),
+            max_price_per_unit=int(self.l1_gas_price * unit_price_multiplier),
         )
 
         l2_resource_bounds = ResourceBounds(
-            max_amount=self.l2_gas_consumed,
-            max_price_per_unit=self.l2_gas_price,
+            max_amount=int(self.l2_gas_consumed * amount_multiplier),
+            max_price_per_unit=int(self.l2_gas_price * unit_price_multiplier),
         )
 
         l1_data_resource_bounds = ResourceBounds(
-            max_amount=self.l1_data_gas_consumed,
-            max_price_per_unit=self.l1_data_gas_price,
+            max_amount=int(self.l1_data_gas_consumed * amount_multiplier),
+            max_price_per_unit=int(self.l1_data_gas_price * unit_price_multiplier),
         )
 
         return ResourceBoundsMapping(

--- a/starknet_py/net/schemas/rpc/general.py
+++ b/starknet_py/net/schemas/rpc/general.py
@@ -1,8 +1,21 @@
 from marshmallow import fields, post_load
 
-from starknet_py.net.client_models import EstimatedFee, ExecutionResources
+from starknet_py.net.client_models import (
+    EstimatedFee,
+    ExecutionResources,
+    InnerCallExecutionResources,
+)
 from starknet_py.net.schemas.common import Felt, PriceUnitField
 from starknet_py.utils.schema import Schema
+
+
+class InnerCallExecutionResourcesSchema(Schema):
+    l1_gas = fields.Integer(data_key="l1_gas", required=True)
+    l2_gas = fields.Integer(data_key="l2_gas", required=True)
+
+    @post_load
+    def make_dataclass(self, data, **kwargs) -> InnerCallExecutionResources:
+        return InnerCallExecutionResources(**data)
 
 
 class ExecutionResourcesSchema(Schema):

--- a/starknet_py/net/schemas/rpc/general.py
+++ b/starknet_py/net/schemas/rpc/general.py
@@ -5,7 +5,7 @@ from starknet_py.net.client_models import (
     ExecutionResources,
     InnerCallExecutionResources,
 )
-from starknet_py.net.schemas.common import Felt, PriceUnitField
+from starknet_py.net.schemas.common import PriceUnitField, Uint64, Uint128
 from starknet_py.utils.schema import Schema
 
 
@@ -29,13 +29,13 @@ class ExecutionResourcesSchema(Schema):
 
 
 class EstimatedFeeSchema(Schema):
-    l1_gas_consumed = Felt(data_key="l1_gas_consumed", required=True)
-    l1_gas_price = Felt(data_key="l1_gas_price", required=True)
-    l2_gas_consumed = Felt(data_key="l2_gas_consumed", required=True)
-    l2_gas_price = Felt(data_key="l2_gas_price", required=True)
-    l1_data_gas_consumed = Felt(data_key="l1_data_gas_consumed", required=True)
-    l1_data_gas_price = Felt(data_key="l1_data_gas_price", required=True)
-    overall_fee = Felt(data_key="overall_fee", required=True)
+    l1_gas_consumed = Uint64(data_key="l1_gas_consumed", required=True)
+    l1_gas_price = Uint128(data_key="l1_gas_price", required=True)
+    l2_gas_consumed = Uint64(data_key="l2_gas_consumed", required=True)
+    l2_gas_price = Uint128(data_key="l2_gas_price", required=True)
+    l1_data_gas_consumed = Uint64(data_key="l1_data_gas_consumed", required=True)
+    l1_data_gas_price = Uint128(data_key="l1_data_gas_price", required=True)
+    overall_fee = Uint128(data_key="overall_fee", required=True)
     unit = PriceUnitField(data_key="unit", required=True)
 
     @post_load

--- a/starknet_py/net/schemas/rpc/trace_api.py
+++ b/starknet_py/net/schemas/rpc/trace_api.py
@@ -18,6 +18,7 @@ from starknet_py.net.schemas.rpc.block import StateDiffSchema
 from starknet_py.net.schemas.rpc.general import (
     EstimatedFeeSchema,
     ExecutionResourcesSchema,
+    InnerCallExecutionResourcesSchema,
 )
 from starknet_py.utils.schema import Schema
 
@@ -67,7 +68,7 @@ class FunctionInvocationSchema(Schema):
         fields.Nested(OrderedMessageSchema()), data_key="messages", required=True
     )
     execution_resources = fields.Nested(
-        ExecutionResourcesSchema(),
+        InnerCallExecutionResourcesSchema(),
         data_key="execution_resources",
         required=True,
     )

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -235,7 +235,6 @@ async def test_sign_invoke_v3(account, calls):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_sign_invoke_v3_auto_estimate(account, map_contract):
     signed_tx = await account.sign_invoke_v3(
         Call(map_contract.address, get_selector_from_name("put"), [3, 4]),
@@ -278,7 +277,6 @@ async def test_sign_declare_v3(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_sign_declare_v3_auto_estimate(
     account, sierra_minimal_compiled_contract_and_class_hash
 ):
@@ -328,7 +326,6 @@ async def test_sign_deploy_account_v3(account):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_sign_deploy_account_v3_auto_estimate(
     account, account_with_validate_deploy_class_hash
 ):

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -248,9 +248,12 @@ async def test_sign_invoke_v3_auto_estimate(account, map_contract):
     assert len(signed_tx.signature) == 2
 
     assert isinstance(signed_tx.resource_bounds, ResourceBoundsMapping)
-    assert signed_tx.resource_bounds.l1_gas.max_amount > 0
+    assert signed_tx.resource_bounds.l1_gas.max_amount >= 0
     assert signed_tx.resource_bounds.l1_gas.max_price_per_unit > 0
-    assert signed_tx.resource_bounds.l2_gas == ResourceBounds.init_with_zeros()
+    assert signed_tx.resource_bounds.l2_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l2_gas.max_price_per_unit > 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_price_per_unit > 0
 
 
 @pytest.mark.asyncio
@@ -296,9 +299,12 @@ async def test_sign_declare_v3_auto_estimate(
     assert len(signed_tx.signature) == 2
 
     assert isinstance(signed_tx.resource_bounds, ResourceBoundsMapping)
-    assert signed_tx.resource_bounds.l1_gas.max_amount > 0
+    assert signed_tx.resource_bounds.l1_gas.max_amount >= 0
     assert signed_tx.resource_bounds.l1_gas.max_price_per_unit > 0
-    assert signed_tx.resource_bounds.l2_gas == ResourceBounds.init_with_zeros()
+    assert signed_tx.resource_bounds.l2_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l2_gas.max_price_per_unit > 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_price_per_unit > 0
 
 
 @pytest.mark.asyncio
@@ -343,9 +349,12 @@ async def test_sign_deploy_account_v3_auto_estimate(
     assert len(signed_tx.signature) == 2
 
     assert isinstance(signed_tx.resource_bounds, ResourceBoundsMapping)
-    assert signed_tx.resource_bounds.l1_gas.max_amount > 0
+    assert signed_tx.resource_bounds.l1_gas.max_amount >= 0
     assert signed_tx.resource_bounds.l1_gas.max_price_per_unit > 0
-    assert signed_tx.resource_bounds.l2_gas == ResourceBounds.init_with_zeros()
+    assert signed_tx.resource_bounds.l2_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l2_gas.max_price_per_unit > 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_amount >= 0
+    assert signed_tx.resource_bounds.l1_data_gas.max_price_per_unit > 0
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/cairo1v2_test.py
+++ b/starknet_py/tests/e2e/cairo1v2_test.py
@@ -21,15 +21,11 @@ async def declare_deploy_hello2(account) -> Tuple[DeclareResult, DeployResult]:
         account=account,
         compiled_contract=contract["sierra"],
         compiled_contract_casm=contract["casm"],
-        # TODO(#1558): Use auto estimation
-        resource_bounds=MAX_RESOURCE_BOUNDS,
+        auto_estimate=True,
     )
     await declare_result.wait_for_acceptance()
 
-    deploy_result = await declare_result.deploy_v3(
-        # TODO(#1558): Use auto estimation
-        resource_bounds=MAX_RESOURCE_BOUNDS,
-    )
+    deploy_result = await declare_result.deploy_v3(auto_estimate=True)
     await deploy_result.wait_for_acceptance()
 
     return declare_result, deploy_result
@@ -49,13 +45,11 @@ async def test_deploy_cairo2(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_interaction(contract):
-    # TODO(#1558): Use auto estimation
     invoke_res = await contract.functions["increase_balance"].invoke_v3(
-        amount=100, resource_bounds=MAX_RESOURCE_BOUNDS
+        amount=100, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["increase_balance"].invoke_v3(
         amount=100, resource_bounds=MAX_RESOURCE_BOUNDS
     )
@@ -67,9 +61,8 @@ async def test_cairo2_interaction(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_interaction2(contract):
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["increase_balance_u8"].invoke_v3(
-        255, resource_bounds=MAX_RESOURCE_BOUNDS
+        255, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
@@ -97,9 +90,8 @@ async def test_cairo2_u256(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_contract_address(contract):
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["set_ca"].invoke_v3(
-        address=contract.account.address, resource_bounds=MAX_RESOURCE_BOUNDS
+        address=contract.account.address, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
 
@@ -109,9 +101,8 @@ async def test_cairo2_contract_address(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_interaction3(contract):
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["increase_balance"].invoke_v3(
-        100, resource_bounds=MAX_RESOURCE_BOUNDS
+        100, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
     (balance,) = await contract.functions["get_balance"].call()
@@ -119,9 +110,8 @@ async def test_cairo2_interaction3(contract):
     storage = await contract.client.get_storage_at(contract.address, key)
     assert storage == balance
 
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["set_ca"].invoke_v3(
-        contract.account.address, resource_bounds=MAX_RESOURCE_BOUNDS
+        contract.account.address, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
     (ca,) = await contract.functions["get_ca"].call()  # pylint: disable=invalid-name
@@ -129,9 +119,8 @@ async def test_cairo2_interaction3(contract):
     storage = await contract.client.get_storage_at(contract.address, key)
     assert storage == ca
 
-    # TODO (#1558): Use auto estimation
     invoke_res = await contract.functions["set_status"].invoke_v3(
-        True, resource_bounds=MAX_RESOURCE_BOUNDS
+        True, auto_estimate=True
     )
     await invoke_res.wait_for_acceptance()
     (status,) = await contract.functions["get_status"].call()
@@ -144,8 +133,7 @@ async def test_cairo2_interaction3(contract):
             "address": contract.account.address,
             "is_claimed": True,
         },
-        # TODO (#1558): Use auto estimation
-        resource_bounds=MAX_RESOURCE_BOUNDS,
+        auto_estimate=True,
     )
     await invoke_res.wait_for_acceptance()
     (user1,) = await contract.functions["get_user1"].call()
@@ -178,10 +166,7 @@ async def test_cairo2_echo_struct(contract):
 
 @pytest.mark.asyncio
 async def test_cairo2_echo_complex_struct(contract):
-    # TODO (#1558): Use auto estimation
-    invoke_result = await contract.functions["set_bet"].invoke_v3(
-        resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_result = await contract.functions["set_bet"].invoke_v3(auto_estimate=True)
     await invoke_result.wait_for_acceptance()
 
     (bet,) = await contract.functions["get_bet"].call(1)

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -147,17 +147,13 @@ async def test_get_storage_at_incorrect_address_full_node_client(client):
 )
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_get_events_without_following_continuation_token(
     client,
     simple_storage_with_event_contract: Contract,
 ):
     for i in range(4):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i, auto_estimate=True
         )
 
     chunk_size = 3
@@ -187,10 +183,7 @@ async def test_get_events_follow_continuation_token(
     total_invokes = 2
     for i in range(total_invokes):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i + 1,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i + 1, auto_estimate=True
         )
 
     events_response = await client.get_events(
@@ -212,7 +205,6 @@ async def test_get_events_follow_continuation_token(
 )
 @pytest.mark.run_on_devnet
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_get_events_nonexistent_event_name(
     client,
     simple_storage_with_event_contract: Contract,
@@ -248,17 +240,11 @@ async def test_get_events_with_two_events(
     invokes_of_two = 2
     invokes_of_all = invokes_of_one + invokes_of_two
     await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke_v3(
-        # TODO(#1558): Use auto estimation
-        1,
-        2,
-        resource_bounds=MAX_RESOURCE_BOUNDS,
+        1, 2, auto_estimate=True
     )
     for i in range(invokes_of_two):
         await simple_storage_with_event_contract.functions[FUNCTION_TWO_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i + 1,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i + 1, auto_estimate=True
         )
 
     event_one_events_response = await client.get_events(
@@ -305,10 +291,7 @@ async def test_get_events_start_from_continuation_token(
 ):
     for i in range(5):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i + 1,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i + 1, auto_estimate=True
         )
 
     chunk_size = 2
@@ -340,16 +323,10 @@ async def test_get_events_no_params(
     default_chunk_size = 1
     for i in range(3):
         await simple_storage_with_event_contract.functions[FUNCTION_ONE_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i + 1,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i + 1, auto_estimate=True
         )
         await simple_storage_with_event_contract.functions[FUNCTION_TWO_NAME].invoke_v3(
-            # TODO(#1558): Use auto estimation
-            i,
-            i + 1,
-            resource_bounds=MAX_RESOURCE_BOUNDS,
+            i, i + 1, auto_estimate=True
         )
     events_response = await client.get_events()
 
@@ -457,10 +434,7 @@ async def test_simulate_transactions_skip_validate(account, deployed_balance_con
         calldata=[0x10],
     )
 
-    # TODO(#1558): Use auto estimation
-    invoke_tx = await account.sign_invoke_v3(
-        calls=call, resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_tx = await account.sign_invoke_v3(calls=call, auto_estimate=True)
     invoke_tx = dataclasses.replace(invoke_tx, signature=[])
 
     simulated_txs = await account.client.simulate_transactions(
@@ -488,10 +462,7 @@ async def test_simulate_transactions_skip_fee_charge(
         calldata=[0x10],
     )
 
-    # TODO(#1558): Use auto estimation
-    invoke_tx = await account.sign_invoke_v3(
-        calls=call, resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_tx = await account.sign_invoke_v3(calls=call, auto_estimate=True)
 
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], skip_fee_charge=True, block_number="latest"
@@ -500,7 +471,6 @@ async def test_simulate_transactions_skip_fee_charge(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
@@ -509,10 +479,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
         calldata=[0x10],
     )
 
-    # TODO(#1558): Use auto estimation
-    invoke_tx = await account.sign_invoke_v3(
-        calls=call, resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_tx = await account.sign_invoke_v3(calls=call, auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], block_number="latest"
     )
@@ -522,10 +489,7 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert simulated_txs[0].transaction_trace.execute_invocation is not None
     assert simulated_txs[0].transaction_trace.execution_resources is not None
 
-    # TODO(#1558): Use auto estimation
-    invoke_tx = await account.sign_invoke_v3(
-        calls=[call, call], resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_tx = await account.sign_invoke_v3(calls=[call, call], auto_estimate=True)
     simulated_txs = await account.client.simulate_transactions(
         transactions=[invoke_tx], block_number="latest"
     )
@@ -537,7 +501,6 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_simulate_transactions_two_txs(account, deployed_balance_contract):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
@@ -545,10 +508,7 @@ async def test_simulate_transactions_two_txs(account, deployed_balance_contract)
         selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
-    # TODO(#1558): Use auto estimation
-    invoke_tx = await account.sign_invoke_v3(
-        calls=call, resource_bounds=MAX_RESOURCE_BOUNDS
-    )
+    invoke_tx = await account.sign_invoke_v3(calls=call, auto_estimate=True)
 
     contract = load_contract(
         contract_name="TestContractDeclare", version=ContractVersion.V1

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -30,7 +30,6 @@ async def test_invoke_v3(map_contract):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558)")
 async def test_auto_fee_estimation_v3(map_contract):
     prepared_invoke = map_contract.functions["put"].prepare_invoke_v3(key=1, value=2)
     assert isinstance(prepared_invoke, PreparedFunctionInvokeV3)

--- a/starknet_py/tests/e2e/docs/code_examples/test_account.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_account.py
@@ -25,7 +25,6 @@ def test_init():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("#1558")
 async def test_execute_v3(account, contract_address):
     # docs-start: execute_v3
     resource_bounds = ResourceBoundsMapping(

--- a/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_invoke_v3.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_prepared_function_invoke_v3.py
@@ -6,7 +6,6 @@ from starknet_py.net.client_models import ResourceBounds, ResourceBoundsMapping
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("TODO(#1558): Use auto estimation")
 async def test_invoke(map_contract: Contract):
     prepared_function_call = map_contract.functions["put"].prepare_invoke_v3(
         key=10, value=20

--- a/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
@@ -10,10 +10,7 @@ async def test_create_call_from_contract(map_contract, account):
 
     client = account.client
     res = await map_contract.functions["put"].invoke_v3(
-        # TODO(#1558): Use auto estimation
-        key=1234,
-        value=9999,
-        resource_bounds=MAX_RESOURCE_BOUNDS,
+        key=1234, value=9999, auto_estimate=True
     )
     await res.wait_for_acceptance()
 

--- a/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
+++ b/starknet_py/tests/e2e/docs/guide/test_contract_client_compatibility.py
@@ -1,7 +1,5 @@
 import pytest
 
-from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
-
 
 @pytest.mark.asyncio
 async def test_create_call_from_contract(map_contract, account):


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1558 


## Introduced changes
<!-- A brief description of the changes -->


- Fee auto estimation is working fine in devnet 0.3.0, hence we can restore some tests and use auto estimation
- Add missing `InnerCallExecutionResources`



##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


