### PR TITLE
Refactor `Call` dataclass

### DIFF
--- a/starknet_py/contract.py
+++ b/starknet_py/contract.py
@@ -483,9 +483,9 @@ class ContractFunction:
 
         calldata = self._payload_transformer.serialize(*args, **kwargs)
         return PreparedFunctionCall(
-            to_addr=self.contract_data.address,
+            contract_address=self.contract_data.address,
             calldata=calldata,
-            selector=self.get_selector(self.name),
+            entry_point_selector=self.get_selector(self.name),
             _client=self.client,
             _payload_transformer=self._payload_transformer,
         )
@@ -527,9 +527,9 @@ class ContractFunction:
 
         calldata = self._payload_transformer.serialize(*args, **kwargs)
         return PreparedFunctionInvokeV3(
-            to_addr=self.contract_data.address,
+            contract_address=self.contract_data.address,
             calldata=calldata,
-            selector=self.get_selector(self.name),
+            entry_point_selector=self.get_selector(self.name),
             resource_bounds=resource_bounds,
             _contract_data=self.contract_data,
             _client=self.client,

--- a/starknet_py/hash/outside_execution.py
+++ b/starknet_py/hash/outside_execution.py
@@ -62,8 +62,8 @@ def outside_execution_to_typed_data(
                     "calls_len": len(outside_execution.calls),
                     "calls": [
                         {
-                            "to": call.to_addr,
-                            "selector": call.selector,
+                            "to": call.contract_address,
+                            "selector": call.entry_point_selector,
                             "calldata_len": len(call.calldata),
                             "calldata": call.calldata,
                         }
@@ -110,8 +110,8 @@ def outside_execution_to_typed_data(
                 "Execute Before": outside_execution.execute_before,
                 "Calls": [
                     {
-                        "To": call.to_addr,
-                        "Selector": call.selector,
+                        "To": call.contract_address,
+                        "Selector": call.entry_point_selector,
                         "Calldata": call.calldata,
                     }
                     for call in outside_execution.calls

--- a/starknet_py/net/account/account.py
+++ b/starknet_py/net/account/account.py
@@ -243,8 +243,10 @@ class Account(BaseAccount, OutsideExecutionSupportBaseMixin):
     ) -> bool:
         (is_valid,) = await self._client.call_contract(
             call=Call(
-                to_addr=self.address,
-                selector=get_selector_from_name("is_valid_outside_execution_nonce"),
+                contract_address=self.address,
+                entry_point_selector=get_selector_from_name(
+                    "is_valid_outside_execution_nonce"
+                ),
                 calldata=[nonce],
             ),
             block_hash=block_hash,
@@ -276,8 +278,8 @@ class Account(BaseAccount, OutsideExecutionSupportBaseMixin):
     ) -> bool:
         (does_support,) = await self._client.call_contract(
             Call(
-                to_addr=self.address,
-                selector=get_selector_from_name("supports_interface"),
+                contract_address=self.address,
+                entry_point_selector=get_selector_from_name("supports_interface"),
                 calldata=[interface_id],
             )
         )
@@ -301,8 +303,8 @@ class Account(BaseAccount, OutsideExecutionSupportBaseMixin):
 
         low, high = await self._client.call_contract(
             Call(
-                to_addr=parse_address(token_address),
-                selector=get_selector_from_name("balance_of"),
+                contract_address=parse_address(token_address),
+                entry_point_selector=get_selector_from_name("balance_of"),
                 calldata=[self.address],
             ),
             block_hash=block_hash,
@@ -360,8 +362,10 @@ class Account(BaseAccount, OutsideExecutionSupportBaseMixin):
         }
 
         return Call(
-            to_addr=self.address,
-            selector=get_selector_from_name(selector_for_version[interface_version]),
+            contract_address=self.address,
+            entry_point_selector=get_selector_from_name(
+                selector_for_version[interface_version]
+            ),
             calldata=_outside_transaction_serialiser.serialize(
                 {
                     "outside_execution": outside_execution.to_abi_dict(),
@@ -650,8 +654,8 @@ def _parse_calls(cairo_version: int, calls: Calls) -> List[int]:
 
 def _parse_call_cairo_v0(call: Call, entire_calldata: List) -> Tuple[Dict, List]:
     _data = {
-        "to": call.to_addr,
-        "selector": call.selector,
+        "to": call.contract_address,
+        "entry_point_selector": call.entry_point_selector,
         "data_offset": len(entire_calldata),
         "data_len": len(call.calldata),
     }
@@ -674,8 +678,8 @@ def _parse_calls_cairo_v1(calls: Iterable[Call]) -> List[Dict]:
     calls_parsed = []
     for call in calls:
         _data = {
-            "to": call.to_addr,
-            "selector": call.selector,
+            "to": call.contract_address,
+            "entry_point_selector": call.entry_point_selector,
             "calldata": call.calldata,
         }
         calls_parsed.append(_data)
@@ -687,7 +691,7 @@ _felt_serializer = FeltSerializer()
 _call_description_cairo_v0 = StructSerializer(
     OrderedDict(
         to=_felt_serializer,
-        selector=_felt_serializer,
+        entry_point_selector=_felt_serializer,
         data_offset=_felt_serializer,
         data_len=_felt_serializer,
     )
@@ -695,7 +699,7 @@ _call_description_cairo_v0 = StructSerializer(
 _call_description_cairo_v1 = StructSerializer(
     OrderedDict(
         to=_felt_serializer,
-        selector=_felt_serializer,
+        entry_point_selector=_felt_serializer,
         calldata=ArraySerializer(_felt_serializer),
     )
 )

--- a/starknet_py/net/client_models.py
+++ b/starknet_py/net/client_models.py
@@ -42,8 +42,8 @@ class Call:
     Dataclass representing a call to Starknet contract.
     """
 
-    to_addr: int
-    selector: int
+    contract_address: int
+    entry_point_selector: int
     calldata: List[int]
 
 
@@ -1235,8 +1235,8 @@ class OutsideExecution:
             "execute_before": self.execute_before,
             "calls": [
                 {
-                    "to": call.to_addr,
-                    "selector": call.selector,
+                    "to": call.contract_address,
+                    "entry_point_selector": call.entry_point_selector,
                     "calldata": call.calldata,
                 }
                 for call in self.calls

--- a/starknet_py/net/full_node_client.py
+++ b/starknet_py/net/full_node_client.py
@@ -543,8 +543,8 @@ class FullNodeClient(Client):
             method_name="call",
             params={
                 "request": {
-                    "contract_address": _to_rpc_felt(call.to_addr),
-                    "entry_point_selector": _to_rpc_felt(call.selector),
+                    "contract_address": _to_rpc_felt(call.contract_address),
+                    "entry_point_selector": _to_rpc_felt(call.entry_point_selector),
                     "calldata": [_to_rpc_felt(i1) for i1 in call.calldata],
                 },
                 **block_identifier,

--- a/starknet_py/net/udc_deployer/deployer.py
+++ b/starknet_py/net/udc_deployer/deployer.py
@@ -118,8 +118,8 @@ class Deployer:
         )
 
         call = Call(
-            to_addr=self.deployer_address,
-            selector=get_selector_from_name("deployContract"),
+            contract_address=self.deployer_address,
+            entry_point_selector=get_selector_from_name("deployContract"),
             calldata=calldata,
         )
 

--- a/starknet_py/proxy/proxy_check.py
+++ b/starknet_py/proxy/proxy_check.py
@@ -44,8 +44,8 @@ class ArgentProxyCheck(ProxyCheck):
     @staticmethod
     async def get_implementation(address: Address, client: Client) -> Optional[int]:
         call = Call(
-            to_addr=address,
-            selector=get_selector_from_name("get_implementation"),
+            contract_address=address,
+            entry_point_selector=get_selector_from_name("get_implementation"),
             calldata=[],
         )
         (implementation,) = await client.call_contract(call=call)

--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -202,7 +202,9 @@ async def test_get_nonce(account, map_contract):
 
     tx = await account.execute_v3(
         Call(
-            to_addr=address, selector=get_selector_from_name("put"), calldata=[10, 20]
+            contract_address=address,
+            entry_point_selector=get_selector_from_name("put"),
+            calldata=[10, 20],
         ),
         resource_bounds=MAX_RESOURCE_BOUNDS,
     )
@@ -574,8 +576,8 @@ async def test_argent_account_execute(
 ):
     # verify that initial balance is 0
     get_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("get_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
     get_balance = await argent_account_v040.client.call_contract(
@@ -586,8 +588,8 @@ async def test_argent_account_execute(
 
     value = 20
     increase_balance_by_20_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[value],
     )
     execute = await argent_account_v040.execute_v3(
@@ -602,8 +604,8 @@ async def test_argent_account_execute(
 
     # verify that the previous call was executed
     get_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("get_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
     get_balance = await argent_account_v040.client.call_contract(
@@ -616,13 +618,13 @@ async def test_argent_account_execute(
 @pytest.mark.asyncio
 async def test_account_execute_v3(account, deployed_balance_contract):
     get_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("get_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
     increase_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[100],
     )
 

--- a/starknet_py/tests/e2e/account/outside_execution_test.py
+++ b/starknet_py/tests/e2e/account/outside_execution_test.py
@@ -28,8 +28,8 @@ async def test_account_outside_execution_any_caller(
     map_contract,
 ):
     put_call = Call(
-        to_addr=map_contract.address,
-        selector=get_selector_from_name("put"),
+        contract_address=map_contract.address,
+        entry_point_selector=get_selector_from_name("put"),
         calldata=[20, 20],
     )
 
@@ -60,8 +60,8 @@ async def test_account_outside_execution_for_invalid_caller(
     random_address = 0x1234567890123456789012345678901234567890
 
     put_call = Call(
-        to_addr=map_contract.address,
-        selector=get_selector_from_name("put"),
+        contract_address=map_contract.address,
+        entry_point_selector=get_selector_from_name("put"),
         calldata=[20, 20],
     )
 
@@ -94,8 +94,8 @@ async def test_account_outside_execution_for_impossible_time_bounds(
     map_contract,
 ):
     put_call = Call(
-        to_addr=map_contract.address,
-        selector=get_selector_from_name("put"),
+        contract_address=map_contract.address,
+        entry_point_selector=get_selector_from_name("put"),
         calldata=[20, 20],
     )
 
@@ -122,8 +122,8 @@ async def test_account_outside_execution_by_itself_is_impossible(
     map_contract,
 ):
     put_call = Call(
-        to_addr=map_contract.address,
-        selector=get_selector_from_name("put"),
+        contract_address=map_contract.address,
+        entry_point_selector=get_selector_from_name("put"),
         calldata=[20, 20],
     )
 

--- a/starknet_py/tests/e2e/client/client_test.py
+++ b/starknet_py/tests/e2e/client/client_test.py
@@ -286,8 +286,8 @@ async def test_get_transaction_receipt(
 async def test_estimate_fee_invoke_v3(account, contract_address):
     invoke_tx = await account.sign_invoke_v3(
         calls=Call(
-            to_addr=contract_address,
-            selector=get_selector_from_name("increase_balance"),
+            contract_address=contract_address,
+            entry_point_selector=get_selector_from_name("increase_balance"),
             calldata=[1000],
         ),
         resource_bounds=ResourceBoundsMapping.init_with_zeros(),
@@ -348,8 +348,8 @@ async def test_estimate_fee_for_multiple_transactions(
 ):
     invoke_tx = await account.sign_invoke_v3(
         calls=Call(
-            to_addr=contract_address,
-            selector=get_selector_from_name("increase_balance"),
+            contract_address=contract_address,
+            entry_point_selector=get_selector_from_name("increase_balance"),
             calldata=[1000],
         ),
         resource_bounds=MAX_RESOURCE_BOUNDS,
@@ -376,8 +376,8 @@ async def test_estimate_fee_for_multiple_transactions(
 @pytest.mark.asyncio
 async def test_call_contract(client, contract_address_2):
     call = Call(
-        to_addr=contract_address_2,
-        selector=get_selector_from_name("get_balance"),
+        contract_address=contract_address_2,
+        entry_point_selector=get_selector_from_name("get_balance"),
         calldata=[],
     )
 

--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -429,8 +429,8 @@ async def test_get_syncing_status(client):
 async def test_simulate_transactions_skip_validate(account, deployed_balance_contract):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
 
@@ -457,8 +457,8 @@ async def test_simulate_transactions_skip_fee_charge(
 ):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
 
@@ -474,8 +474,8 @@ async def test_simulate_transactions_skip_fee_charge(
 async def test_simulate_transactions_invoke(account, deployed_balance_contract):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
 
@@ -504,8 +504,8 @@ async def test_simulate_transactions_invoke(account, deployed_balance_contract):
 async def test_simulate_transactions_two_txs(account, deployed_balance_contract):
     assert isinstance(deployed_balance_contract, Contract)
     call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
     invoke_tx = await account.sign_invoke_v3(calls=call, auto_estimate=True)

--- a/starknet_py/tests/e2e/contract_interaction/interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/interaction_test.py
@@ -177,8 +177,8 @@ async def test_call_uninitialized_contract(client):
     with pytest.raises(ClientError, match="Contract not found"):
         await client.call_contract(
             Call(
-                to_addr=1,
-                selector=get_selector_from_name("get_nonce"),
+                contract_address=1,
+                entry_point_selector=get_selector_from_name("get_nonce"),
                 calldata=[],
             ),
             block_hash="latest",

--- a/starknet_py/tests/e2e/docs/code_examples/test_account.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_account.py
@@ -34,8 +34,8 @@ async def test_execute_v3(account, contract_address):
     )
     resp = await account.execute_v3(
         Call(
-            to_addr=contract_address,
-            selector=get_selector_from_name("increase_balance"),
+            contract_address=contract_address,
+            entry_point_selector=get_selector_from_name("increase_balance"),
             calldata=[123],
         ),
         resource_bounds=resource_bounds,
@@ -43,8 +43,8 @@ async def test_execute_v3(account, contract_address):
     # or
     # docs-end: execute_v3
     call1 = call2 = Call(
-        to_addr=contract_address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=contract_address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[123],
     )
     # docs-start: execute_v3

--- a/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_full_node_client.py
@@ -108,8 +108,8 @@ async def test_call_contract(client, contract_address):
     # docs-start: call_contract
     response = await client.call_contract(
         call=Call(
-            to_addr=contract_address,
-            selector=get_selector_from_name("increase_balance"),
+            contract_address=contract_address,
+            entry_point_selector=get_selector_from_name("increase_balance"),
             calldata=[123],
         ),
         block_number="latest",
@@ -247,8 +247,8 @@ async def test_simulate_transactions(
     second_transaction = deploy_account_transaction
     # docs-start: simulate_transactions
     call = Call(
-        to_addr=contract_address,
-        selector=get_selector_from_name("method_name"),
+        contract_address=contract_address,
+        entry_point_selector=get_selector_from_name("method_name"),
         calldata=[0xCA11DA7A],
     )
     first_transaction = await account.sign_invoke_v3(
@@ -257,8 +257,8 @@ async def test_simulate_transactions(
     # docs-end: simulate_transactions
 
     call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[0x10],
     )
     first_transaction = await account.sign_invoke_v3(calls=call, auto_estimate=True)

--- a/starknet_py/tests/e2e/docs/code_examples/test_websocket_client.py
+++ b/starknet_py/tests/e2e/docs/code_examples/test_websocket_client.py
@@ -119,8 +119,8 @@ async def test_subscribe_events(
     # ...
     # docs-end: subscribe_events
     increase_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[100],
     )
     execute = await argent_account_v040.execute_v3(
@@ -162,8 +162,8 @@ async def test_subscribe_transaction_status(
         new_transaction_status = transaction_status_notification.result
 
     increase_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[100],
     )
     execute = await argent_account_v040.execute_v3(
@@ -237,8 +237,8 @@ async def test_subscribe_pending_transactions(
     # ...
     # docs-end: subscribe_pending_transactions
     increase_balance_call = Call(
-        to_addr=deployed_balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=deployed_balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[100],
     )
     execute = await argent_account_v040.execute_v3(

--- a/starknet_py/tests/e2e/docs/guide/test_account_sign_outside_transaction.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_sign_outside_transaction.py
@@ -27,8 +27,8 @@ async def test_account_outside_execution_any_caller(
 
     # Create a call to put value 100 at key 1.
     put_call = Call(
-        to_addr=map_contract.address,
-        selector=get_selector_from_name("put"),
+        contract_address=map_contract.address,
+        entry_point_selector=get_selector_from_name("put"),
         calldata=[1, 100],
     )
 

--- a/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
+++ b/starknet_py/tests/e2e/docs/guide/test_account_sign_without_execute.py
@@ -23,7 +23,9 @@ async def test_account_sign_without_execute(
     from starknet_py.net.client_models import Call
 
     # Create a signed Invoke transaction
-    call = Call(to_addr=address, selector=selector, calldata=calldata)
+    call = Call(
+        contract_address=address, entry_point_selector=selector, calldata=calldata
+    )
     invoke_transaction = await account.sign_invoke_v3(
         call, resource_bounds=resource_bounds
     )

--- a/starknet_py/tests/e2e/docs/guide/test_executing_transactions.py
+++ b/starknet_py/tests/e2e/docs/guide/test_executing_transactions.py
@@ -14,7 +14,9 @@ async def test_executing_transactions(account, map_contract):
     )
 
     call = Call(
-        to_addr=address, selector=get_selector_from_name("put"), calldata=[20, 20]
+        contract_address=address,
+        entry_point_selector=get_selector_from_name("put"),
+        calldata=[20, 20],
     )
 
     resp = await account.execute_v3(
@@ -31,6 +33,10 @@ async def test_executing_transactions(account, map_contract):
     await account.client.wait_for_tx(resp.transaction_hash)
     # docs: end
 
-    call = Call(to_addr=address, selector=get_selector_from_name("get"), calldata=[20])
+    call = Call(
+        contract_address=address,
+        entry_point_selector=get_selector_from_name("get"),
+        calldata=[20],
+    )
     (value,) = await account.client.call_contract(call)
     assert value == 20

--- a/starknet_py/tests/e2e/docs/guide/test_multicall.py
+++ b/starknet_py/tests/e2e/docs/guide/test_multicall.py
@@ -13,8 +13,8 @@ async def test_multicall(account, deployed_balance_contract):
     from starknet_py.net.client_models import Call
 
     increase_balance_by_20_call = Call(
-        to_addr=balance_contract.address,
-        selector=get_selector_from_name("increase_balance"),
+        contract_address=balance_contract.address,
+        entry_point_selector=get_selector_from_name("increase_balance"),
         calldata=[20],
     )
     calls = [increase_balance_by_20_call, increase_balance_by_20_call]

--- a/starknet_py/tests/e2e/docs/guide/test_resolving_proxies.py
+++ b/starknet_py/tests/e2e/docs/guide/test_resolving_proxies.py
@@ -55,8 +55,8 @@ async def test_resolving_proxies(
             self, address: Address, client: Client
         ) -> Optional[int]:
             call = Call(
-                to_addr=address,
-                selector=get_selector_from_name("impl"),
+                contract_address=address,
+                entry_point_selector=get_selector_from_name("impl"),
                 calldata=[],
             )
             (implementation,) = await client.call_contract(call=call)

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -154,8 +154,8 @@ async def test_raw_call(account):
 
     # Create a call to function "balanceOf" at address `eth_token_address`
     call = Call(
-        to_addr=eth_token_address,
-        selector=get_selector_from_name("balanceOf"),
+        contract_address=eth_token_address,
+        entry_point_selector=get_selector_from_name("balanceOf"),
         calldata=[account.address],
     )
     # Pass the created call to Client.call_contract

--- a/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
+++ b/starknet_py/tests/e2e/docs/migration_guide/test_account_comparison.py
@@ -22,7 +22,7 @@ async def test_account_comparison(gateway_account, map_contract):
     await account.client.get_storage_at(contract_address=address, key=key)
     # docs-1: end
 
-    call = Call(to_addr=0x1, selector=0x1234, calldata=[])
+    call = Call(contract_address=0x1, entry_point_selector=0x1234, calldata=[])
     resource_bounds = MAX_RESOURCE_BOUNDS
 
     # docs-2: start

--- a/starknet_py/tests/e2e/tests_on_networks/account_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/account_test.py
@@ -26,8 +26,8 @@ async def test_account_execute_v3_braavos(client_sepolia_testnet: FullNodeClient
         await braavos_account.execute_v3(
             calls=[
                 Call(
-                    to_addr=0x0589A8B8BF819B7820CB699EA1F6C409BC012C9B9160106DDC3DACD6A89653CF,
-                    selector=get_selector_from_name("get_balance"),
+                    contract_address=0x0589A8B8BF819B7820CB699EA1F6C409BC012C9B9160106DDC3DACD6A89653CF,
+                    entry_point_selector=get_selector_from_name("get_balance"),
                     calldata=[],
                 )
             ],

--- a/starknet_py/tests/e2e/tests_on_networks/client_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/client_test.py
@@ -77,8 +77,8 @@ async def test_wait_for_tx_reverted(account_sepolia_testnet):
     account = account_sepolia_testnet
     # Calldata too long for the function (it has no parameters) to trigger REVERTED status
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[0x1, 0x2, 0x3, 0x4, 0x5],
     )
     sign_invoke = await account.sign_invoke_v3(
@@ -94,8 +94,8 @@ async def test_wait_for_tx_reverted(account_sepolia_testnet):
 async def test_wait_for_tx_accepted(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     sign_invoke = await account.sign_invoke_v3(
@@ -113,8 +113,8 @@ async def test_wait_for_tx_accepted(account_sepolia_testnet):
 async def test_sign_invoke_v3_auto_estimate(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     sign_invoke = await account.sign_invoke_v3(calls=call, auto_estimate=True)
@@ -129,8 +129,8 @@ async def test_sign_invoke_v3_auto_estimate(account_sepolia_testnet):
 async def test_transaction_not_received_max_fee_too_small(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     resource_bounds = ResourceBoundsMapping(
@@ -154,8 +154,8 @@ async def test_transaction_not_received_max_fee_too_small(account_sepolia_testne
 async def test_transaction_not_received_max_fee_too_big(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     resource_bounds = ResourceBoundsMapping(
@@ -179,8 +179,8 @@ async def test_transaction_not_received_max_fee_too_big(account_sepolia_testnet)
 async def test_transaction_not_received_invalid_nonce(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     sign_invoke = await account.sign_invoke_v3(
@@ -195,8 +195,8 @@ async def test_transaction_not_received_invalid_nonce(account_sepolia_testnet):
 async def test_transaction_not_received_invalid_signature(account_sepolia_testnet):
     account = account_sepolia_testnet
     call = Call(
-        to_addr=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
-        selector=get_selector_from_name("empty"),
+        contract_address=int(EMPTY_CONTRACT_ADDRESS_SEPOLIA, 0),
+        entry_point_selector=get_selector_from_name("empty"),
         calldata=[],
     )
     sign_invoke = await account.sign_invoke_v3(

--- a/starknet_py/tests/unit/net/account/account_test.py
+++ b/starknet_py/tests/unit/net/account/account_test.py
@@ -36,7 +36,7 @@ async def test_get_balance_default_token_address():
 
     (call,) = call[0]
 
-    assert call.to_addr == parse_address(FEE_CONTRACT_ADDRESS)
+    assert call.contract_address == parse_address(FEE_CONTRACT_ADDRESS)
 
 
 @pytest.mark.asyncio

--- a/starknet_py/tests/unit/signer/test_ledger_signer.py
+++ b/starknet_py/tests/unit/signer/test_ledger_signer.py
@@ -103,9 +103,9 @@ def test_create_account_with_ledger_signer():
 async def _get_account_balance_strk(client: FullNodeClient, address: int):
     balance = await client.call_contract(
         call=Call(
-            to_addr=int(STRK_FEE_CONTRACT_ADDRESS, 16),
+            contract_address=int(STRK_FEE_CONTRACT_ADDRESS, 16),
             calldata=[address],
-            selector=get_selector_from_name("balanceOf"),
+            entry_point_selector=get_selector_from_name("balanceOf"),
         )
     )
     return balance


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1538


## Introduced changes
<!-- A brief description of the changes -->

Refactor `Call` dataclass to match names from the [spec](https://github.com/starkware-libs/starknet-specs/blob/6d88b7399f56260ece3821c71f9ce53ec55f830b/api/starknet_api_openrpc.json#L3006).


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


