### PR TITLE
Move revision enum

### DIFF
--- a/starknet_py/hash/outside_execution.py
+++ b/starknet_py/hash/outside_execution.py
@@ -1,6 +1,6 @@
 from starknet_py.constants import OutsideExecutionInterfaceID
 from starknet_py.net.client_models import OutsideExecution
-from starknet_py.net.schemas.common import Revision
+from starknet_py.net.models.typed_data import Revision
 from starknet_py.utils.typed_data import TypedData
 
 OUTSIDE_EXECUTION_INTERFACE_ID_TO_TYPED_DATA_REVISION = {

--- a/starknet_py/net/models/typed_data.py
+++ b/starknet_py/net/models/typed_data.py
@@ -3,14 +3,22 @@ TypedDict structures for TypedData
 """
 
 import sys
+from enum import Enum
 from typing import Any, Dict, List, Optional, TypedDict
-
-from starknet_py.net.schemas.common import Revision
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired
 else:
     from typing import NotRequired
+
+
+class Revision(Enum):
+    """
+    Enum representing the revision of the specification to be used.
+    """
+
+    V0 = 0
+    V1 = 1
 
 
 class ParameterDict(TypedDict):

--- a/starknet_py/net/schemas/common.py
+++ b/starknet_py/net/schemas/common.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from enum import Enum
 from typing import Any, Mapping, Optional, Union
 
 from marshmallow import Schema, ValidationError, fields, post_load
@@ -377,35 +376,3 @@ class StorageEntrySchema(Schema):
     def make_dataclass(self, data, **kwargs):
         # pylint: disable=no-self-use
         return StorageEntry(**data)
-
-
-class Revision(Enum):
-    """
-    Enum representing the revision of the specification to be used.
-    """
-
-    V0 = 0
-    V1 = 1
-
-
-class RevisionField(fields.Field):
-    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs):
-        if value is None or value == Revision.V0:
-            return str(Revision.V0.value)
-        return value.value
-
-    def _deserialize(self, value, attr, data, **kwargs) -> Revision:
-        if isinstance(value, str):
-            value = int(value)
-
-        if isinstance(value, Revision):
-            value = value.value
-
-        revisions = [revision.value for revision in Revision]
-        if value not in revisions:
-            allowed_revisions_str = "".join(list(map(str, revisions)))
-            raise ValidationError(
-                f"Invalid value provided for Revision: {value}. Allowed values are {allowed_revisions_str}."
-            )
-
-        return Revision(value)

--- a/starknet_py/net/schemas/revision.py
+++ b/starknet_py/net/schemas/revision.py
@@ -1,0 +1,28 @@
+from typing import Any, Optional
+
+from marshmallow import ValidationError, fields
+
+from starknet_py.net.models.typed_data import Revision
+
+
+class RevisionField(fields.Field):
+    def _serialize(self, value: Any, attr: Optional[str], obj: Any, **kwargs):
+        if value is None or value == Revision.V0:
+            return str(Revision.V0.value)
+        return value.value
+
+    def _deserialize(self, value, attr, data, **kwargs) -> Revision:
+        if isinstance(value, str):
+            value = int(value)
+
+        if isinstance(value, Revision):
+            value = value.value
+
+        revisions = [revision.value for revision in Revision]
+        if value not in revisions:
+            allowed_revisions_str = "".join(list(map(str, revisions)))
+            raise ValidationError(
+                f"Invalid value provided for Revision: {value}. Allowed values are {allowed_revisions_str}."
+            )
+
+        return Revision(value)

--- a/starknet_py/utils/typed_data.py
+++ b/starknet_py/utils/typed_data.py
@@ -12,7 +12,7 @@ from starknet_py.hash.hash_method import HashMethod
 from starknet_py.hash.selector import get_selector_from_name
 from starknet_py.net.client_utils import _to_rpc_felt
 from starknet_py.net.models.typed_data import DomainDict, Revision, TypedDataDict
-from starknet_py.net.schemas.common import RevisionField
+from starknet_py.net.schemas.revision import RevisionField
 from starknet_py.serialization.data_serializers import ByteArraySerializer
 from starknet_py.utils.merkle_tree import MerkleTree
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1367 

There were two causes of Circular Import Error,
- `int_from_bytes`: The root cause is a circular dependency involving `starknet_py.common` and other `starknet_py` modules. The traceback states: `cannot import name 'int_from_bytes' from partially initialized module 'starknet_py.common'`.
- `HEX_PREFIX = "0x"`: This creates a circular dependency between `starknet_py.hash.address` and `starknet_py.hash.utils` when running the module `starknet_py/tests/e2e/fixtures/clients.py`.
`CasmClassSchema`, `Felt` ...

## Introduced changes
Fixing this was moving `RevisionField` out of common to a separate module.

##

- [ ] This PR contains breaking changes

<!-- List of all breaking changes -->


