### PR TITLE
Add explicit `package` in `load_contract` calls

### DIFF
--- a/starknet_py/tests/e2e/account/account_test.py
+++ b/starknet_py/tests/e2e/account/account_test.py
@@ -735,7 +735,7 @@ async def test_deploy_account_v3_auto_estimate_tip(
 
 @pytest.mark.asyncio
 async def test_declare_v3_with_tip(account):
-    compiled_contract = load_contract("TestContract3")
+    compiled_contract = load_contract("TestContract3", package="contracts_v2")
 
     tip = 12345
     signed_tx = await account.sign_declare_v3(
@@ -757,7 +757,7 @@ async def test_declare_v3_auto_estimate_tip(
     get_block_with_txs_path,
     block_with_tips_mock,
 ):
-    compiled_contract = load_contract("TestContract4")
+    compiled_contract = load_contract("TestContract4", package="contracts_v2")
 
     with patch(get_block_with_txs_path, AsyncMock()) as mocked_block_with_txs:
         mocked_block_with_txs.return_value = block_with_tips_mock

--- a/starknet_py/tests/e2e/cairo1v2_test.py
+++ b/starknet_py/tests/e2e/cairo1v2_test.py
@@ -15,7 +15,7 @@ U256_MAX = (1 << 256) - 1
 
 @pytest_asyncio.fixture(scope="package")
 async def declare_deploy_hello2(account) -> Tuple[DeclareResult, DeployResult]:
-    contract = load_contract(contract_name="Hello2")
+    contract = load_contract(contract_name="Hello2", package="contracts_v2")
 
     declare_result = await Contract.declare_v3(
         account=account,

--- a/starknet_py/tests/e2e/contract_interaction/declare_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/declare_test.py
@@ -57,7 +57,7 @@ async def test_declare_v3_auto_estimate_tip(
     get_block_with_txs_path,
     block_with_tips_mock,
 ):
-    contract = load_contract(contract_name="TestContract2")
+    contract = load_contract(contract_name="TestContract2", package="contracts_v2")
 
     with patch(get_block_with_txs_path, AsyncMock()) as get_block_with_txs_mock:
         get_block_with_txs_mock.return_value = block_with_tips_mock

--- a/starknet_py/tests/e2e/devnet_client/fixtures/contracts.py
+++ b/starknet_py/tests/e2e/devnet_client/fixtures/contracts.py
@@ -10,7 +10,7 @@ from starknet_py.tests.e2e.fixtures.misc import load_contract
 
 @pytest_asyncio.fixture(scope="package", name="f_string_contract_class_hash")
 async def declare_string_contract(account_forked_devnet) -> int:
-    contract = load_contract("MyString")
+    contract = load_contract("MyString", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account_forked_devnet, contract["sierra"], contract["casm"]
     )
@@ -30,7 +30,7 @@ async def deploy_string_contract(
 
 @pytest_asyncio.fixture(scope="package", name="l1_l2_contract_class_hash")
 async def declare_l1_l2_contract(account) -> int:
-    contract = load_contract("l1_l2")
+    contract = load_contract("l1_l2", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )

--- a/starknet_py/tests/e2e/docs/guide/test_serializing.py
+++ b/starknet_py/tests/e2e/docs/guide/test_serializing.py
@@ -58,6 +58,7 @@ def test_abi_parsing():
     raw_abi_string = json.loads(
         load_contract(
             contract_name="ERC20",
+            package="contracts_v2",
         )["sierra"]
     )["abi"]
     abi = AbiParser(raw_abi_string).parse()

--- a/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy_cairo1.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_declare_and_deploy_cairo1.py
@@ -17,7 +17,7 @@ async def test_simple_declare_and_deploy(account):
     from starknet_py.net.client_models import ResourceBounds, ResourceBoundsMapping
 
     # docs: end
-    compiled_contract = load_contract("AccountCopy1")
+    compiled_contract = load_contract("AccountCopy1", package="contracts_v2")
     constructor_args = {"public_key": 0x123}
 
     # docs: start

--- a/starknet_py/tests/e2e/docs/guide/test_simple_deploy_cairo1.py
+++ b/starknet_py/tests/e2e/docs/guide/test_simple_deploy_cairo1.py
@@ -21,7 +21,9 @@ async def test_simple_deploy_cairo1(account, erc20_class_hash):
 
     # docs: end
 
-    compiled_contract = load_contract(contract_name="ERC20")["sierra"]
+    compiled_contract = load_contract(contract_name="ERC20", package="contracts_v2")[
+        "sierra"
+    ]
 
     class_hash = erc20_class_hash
 

--- a/starknet_py/tests/e2e/fixtures/contracts_v1.py
+++ b/starknet_py/tests/e2e/fixtures/contracts_v1.py
@@ -35,7 +35,7 @@ async def declare_contract(
 
 @pytest_asyncio.fixture(scope="package")
 async def erc20_class_hash(account: BaseAccount) -> int:
-    contract = load_contract("ERC20")
+    contract = load_contract("ERC20", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
@@ -44,7 +44,7 @@ async def erc20_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def constructor_with_arguments_class_hash(account: BaseAccount) -> int:
-    contract = load_contract("ConstructorWithArguments")
+    contract = load_contract("ConstructorWithArguments", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
@@ -57,7 +57,9 @@ def constructor_with_arguments_abi() -> List:
     Returns an abi of the constructor_with_arguments.cairo.
     """
     compiled_contract = create_sierra_compiled_contract(
-        compiled_contract=load_contract("ConstructorWithArguments")["sierra"]
+        compiled_contract=load_contract(
+            "ConstructorWithArguments", package="contracts_v2"
+        )["sierra"]
     )
     assert compiled_contract.parsed_abi is not None
     return compiled_contract.parsed_abi
@@ -141,7 +143,7 @@ async def test_option_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package")
 async def token_bridge_class_hash(account: BaseAccount) -> int:
-    contract = load_contract("TokenBridge")
+    contract = load_contract("TokenBridge", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
@@ -180,6 +182,7 @@ async def hello_starknet_contract(account: BaseAccount, hello_starknet_class_has
 async def declare_string_contract(account: BaseAccount) -> int:
     contract = load_contract(
         "MyString",
+        package="contracts_v2",
     )
     class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
@@ -240,7 +243,7 @@ def map_compiled_contract_and_class_hash() -> Tuple[str, int]:
 
 @pytest.fixture(scope="package")
 def map_compiled_contract_and_class_hash_copy_1() -> Tuple[str, int]:
-    contract = load_contract("MapCopy1")
+    contract = load_contract("MapCopy1", package="contracts_v2")
 
     return (
         contract["sierra"],
@@ -250,7 +253,7 @@ def map_compiled_contract_and_class_hash_copy_1() -> Tuple[str, int]:
 
 @pytest.fixture(scope="package")
 def map_compiled_contract_and_class_hash_copy_2() -> Tuple[str, int]:
-    contract = load_contract("MapCopy2")
+    contract = load_contract("MapCopy2", package="contracts_v2")
 
     return (
         contract["sierra"],
@@ -267,7 +270,7 @@ def map_compiled_contract_casm() -> str:
 
 @pytest_asyncio.fixture(scope="package")
 async def simple_storage_with_event_class_hash(account: BaseAccount) -> int:
-    contract = load_contract("SimpleStorageWithEvent")
+    contract = load_contract("SimpleStorageWithEvent", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account, contract["sierra"], contract["casm"]
     )
@@ -276,7 +279,7 @@ async def simple_storage_with_event_class_hash(account: BaseAccount) -> int:
 
 @pytest_asyncio.fixture(scope="package", name="eth_account_class_hash")
 async def declare_eth_account(account: BaseAccount) -> int:
-    contract = load_contract("EthAccountUpgradeable")
+    contract = load_contract("EthAccountUpgradeable", package="contracts_v2")
     class_hash, _ = await declare_contract(
         account,
         contract["sierra"],
@@ -315,7 +318,7 @@ def abi_types_compiled_contract_and_class_hash() -> Tuple[str, int]:
     """
     Returns abi_types contract compiled to sierra and its compiled class hash.
     """
-    contract = load_contract(contract_name="AbiTypes")
+    contract = load_contract(contract_name="AbiTypes", package="contracts_v2")
 
     return (
         contract["sierra"],
@@ -389,7 +392,7 @@ async def deploy_v3_contract(
     :param calldata: Dict with constructor arguments (can be empty).
     :returns: Instance of the deployed contract.
     """
-    contract_sierra = load_contract(contract_name)["sierra"]
+    contract_sierra = load_contract(contract_name, package="contracts_v2")["sierra"]
 
     abi = create_sierra_compiled_contract(contract_sierra).parsed_abi
 

--- a/starknet_py/tests/e2e/tests_on_networks/account_test.py
+++ b/starknet_py/tests/e2e/tests_on_networks/account_test.py
@@ -106,7 +106,7 @@ async def test_deploy_account_v3(
 
 @pytest.mark.asyncio
 async def test_declare_v3(account_sepolia_testnet):
-    contract = load_contract(contract_name="SimpleContract")
+    contract = load_contract(contract_name="SimpleContract", package="contracts_v2")
 
     compiled_contract = contract["sierra"]
     compiled_class_hash = compute_casm_class_hash(create_casm_class(contract["casm"]))

--- a/starknet_py/tests/unit/abi/v2/parser_test.py
+++ b/starknet_py/tests/unit/abi/v2/parser_test.py
@@ -29,6 +29,7 @@ def test_abi_parse(contract_name):
     abi = json.loads(
         load_contract(
             contract_name=contract_name,
+            package="contracts_v2",
         )["sierra"]
     )["abi"]
 

--- a/starknet_py/tests/unit/abi/v2/schemas_test.py
+++ b/starknet_py/tests/unit/abi/v2/schemas_test.py
@@ -27,6 +27,7 @@ def test_deserialize_abi(contract_name):
     abi = json.loads(
         load_contract(
             contract_name,
+            package="contracts_v2",
         )["sierra"]
     )["abi"]
     deserialized = [

--- a/starknet_py/tests/unit/hash/casm_class_hash_test.py
+++ b/starknet_py/tests/unit/hash/casm_class_hash_test.py
@@ -25,6 +25,7 @@ from starknet_py.tests.e2e.fixtures.misc import load_contract, read_contract
 def test_compute_casm_class_hash_with_poseidon(contract, expected_casm_class_hash_poseidon):
     casm_contract_class_str = load_contract(
         contract,
+        package="contracts_v2",
     )['casm']
 
     casm_class = create_casm_class(casm_contract_class_str)
@@ -81,7 +82,7 @@ def test_get_casm_hash_method_for_starknet_version(starknet_version, expected_ha
 )
 
 def test_compute_casm_class_hash_with_blake2s(contract, expected_casm_class_hash_blake2s):
-    casm_contract_class_str = load_contract(contract)['casm']
+    casm_contract_class_str = load_contract(contract, package="contracts_v2")['casm']
 
     casm_class = create_casm_class(casm_contract_class_str)
     casm_class_hash = compute_casm_class_hash(casm_class, hash_method=HashMethod.BLAKE2S)

--- a/starknet_py/tests/unit/hash/sierra_class_hash_test.py
+++ b/starknet_py/tests/unit/hash/sierra_class_hash_test.py
@@ -19,7 +19,9 @@ from starknet_py.tests.e2e.fixtures.misc import load_contract
     # fmt: on
 )
 def test_compute_sierra_class_hash(contract_name, expected_class_hash):
-    sierra_contract_class_str = load_contract(contract_name=contract_name)["sierra"]
+    sierra_contract_class_str = load_contract(
+        contract_name=contract_name, package="contracts_v2"
+    )["sierra"]
 
     sierra_contract_class = create_sierra_compiled_contract(sierra_contract_class_str)
     class_hash = compute_sierra_class_hash(sierra_contract_class)

--- a/starknet_py/tests/unit/serialization/serialization_test.py
+++ b/starknet_py/tests/unit/serialization/serialization_test.py
@@ -155,6 +155,7 @@ def test_event_serialization_v2():
     abi_v2 = json.loads(
         load_contract(
             contract_name="NewSyntaxTestContract",
+            package="contracts_v2",
         )["sierra"]
     )["abi"]
 


### PR DESCRIPTION
Towards #1698

- Add explicit `package=` in `load_contract` calls where possible, especially for contracts that only exists in v2 directory to avoid relying on default behavior

