### PR TITLE
Use `latest` block as default in tip estimation

### DIFF
--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -2,6 +2,15 @@ Migration guide
 ===============
 
 ***************************
+0.28.0-rc.2 Migration guide
+***************************
+
+Tip Estimation
+--------------
+
+1. Automatic tip estimation will now use `latest` block instead of `pre_confirmed` to calculate tip if no block is provided.
+
+***************************
 0.28.0-rc.1 Migration guide
 ***************************
 

--- a/docs/migration_guide.rst
+++ b/docs/migration_guide.rst
@@ -5,8 +5,8 @@ Migration guide
 0.28.0-rc.2 Migration guide
 ***************************
 
-Tip Estimation
---------------
+Tip Estimations
+---------------
 
 1. Automatic tip estimation will now use `latest` block instead of `pre_confirmed` to calculate tip if no block is provided.
 

--- a/starknet_py/net/tip/__init__.py
+++ b/starknet_py/net/tip/__init__.py
@@ -13,14 +13,14 @@ async def estimate_tip(
 ) -> int:
     """
     Estimates the transaction tip by taking the median of all V3 transaction tips in the specified block.
-    If no block is provided, the `pre-confirmed` block is used.
+    If no block is provided, the `latest` block is used.
 
     :param client: Client instance.
     :param block_hash: Block's hash or literals `"latest" or "pre_confirmed"`
     :param block_number: Block's number or literals `"latest" or "pre_confirmed"``
     """
     if block_hash is None and block_number is None:
-        block_hash = "pre_confirmed"
+        block_hash = "latest"
 
     block_with_txs = await client.get_block_with_txs(block_hash, block_number)
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #


## Introduced changes
<!-- A brief description of the changes -->


- Changed the `estimate_tip` method so it uses `latest` block as default if block is not provided


##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


