### PR TITLE
Stop using `sys.args` logic in test

### DIFF
--- a/starknet_py/tests/e2e/client/full_node_test.py
+++ b/starknet_py/tests/e2e/client/full_node_test.py
@@ -1,5 +1,4 @@
 import dataclasses
-import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -33,7 +32,7 @@ from starknet_py.net.client_models import (
 from starknet_py.net.full_node_client import _to_rpc_felt
 from starknet_py.net.models import StarknetChainId
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
-from starknet_py.tests.e2e.fixtures.misc import load_contract
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir, load_contract
 
 
 def _parse_event_name(event: str) -> str:
@@ -147,7 +146,7 @@ async def test_get_storage_at_incorrect_address_full_node_client(client):
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -176,7 +175,7 @@ async def test_get_events_without_following_continuation_token(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -205,7 +204,7 @@ async def test_get_events_follow_continuation_token(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -232,7 +231,7 @@ async def test_get_events_nonexistent_event_name(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -285,7 +284,7 @@ async def test_get_events_with_two_events(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -316,7 +315,7 @@ async def test_get_events_start_from_continuation_token(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -339,7 +338,7 @@ async def test_get_events_no_params(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet
@@ -620,7 +619,7 @@ async def test_trace_block_transactions_return_initial_reads(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.run_on_devnet

--- a/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
+++ b/starknet_py/tests/e2e/contract_interaction/v1_interaction_test.py
@@ -1,17 +1,16 @@
-import sys
-
 import pytest
 
 from starknet_py.cairo.felt import decode_shortstring, encode_shortstring
 from starknet_py.contract import Contract
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
 from starknet_py.tests.e2e.fixtures.contracts_v1 import deploy_v3_contract
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 # TODO (#1219): investigate why some of these tests fails for contracts_compiled_v1
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -57,7 +56,7 @@ async def test_general_v3_interaction(account, erc20_class_hash: int):
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -149,7 +148,7 @@ async def test_serializing_enum(account, test_enum_class_hash: int):
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -177,7 +176,7 @@ async def test_from_address_on_v1_contract(account, erc20_class_hash: int):
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/deploy/deployer_test.py
+++ b/starknet_py/tests/e2e/deploy/deployer_test.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from starknet_py.contract import Contract
@@ -7,6 +5,7 @@ from starknet_py.hash.address import compute_address
 from starknet_py.net.full_node_client import FullNodeClient
 from starknet_py.net.udc_deployer.deployer import Deployer
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 from starknet_py.utils.constructor_args_translator import translate_constructor_args
 
 
@@ -27,7 +26,7 @@ async def test_default_deploy_with_class_hash(account, map_class_hash):
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -64,7 +63,7 @@ async def test_constructor_arguments_contract_deploy_without_abi(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -117,7 +116,7 @@ async def test_constructor_arguments_contract_deploy(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -179,7 +178,7 @@ async def test_address_computation(salt, pass_account_address, account, map_clas
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -226,7 +225,7 @@ async def test_create_deployment_call_raw(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/devnet_client/account_impersonate_test.py
+++ b/starknet_py/tests/e2e/devnet_client/account_impersonate_test.py
@@ -1,14 +1,13 @@
-import sys
-
 import pytest
 
 from starknet_py.contract import Contract
 from starknet_py.net.client_errors import ClientError
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -37,7 +36,7 @@ async def test_impersonate_account(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio
@@ -62,7 +61,7 @@ async def test_auto_impersonate(
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
@@ -20,7 +20,7 @@ async def test_declaring_contracts(
 
     resource_bounds = ResourceBoundsMapping(
         l1_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
-        l2_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
+        l2_gas=ResourceBounds(max_amount=int(1e10), max_price_per_unit=int(1e17)),
         l1_data_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
     )
     declare_transaction = await account.sign_declare_v3(

--- a/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_declaring_contracts.py
@@ -1,12 +1,11 @@
-import sys
-
 import pytest
 
 from starknet_py.net.client_models import ResourceBounds, ResourceBoundsMapping
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
+++ b/starknet_py/tests/e2e/docs/guide/test_deploying_with_udc.py
@@ -1,10 +1,10 @@
-import sys
-
 import pytest
+
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
+++ b/starknet_py/tests/e2e/docs/guide/test_using_existing_contracts.py
@@ -1,8 +1,7 @@
-import sys
-
 import pytest
 
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 # docs-abi: start
 abi = [
@@ -28,7 +27,7 @@ abi = [
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v1" in sys.argv,
+    _contract_dir == "v1",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
@@ -1,15 +1,15 @@
 import os
-import sys
 
 import pytest
 
 from starknet_py.net.client_models import ResourceBoundsMapping
+from starknet_py.tests.e2e.fixtures.misc import _contract_dir
 
 directory = os.path.dirname(__file__)
 
 
 @pytest.mark.skipif(
-    "--contract_dir=v2" not in sys.argv,
+    _contract_dir != "v2",
     reason="Contract exists only in v2 directory",
 )
 @pytest.mark.asyncio

--- a/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
+++ b/starknet_py/tests/e2e/docs/quickstart/test_using_account.py
@@ -22,13 +22,10 @@ async def test_using_account(account, map_compiled_contract_and_class_hash_copy_
 
     # docs: end
     # docs: start
-    l1_resource_bounds = ResourceBounds(
-        max_amount=int(1e5), max_price_per_unit=int(1e13)
-    )
     resource_bounds = ResourceBoundsMapping(
-        l1_gas=l1_resource_bounds,
-        l2_gas=ResourceBounds.init_with_zeros(),
-        l1_data_gas=ResourceBounds.init_with_zeros(),
+        l1_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
+        l2_gas=ResourceBounds(max_amount=int(1e10), max_price_per_unit=int(1e17)),
+        l1_data_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
     )
     # Declare and deploy an example contract which implements a simple k-v store.
     # Contract.declare_v3 takes string containing a compiled contract (sierra) and
@@ -53,9 +50,9 @@ async def test_using_account(account, map_compiled_contract_and_class_hash_copy_
     # Adds a transaction to mutate the state of k-v store. The call goes through account proxy, because we've used
     # Account to create the contract object
     resource_bounds = ResourceBoundsMapping(
-        l1_gas=l1_resource_bounds,
-        l2_gas=ResourceBounds.init_with_zeros(),
-        l1_data_gas=ResourceBounds.init_with_zeros(),
+        l1_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
+        l2_gas=ResourceBounds(max_amount=int(1e10), max_price_per_unit=int(1e17)),
+        l1_data_gas=ResourceBounds(max_amount=int(1e5), max_price_per_unit=int(1e13)),
     )
     await (
         await map_contract.functions["put"].invoke_v3(

--- a/starknet_py/tests/e2e/fixtures/misc.py
+++ b/starknet_py/tests/e2e/fixtures/misc.py
@@ -2,7 +2,6 @@
 
 import json
 import random
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +22,9 @@ from starknet_py.net.models.typed_data import TypedDataDict
 from starknet_py.tests.e2e.fixtures.constants import MOCK_DIR, TYPED_DATA_DIR
 from starknet_py.utils.typed_data import TypedData
 
+# Populated in `pytest_configure` from the `--contract_dir` CLI option, before test modules are imported.
+_contract_dir: str = ""
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -31,6 +33,11 @@ def pytest_addoption(parser):
         default="",
         help="Contract directory: possible 'v1', 'v2'",
     )
+
+
+def pytest_configure(config):
+    global _contract_dir  # pylint: disable=global-statement
+    _contract_dir = config.getoption("contract_dir", default="")
 
 
 @pytest.fixture(
@@ -144,7 +151,7 @@ class UnknownArtifacts(BaseException):
 
 def load_contract(contract_name: str, package: Optional[str] = None):
     if package is None:
-        if "--contract_dir=v1" in sys.argv:
+        if _contract_dir == "v1":
             package = "contracts_v1"
         else:
             package = "contracts_v2"


### PR DESCRIPTION
Towards #1698

- `sys.args` logic is unereliable when tests are run on multiple workers using `pytest-xdist`, each worker executes a separate command which doesn't include intiial `--contract_dir` value. To fix this we set global `_contract_dir` variable that is executed before running tests

