### PR TITLE
Use new contract in `test_declare_v3_tx`

### DIFF
--- a/starknet_py/tests/e2e/declare/declare_test.py
+++ b/starknet_py/tests/e2e/declare/declare_test.py
@@ -1,15 +1,21 @@
 import pytest
 
+from starknet_py.common import create_casm_class
+from starknet_py.hash.casm_class_hash import compute_casm_class_hash
 from starknet_py.net.client_models import TransactionExecutionStatus
 from starknet_py.net.models.transaction import DeclareV3
 from starknet_py.tests.e2e.fixtures.constants import MAX_RESOURCE_BOUNDS
+from starknet_py.tests.e2e.fixtures.misc import load_contract
 
 
 @pytest.mark.asyncio
-async def test_declare_v3_tx(account, abi_types_compiled_contract_and_class_hash):
+async def test_declare_v3_tx(account):
+    contract = load_contract(contract_name="TestContract5", package="contracts_v2")
     declare_tx = await account.sign_declare_v3(
-        compiled_contract=abi_types_compiled_contract_and_class_hash[0],
-        compiled_class_hash=abi_types_compiled_contract_and_class_hash[1],
+        compiled_contract=contract["sierra"],
+        compiled_class_hash=compute_casm_class_hash(
+            create_casm_class(contract["casm"])
+        ),
         resource_bounds=MAX_RESOURCE_BOUNDS,
     )
     assert isinstance(declare_tx, DeclareV3)

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/lib.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/lib.cairo
@@ -19,6 +19,7 @@ mod test_contract;
 mod test_contract2;
 mod test_contract3;
 mod test_contract4;
+mod test_contract5;
 mod test_enum;
 mod test_option;
 mod token_bridge;

--- a/starknet_py/tests/e2e/mock/contracts_v2/src/test_contract5.cairo
+++ b/starknet_py/tests/e2e/mock/contracts_v2/src/test_contract5.cairo
@@ -1,0 +1,64 @@
+#[starknet::interface]
+trait IAnotherContract<T> {
+    fn foo(ref self: T, a: u128) -> u128;
+}
+
+
+#[starknet::contract]
+mod TestContract5 {
+    use dict::Felt252DictTrait;
+    use super::{
+        IAnotherContractDispatcher, IAnotherContractDispatcherTrait,
+        IAnotherContractLibraryDispatcher, MyType,
+    };
+
+    #[storage]
+    struct Storage {
+        my_storage_var: felt252,
+    }
+
+    fn internal_func() -> felt252 {
+        1
+    }
+
+    #[external(v0)]
+    fn test(ref self: ContractState, ref arg: felt252, arg1: felt252, arg2: felt252) -> felt252 {
+        let mut x = self.my_storage_var.read();
+        x += 1;
+        self.my_storage_var.write(x);
+        x + internal_func()
+    }
+
+    #[external(v0)]
+    fn another_function(ref self: ContractState, x: MyType) {}
+
+    #[external(v0)]
+    fn call_foo(
+        ref self: ContractState, another_contract_address: starknet::ContractAddress, a: u128,
+    ) -> u128 {
+        IAnotherContractDispatcher { contract_address: another_contract_address }.foo(a)
+    }
+
+    #[external(v0)]
+    fn libcall_foo(ref self: ContractState, a: u128) -> u128 {
+        IAnotherContractLibraryDispatcher { class_hash: starknet::class_hash_const::<0>() }.foo(a)
+    }
+
+    /// An external method that requires the `segment_arena` builtin.
+    #[external(v0)]
+    fn segment_arena_builtin(ref self: ContractState) {
+        let x = felt252_dict_new::<felt252>();
+        x.squash();
+    }
+
+    #[l1_handler]
+    fn l1_handle(ref self: ContractState, from_address: felt252, arg: felt252) -> felt252 {
+        arg
+    }
+}
+
+#[derive(Copy, Drop, Serde)]
+struct MyType {
+    a: felt252,
+    b: bool,
+}


### PR DESCRIPTION
Towards #1698

- This test fails when running on a single thread as the same contract is already declared in other test. We should have more sophisticated solution for example with salting instead of adding new contracts that are basically the same, but for now this is the easiest fix

