### PR TITLE
Move ledger tests to separate job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,14 +43,6 @@ jobs:
           python-version: "3.14"
           cache: 'poetry'
 
-      - name: Install dependencies needed for HIDAPI and Pillow
-        run: |
-          sudo apt install python3-dev libusb-1.0-0-dev libudev-dev libjpeg-dev
-
-      - name: Install dependencies
-        run: |
-          poetry install -E ledger
-
       - name: Check poetry.lock
         run: |
           poetry check --lock
@@ -347,14 +339,6 @@ jobs:
         with:
           python-version: "3.14"
           cache: 'poetry'
-
-      - name: Install dependencies needed for HIDAPI and Pillow
-        run: |
-          sudo apt install python3-dev libusb-1.0-0-dev libudev-dev libjpeg-dev
-
-      - name: Install dependencies
-        run: |
-          poetry install -E ledger
 
       # ====================== SETUP DEVNET ====================== #
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -226,6 +226,7 @@ jobs:
 
       - name: Install dependencies needed for HIDAPI and Pillow
         run: |
+          sudo apt-get update
           sudo apt install python3-dev libusb-1.0-0-dev libudev-dev libjpeg-dev
 
       - name: Install dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -132,6 +132,76 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.14" ]
     env:
+      SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download contracts
+        uses: actions/download-artifact@v4
+        with:
+          name: contract-artifacts
+          path: starknet_py/tests/e2e/mock/
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: 'pip'
+
+      # ====================== SETUP PYTHON ====================== #
+
+      - name: Install poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: |
+          poetry install
+
+      # ====================== SETUP DEVNET ====================== #
+
+      - name: Install devnet
+        run: ./starknet_py/tests/install_devnet.sh
+
+      # ====================== RUN TESTS ====================== #
+
+      - name: Check circular imports
+        run: |
+          poetry run poe circular_imports_check
+
+      - uses: asdf-vm/actions/setup@v3
+
+      - name: Run tests
+        run: |
+          poetry run poe test_ci_v2
+          poetry run poe test_ci_v1
+
+      - name: Generate coverage in XML
+        run: |
+          poetry run coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+
+  # ---------------------------------------------------------- #
+  # .....................RUN-LEDGER-TESTS..................... #
+  # ---------------------------------------------------------- #
+
+  run-ledger-tests:
+    name: Ledger Tests
+    needs: setup-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.10", "3.14" ]
+    env:
       LEDGER_PROXY_ADDRESS: 127.0.0.1
       LEDGER_PROXY_PORT: 9999
       SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
@@ -180,7 +250,6 @@ jobs:
       - name: Pull speculos image
         run: docker pull ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools@sha256:${{ env.LEDGER_APP_DEV_TOOLS_SHA }}
 
-
       - name: Clone LedgerHQ Starknet app repository
         run: git clone https://github.com/LedgerHQ/app-starknet.git
 
@@ -224,16 +293,9 @@ jobs:
 
       # ====================== RUN TESTS ====================== #
 
-      - name: Check circular imports
-        run: |
-          poetry run poe circular_imports_check
-
-      - uses: asdf-vm/actions/setup@v3
-
       - name: Run tests
         run: |
-          poetry run poe test_ci_v2
-          poetry run poe test_ci_v1
+          poetry run poe test_ci_ledger
 
       - name: Generate coverage in XML
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,10 @@ jobs:
           python-version: "3.14"
           cache: 'poetry'
 
+      - name: Install dependencies
+        run: |
+          poetry install -E ledger
+
       - name: Check poetry.lock
         run: |
           poetry check --lock

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,11 @@ jobs:
           python-version: "3.14"
           cache: 'poetry'
 
+      - name: Install dependencies needed for HIDAPI and Pillow
+        run: |
+          sudo apt-get update
+          sudo apt install python3-dev libusb-1.0-0-dev libudev-dev libjpeg-dev
+
       - name: Install dependencies
         run: |
           poetry install -E ledger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,9 @@ test = [
 ]
 
 test_ci = ["test_ci_v1", "test_ci_v2"]
-test_ci_v1 = "coverage run -a -m pytest -n auto --contract_dir=v1 starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/tests_on_networks"
-test_ci_v2 = "coverage run -a -m pytest -n auto --contract_dir=v2 starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/tests_on_networks"
+test_ci_v1 = "coverage run -a -m pytest -n auto --contract_dir=v1 starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/tests_on_networks --ignore=starknet_py/tests/unit/signer/test_ledger_signer.py"
+test_ci_v2 = "coverage run -a -m pytest -n auto --contract_dir=v2 starknet_py --ignore=starknet_py/tests/e2e/docs --ignore=starknet_py/tests/e2e/tests_on_networks --ignore=starknet_py/tests/unit/signer/test_ledger_signer.py"
+test_ci_ledger = "coverage run -a -m pytest --contract_dir=v2 starknet_py/tests/unit/signer/test_ledger_signer.py"
 
 test_ci_on_networks = "coverage run -a -m pytest --contract_dir=v2 starknet_py/tests/e2e/tests_on_networks --ignore=starknet_py/tests/e2e/tests_on_networks/account_test.py"
 test_ci_on_networks_extended = "coverage run -a -m pytest --contract_dir=v2 starknet_py/tests/e2e/tests_on_networks"


### PR DESCRIPTION
Sometimes tests on CI are hanging e.g. https://github.com/software-mansion/starknet.py/actions/runs/23637820533/job/69237650717?pr=1710. It is probably caused by ledger tests and deadlock that can happen due to running tests in parallel. This is attempt to fix it by moving ledger tests to a separate job and run them sequentially.